### PR TITLE
Remove builtins from entry function arguments in tgpu-gen

### DIFF
--- a/packages/tgpu-gen/gen.mjs
+++ b/packages/tgpu-gen/gen.mjs
@@ -472,7 +472,12 @@ function generateFunction(func, wgsl, options) {
         : 'fn';
 
   const inputs = `[${func.arguments
-    .flatMap((arg) => (arg.type ? [generateType(arg.type, options)] : []))
+    .flatMap((arg) =>
+      arg.type &&
+      arg.type.attributes?.find((attr) => attr.name === 'builtin') === undefined
+        ? [generateType(arg.type, options)]
+        : [],
+    )
     .join(', ')}]`;
 
   const output = func.returnType

--- a/packages/tgpu-gen/tests/functions.test.ts
+++ b/packages/tgpu-gen/tests/functions.test.ts
@@ -67,7 +67,7 @@ fn mainVert(@builtin(instance_index) ii: u32, @location(0) v: vec2f) -> VertexOu
 
     expect(generate(wgsl)).toContain(`\
 export const mainVert = tgpu
-  .vertexFn([d.u32, d.location(0, d.vec2f)], VertexOutput)
+  .vertexFn([d.location(0, d.vec2f)], VertexOutput)
   .does(/* wgsl */ \`(@builtin(instance_index) ii: u32, @location(0) v: vec2f) -> VertexOutput {
     let instanceInfo = trianglePos[ii];
 


### PR DESCRIPTION
closes #531 

(note: builtin arguments are still present as struct members)