### PR TITLE
Fix webgpu types visibility for tests in vscode

### DIFF
--- a/packages/typegpu/tests/tsconfig.json
+++ b/packages/typegpu/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "typeRoots": ["../node_modules/@webgpu/types", "../node_modules/@types"]
+  },
+  "include": ["./**/*"]
+}


### PR DESCRIPTION
closes #212 