### PR TITLE
chore: Split standard and experimental root API.

### DIFF
--- a/packages/typegpu/src/bindGroupResolver.ts
+++ b/packages/typegpu/src/bindGroupResolver.ts
@@ -1,6 +1,6 @@
 import type { TgpuBufferVertex } from './core/buffer/bufferUsage';
 import type { ResolutionCtxImpl } from './resolutionCtx';
-import { type TgpuRoot, deriveVertexFormat } from './tgpuRoot';
+import { type ExperimentalTgpuRoot, deriveVertexFormat } from './tgpuRoot';
 import { type TgpuSampler, isSampler } from './tgpuSampler';
 import {
   type TgpuAnyTextureView,
@@ -32,7 +32,7 @@ export class BindGroupResolver {
   private vertexLayout: GPUVertexBufferLayout[] | null = null;
 
   constructor(
-    private root: TgpuRoot,
+    private root: ExperimentalTgpuRoot,
     private context: ResolutionCtxImpl,
     public readonly shaderStage: number,
   ) {

--- a/packages/typegpu/src/core/buffer/buffer.ts
+++ b/packages/typegpu/src/core/buffer/buffer.ts
@@ -1,7 +1,7 @@
 import { BufferReader, BufferWriter, type Parsed } from 'typed-binary';
 import type { TgpuNamable } from '../../namable';
 import { type TgpuPlum, type Unsubscribe, isPlum } from '../../tgpuPlumTypes';
-import type { TgpuRoot } from '../../tgpuRoot';
+import type { ExperimentalTgpuRoot } from '../../tgpuRoot';
 import { type AnyTgpuData, isGPUBuffer } from '../../types';
 
 // ----------
@@ -52,7 +52,7 @@ export interface TgpuBuffer<TData extends AnyTgpuData> extends TgpuNamable {
 }
 
 export function createBufferImpl<TData extends AnyTgpuData>(
-  group: TgpuRoot | undefined,
+  group: ExperimentalTgpuRoot | undefined,
   typeSchema: TData,
   initialOrBuffer?: Parsed<TData> | TgpuPlum<Parsed<TData>> | GPUBuffer,
 ): TgpuBuffer<TData> {
@@ -104,7 +104,7 @@ class TgpuBufferImpl<TData extends AnyTgpuData> implements TgpuBuffer<TData> {
   public usableAsVertex = false;
 
   constructor(
-    private readonly _group: TgpuRoot | undefined,
+    private readonly _group: ExperimentalTgpuRoot | undefined,
     public readonly dataType: TData,
     public readonly initialOrBuffer?:
       | Parsed<TData>

--- a/packages/typegpu/src/createRoot.ts
+++ b/packages/typegpu/src/createRoot.ts
@@ -20,10 +20,10 @@ import type { ExtractPlumValue, TgpuPlum, Unsubscribe } from './tgpuPlumTypes';
 import type {
   ComputePipelineExecutorOptions,
   ComputePipelineOptions,
+  ExperimentalTgpuRoot,
   RenderPipelineExecutorOptions,
   RenderPipelineOptions,
   SetPlumAction,
-  TgpuRoot,
 } from './tgpuRoot';
 import type { TgpuSampler } from './tgpuSampler';
 import type {
@@ -37,7 +37,7 @@ import type { AnyTgpuData } from './types';
  * Holds all data that is necessary to facilitate CPU and GPU communication.
  * Programs that share a root can interact via GPU buffers.
  */
-class TgpuRootImpl implements TgpuRoot {
+class TgpuRootImpl implements ExperimentalTgpuRoot {
   private _buffers: TgpuBuffer<AnyTgpuData>[] = [];
   private _samplers = new WeakMap<TgpuSampler, GPUSampler>();
   private _textures = new WeakMap<TgpuAnyTexture, GPUTexture>();
@@ -327,7 +327,7 @@ interface PipelineExecutor {
 
 class RenderPipelineExecutor implements PipelineExecutor {
   constructor(
-    private root: TgpuRoot,
+    private root: ExperimentalTgpuRoot,
     private pipeline: GPURenderPipeline,
     private vertexProgram: Program,
     private fragmentProgram: Program,
@@ -384,7 +384,7 @@ class RenderPipelineExecutor implements PipelineExecutor {
 
 class ComputePipelineExecutor implements PipelineExecutor {
   constructor(
-    private root: TgpuRoot,
+    private root: ExperimentalTgpuRoot,
     private pipeline: GPUComputePipeline,
     private programs: Program[],
     private externalLayoutCount: number,
@@ -456,7 +456,7 @@ export type CreateRootOptions = {
  */
 export async function createRoot(
   options?: CreateRootOptions,
-): Promise<TgpuRoot> {
+): Promise<ExperimentalTgpuRoot> {
   if (doesResembleDevice(options?.device)) {
     return new TgpuRootImpl(options.device, options.jitTranspiler);
   }

--- a/packages/typegpu/src/programBuilder.ts
+++ b/packages/typegpu/src/programBuilder.ts
@@ -11,7 +11,7 @@ import type { SimpleTgpuData, TgpuArray } from './data';
 import { type NameRegistry, RandomNameRegistry } from './nameRegistry';
 import { ResolutionCtxImpl } from './resolutionCtx';
 import { code } from './tgpuCode';
-import type { TgpuRoot } from './tgpuRoot';
+import type { ExperimentalTgpuRoot } from './tgpuRoot';
 import type {
   AnyTgpuData,
   BoundTgpuCode,
@@ -33,7 +33,7 @@ type BuildOptions = {
 
 export default class ProgramBuilder {
   constructor(
-    private root: TgpuRoot,
+    private root: ExperimentalTgpuRoot,
     private rootNode: TgpuResolvable,
   ) {}
 
@@ -75,7 +75,7 @@ function getUsedBuiltinsNamed(
 
 export class RenderProgramBuilder {
   constructor(
-    private root: TgpuRoot,
+    private root: ExperimentalTgpuRoot,
     private vertexRoot: TgpuCode | BoundTgpuCode,
     private fragmentRoot: TgpuCode | BoundTgpuCode,
     private vertexOutputFormat: {
@@ -248,7 +248,7 @@ export class RenderProgramBuilder {
 
 export class ComputeProgramBuilder {
   constructor(
-    private root: TgpuRoot,
+    private root: ExperimentalTgpuRoot,
     private computeRoot: Wgsl,
     private workgroupSize: readonly [
       number,

--- a/packages/typegpu/src/tgpuRoot.ts
+++ b/packages/typegpu/src/tgpuRoot.ts
@@ -22,19 +22,24 @@ import type { Unwrapper } from './unwrapper';
 export type SetPlumAction<T> = T | ((prev: T) => T);
 
 export interface TgpuRoot extends Unwrapper {
-  readonly device: GPUDevice;
-  readonly jitTranspiler?: JitTranspiler | undefined;
   /**
-   * The current command encoder. This property will
-   * hold the same value until `flush()` is called.
+   * The GPU device associated with this root.
    */
-  readonly commandEncoder: GPUCommandEncoder;
+  readonly device: GPUDevice;
 
+  /**
+   * @param typeSchema The type of data that this buffer will hold.
+   * @param initial The initial value of the buffer. (optional)
+   */
   createBuffer<TData extends AnyTgpuData>(
     typeSchema: TData,
     initial?: Parsed<TData> | TgpuPlum<Parsed<TData>> | undefined,
   ): TgpuBuffer<TData>;
 
+  /**
+   * @param typeSchema The type of data that this buffer will hold.
+   * @param gpuBuffer A vanilla WebGPU buffer.
+   */
   createBuffer<TData extends AnyTgpuData>(
     typeSchema: TData,
     gpuBuffer: GPUBuffer,
@@ -43,6 +48,17 @@ export interface TgpuRoot extends Unwrapper {
   unwrap(resource: TgpuBuffer<AnyTgpuData>): GPUBuffer;
   unwrap(resource: TgpuBindGroupLayout): GPUBindGroupLayout;
   unwrap(resource: TgpuBindGroup): GPUBindGroup;
+
+  destroy(): void;
+}
+
+export interface ExperimentalTgpuRoot extends TgpuRoot {
+  readonly jitTranspiler?: JitTranspiler | undefined;
+  /**
+   * The current command encoder. This property will
+   * hold the same value until `flush()` is called.
+   */
+  readonly commandEncoder: GPUCommandEncoder;
 
   readPlum<TPlum extends TgpuPlum>(plum: TPlum): ExtractPlumValue<TPlum>;
 
@@ -68,7 +84,6 @@ export interface TgpuRoot extends Unwrapper {
   viewFor(view: TgpuAnyTextureView): GPUTextureView;
   externalTextureFor(texture: TgpuTextureExternal): GPUExternalTexture;
   samplerFor(sampler: TgpuSampler): GPUSampler;
-  destroy(): void;
 
   /**
    * Causes all commands enqueued by pipelines to be

--- a/packages/typegpu/tests/bindGroupLayout.test.ts
+++ b/packages/typegpu/tests/bindGroupLayout.test.ts
@@ -9,7 +9,7 @@ import {
 } from 'vitest';
 import { type F32, type U32, type Vec3f, f32, u32, vec3f } from '../src/data';
 import tgpu, {
-  type TgpuRoot,
+  type ExperimentalTgpuRoot,
   type TgpuBindGroupLayout,
   asUniform,
   type TgpuBuffer,
@@ -85,7 +85,7 @@ const mockDevice = {
 };
 
 describe('TgpuBindGroupLayout', () => {
-  let root: TgpuRoot;
+  let root: ExperimentalTgpuRoot;
 
   beforeEach(async () => {
     root = await tgpu.init({
@@ -176,7 +176,7 @@ describe('TgpuBindGroupLayout', () => {
 });
 
 describe('TgpuBindGroup', () => {
-  let root: TgpuRoot;
+  let root: ExperimentalTgpuRoot;
 
   beforeEach(async () => {
     root = await tgpu.init({


### PR DESCRIPTION
This is in preparation for exporting the root with limited functionality.