### PR TITLE
Blur example filter fix

### DIFF
--- a/apps/typegpu-docs/src/content/examples/image-processing/blur.ts
+++ b/apps/typegpu-docs/src/content/examples/image-processing/blur.ts
@@ -5,6 +5,9 @@
 }
 */
 
+// Original implementation:
+// https://webgpu.github.io/webgpu-samples/?sample=imageBlur
+
 // -- Hooks into the example environment
 import {
   addElement,
@@ -37,7 +40,7 @@ const batch = [4, 4];
 
 const filterSize = addSliderPlumParameter('filter size', 2, {
   min: 2,
-  max: 16,
+  max: 40,
   step: 2,
 });
 const iterations = addSliderPlumParameter('iterations', 1, {


### PR DESCRIPTION
Fixed filter dim param (odd values caused the whole picture to get offset every iteration) - the bug also exists in [the original](https://webgpu.github.io/webgpu-samples/?sample=imageBlur).
Also referenced the original as this is heavily inspired by it.