### PR TITLE
Create makeRenderPipeline and makeComputePipeline methods in WigsillRuntime + new Matrix Multiplication example

### DIFF
--- a/apps/wigsill-examples/src/examples/camera-thresholding.ts
+++ b/apps/wigsill-examples/src/examples/camera-thresholding.ts
@@ -70,42 +70,42 @@ const renderProgram = runtime.makeRenderPipeline({
   vertex: {
     args: ['@builtin(vertex_index) VertexIndex: u32'],
     code: wgsl`
-    const pos = array(
-    vec2( 1.0,  1.0),
-    vec2( 1.0, -1.0),
-    vec2(-1.0, -1.0),
-    vec2( 1.0,  1.0),
-    vec2(-1.0, -1.0),
-    vec2(-1.0,  1.0),
-  );
+      const pos = array(
+        vec2( 1.0,  1.0),
+        vec2( 1.0, -1.0),
+        vec2(-1.0, -1.0),
+        vec2( 1.0,  1.0),
+        vec2(-1.0, -1.0),
+        vec2(-1.0,  1.0),
+      );
 
-  const uv = array(
-    vec2(1.0, 0.0),
-    vec2(1.0, 1.0),
-    vec2(0.0, 1.0),
-    vec2(1.0, 0.0),
-    vec2(0.0, 1.0),
-    vec2(0.0, 0.0),
-  );
+      const uv = array(
+        vec2(1.0, 0.0),
+        vec2(1.0, 1.0),
+        vec2(0.0, 1.0),
+        vec2(1.0, 0.0),
+        vec2(0.0, 1.0),
+        vec2(0.0, 0.0),
+      );
 
-  var output : ${outputStruct};
-  output.Position = vec4(pos[VertexIndex], 0.0, 1.0);
-  output.fragUV = uv[VertexIndex];
-  return output;
+      var output : ${outputStruct};
+      output.Position = vec4(pos[VertexIndex], 0.0, 1.0);
+      output.fragUV = uv[VertexIndex];
+      return output;
     `,
     output: outputStruct,
   },
   fragment: {
     args: ['@location(0) fragUV : vec2f'],
     code: wgsl`
-  var color = textureSampleBaseClampToEdge(videoTexture, sampler_, fragUV);
-  let grey = 0.299*color.r + 0.587*color.g + 0.114*color.b;
+      var color = textureSampleBaseClampToEdge(videoTexture, sampler_, fragUV);
+      let grey = 0.299*color.r + 0.587*color.g + 0.114*color.b;
 
-  if grey < ${thresholdData} {
-    return vec4f(0, 0, 0, 1);
-  }
+      if grey < ${thresholdData} {
+        return vec4f(0, 0, 0, 1);
+      }
 
-  return vec4f(1);
+      return vec4f(1);
     `,
     output: '@location(0) vec4f',
     target: [
@@ -119,10 +119,10 @@ const renderProgram = runtime.makeRenderPipeline({
   },
   arenas: [arena],
   externalLayouts: [bindGroupLayout],
-  additionalShaderCode: wgsl`
-  @group(0) @binding(0) var sampler_ : sampler;
-  @group(0) @binding(1) var videoTexture : texture_external;
-  `,
+  externalDeclarations: [
+    wgsl`@group(0) @binding(0) var sampler_ : sampler;`,
+    wgsl`@group(0) @binding(1) var videoTexture : texture_external;`,
+  ],
 });
 
 const sampler = device.createSampler({

--- a/apps/wigsill-examples/src/examples/gradient-tiles.ts
+++ b/apps/wigsill-examples/src/examples/gradient-tiles.ts
@@ -80,9 +80,10 @@ const renderPipeline = runtime.makeRenderPipeline({
   fragment: {
     args: ['@builtin(position) Position: vec4f', '@location(0) uv: vec2f'],
     code: wgsl.code`
-  let red = floor(uv.x * f32(${xSpanData})) / f32(${xSpanData});
-  let green = floor(uv.y * f32(${ySpanData})) / f32(${ySpanData});
-  return vec4(red, green, 0.5, 1.0);`,
+      let red = floor(uv.x * f32(${xSpanData})) / f32(${xSpanData});
+      let green = floor(uv.y * f32(${ySpanData})) / f32(${ySpanData});
+      return vec4(red, green, 0.5, 1.0);
+    `,
     output: '@location(0) vec4f',
     target: [
       {

--- a/apps/wigsill-examples/src/examples/matrix-multiplication.ts
+++ b/apps/wigsill-examples/src/examples/matrix-multiplication.ts
@@ -55,7 +55,6 @@ const program = runtime.makeComputePipeline({
   workgroupSize: workgroupSize,
   args: ['@builtin(global_invocation_id)  global_id: vec3<u32>'],
   code: wgsl`
-    // Guard against out-of-bounds work group sizes
     if (global_id.x >= u32(${firstMatrixData}.size.x) || global_id.y >= u32(${secondMatrixData}.size.y)) {
       return;
     }
@@ -105,7 +104,6 @@ device.queue.submit([encoder.finish()]);
 await gpuReadBuffer.mapAsync(GPUMapMode.READ);
 const arrayBuffer = gpuReadBuffer.getMappedRange();
 const multiplicationResult = new Float32Array(arrayBuffer);
-console.log(multiplicationResult);
 
 const canvas = await addElement('canvas', { width: 400, height: 400 });
 const context = canvas.getContext('2d') as CanvasRenderingContext2D;


### PR DESCRIPTION
What's still left to be done in the following PRs (potentially also new issues or as part of the same one (#14)):

- [ ] improve handling shader entry function's arguments and outputs more automatically, without passing in a list of args and outputs, taking into account (at)location and (at)builtin
- [ ] improve Matrix Multiplication example, mostly visually, maybe create a dedicated matrix react component to present all three matrices (the example was made specifically to only include compute shaders, no render shaders)
- [ ] consider implementing proposed alternate method api for makeRenderPipeline
- [ ] introduce more optional parameters to all created methods, allowing customization of pipelines, commandEncoders etc.
- [ ] the good defaults
- [ ] tests