### PR TITLE
Fix MNIST inference example bug on mobile

### DIFF
--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -290,6 +290,10 @@ window.addEventListener('mouseup', () => {
   uiState.lastPos = null;
 });
 
+canvas.addEventListener('touchend', () => {
+  uiState.lastPos = null;
+});
+
 function centerImage(data: number[]) {
   const mass = data.reduce((acc, value) => acc + value, 0);
   const x = data.reduce((acc, value, i) => acc + value * (i % SIZE), 0) / mass;


### PR DESCRIPTION
Since there is no event listener for `touchend` there sometimes occurs unwanted interpolation. Simply adding the listener fixes it.