### PR TITLE
Add `$idx` builder method to bindGroupLayouts

### DIFF
--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -136,6 +136,11 @@ export interface TgpuBindGroupLayoutExperimental<
     TgpuLayoutEntry | null
   >,
 > extends TgpuBindGroupLayout<Entries> {
+  /**
+   * Marks a bind group layout to appear with a specific group index in the resulting WGSL code
+   */
+  $idx(index?: number): this;
+
   readonly bound: {
     [K in keyof Entries]: BindLayoutEntry<Entries[K]>;
   };
@@ -252,6 +257,7 @@ class TgpuBindGroupLayoutImpl<
 > implements TgpuBindGroupLayoutExperimental<Entries>
 {
   private _label: string | undefined;
+  private _index: number | undefined;
 
   public readonly resourceType = 'bind-group-layout' as const;
 
@@ -268,6 +274,11 @@ class TgpuBindGroupLayoutImpl<
 
   $name(label?: string | undefined): this {
     this._label = label;
+    return this;
+  }
+
+  $idx(index?: number): this {
+    this._index = index;
     return this;
   }
 

--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -137,7 +137,10 @@ export interface TgpuBindGroupLayoutExperimental<
   >,
 > extends TgpuBindGroupLayout<Entries> {
   /**
-   * Marks a bind group layout to appear with a specific group index in the resulting WGSL code
+   * Associates this bind group layout with an explicit numeric index. When a call to this
+   * method is omitted, a unique numeric index is assigned to it automatically.
+   *
+   * Used when generating WGSL code: `@group(${index}) @binding(...) ...;`
    */
   $idx(index?: number): this;
 


### PR DESCRIPTION
closes #523 

* doesn't do anything yet
* isn't generated by tgpu-gen (also yet)