### PR TITLE
Camera thresholding example resource cleanup

### DIFF
--- a/apps/typegpu-docs/src/content/examples/image-processing/camera-thresholding.ts
+++ b/apps/typegpu-docs/src/content/examples/image-processing/camera-thresholding.ts
@@ -9,6 +9,7 @@
 import {
   addElement,
   addSliderParameter,
+  onCleanup,
   onFrame,
 } from '@typegpu/example-toolkit';
 // --
@@ -132,4 +133,14 @@ onFrame(() => {
   });
 
   runtime.flush();
+});
+
+onCleanup(() => {
+  if (video.srcObject) {
+    for (const track of (video.srcObject as MediaStream).getTracks()) {
+      track.stop();
+    }
+  }
+
+  runtime.dispose();
 });


### PR DESCRIPTION
it makes it so that we no longer access user camera after changing example from camera thresholding to a different one