### PR TITLE
Fix MNIST example type issue

### DIFF
--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -272,7 +272,7 @@ const bars = document.querySelectorAll('.bar') as NodeListOf<HTMLDivElement>;
 const resetAll = () => {
   canvasData.fill(0);
   resetCanvas();
-  for (const bar of bars) {
+  for (const bar of Array.from(bars)) {
     bar.style.setProperty('--bar-width', '0');
   }
 };

--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -315,7 +315,7 @@ canvas.addEventListener('mousedown', () => {
   isDrawing = true;
 });
 
-canvas.addEventListener('mouseup', () => {
+window.addEventListener('mouseup', () => {
   isDrawing = false;
 });
 

--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -267,12 +267,14 @@ const network = createNetwork([
 
 const context = canvas.getContext('2d') as CanvasRenderingContext2D;
 
-const bars = document.querySelectorAll('.bar') as NodeListOf<HTMLDivElement>;
+const bars = Array.from(
+  document.querySelectorAll('.bar') as NodeListOf<HTMLDivElement>,
+);
 
 const resetAll = () => {
   canvasData.fill(0);
   resetCanvas();
-  for (const bar of Array.from(bars)) {
+  for (const bar of bars) {
     bar.style.setProperty('--bar-width', '0');
   }
 };

--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -267,9 +267,7 @@ const network = createNetwork([
 
 const context = canvas.getContext('2d') as CanvasRenderingContext2D;
 
-const bars = Array.from(
-  document.querySelectorAll('.bar'),
-) as HTMLDivElement[];
+const bars = Array.from(document.querySelectorAll('.bar')) as HTMLDivElement[];
 
 const resetAll = () => {
   canvasData.fill(0);

--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -268,8 +268,8 @@ const network = createNetwork([
 const context = canvas.getContext('2d') as CanvasRenderingContext2D;
 
 const bars = Array.from(
-  document.querySelectorAll('.bar') as NodeListOf<HTMLDivElement>,
-);
+  document.querySelectorAll('.bar'),
+) as HTMLDivElement[];
 
 const resetAll = () => {
   canvasData.fill(0);


### PR DESCRIPTION
`NodeListOf` type does not have an iterator in the live examples environment, this PR changes bars to `Array` type so it can be iterated over inside for..of (according to the types)