### PR TITLE
Fix overflow in the roadmap section of the landing page

### DIFF
--- a/apps/typegpu-docs/src/pages/index.astro
+++ b/apps/typegpu-docs/src/pages/index.astro
@@ -158,7 +158,7 @@ const showcaseVideoResolution = [2048, 1200];
 
     {/* Roadmap Section */}
     <div
-      class="box-border flex flex-col items-center bg-white w-full md:my-8 lg:my-20 py-12 md:p-20 lg:p-32 md:rounded-[5rem] rounded-[2.5rem]">
+      class="box-border flex flex-col items-center bg-white w-full md:my-8 lg:my-20 py-12 md:p-20 lg:p-32 md:rounded-[5rem] rounded-[2.5rem] overflow-hidden">
       <section
         class="box-border flex flex-col items-center justify-center px-4 lg:gap-20 gap-10 md:gap-[3.75rem] lg:max-w-[85rem] md:max-w-[53.5rem] max-w-[34.5rem]">
         <div>


### PR DESCRIPTION

before: <img width="400px" src="https://github.com/user-attachments/assets/10f38613-df0e-4fc4-9b48-e4f745fd2930">
