### PR TITLE
Fix mobile preview positioning

### DIFF
--- a/apps/typegpu-docs/src/components/ExampleView.tsx
+++ b/apps/typegpu-docs/src/components/ExampleView.tsx
@@ -128,7 +128,7 @@ export function ExampleView({ example, isPlayground = false }: Props) {
         <div
           className={cs(
             'flex-1 grid gap-4',
-            codeEditorShowing ? 'grid-rows-2' : '',
+            codeEditorShowing ? 'md:grid-rows-2' : '',
           )}
         >
           <div


### PR DESCRIPTION
Tiny fix.

Before:
<img width="763" alt="Zrzut ekranu 2024-09-20 o 17 28 26" src="https://github.com/user-attachments/assets/7278f7b3-fe71-439c-afaf-4d7f5a9b339b">

After:
<img width="763" alt="Zrzut ekranu 2024-09-20 o 17 28 35" src="https://github.com/user-attachments/assets/5037f7ac-8742-4738-b64e-5fbb19d886a3">