### PR TITLE
Remove `expressionCode` property from vectors, numerics and bools

### DIFF
--- a/packages/typegpu/src/data/numeric.ts
+++ b/packages/typegpu/src/data/numeric.ts
@@ -16,7 +16,6 @@ const primitiveNumeric = <TKind extends string>(
     kind: code,
     size: 4,
     byteAlignment: 4,
-    expressionCode: code,
 
     write(output: TB.ISerialOutput, value: number): void {
       schema.write(output, value);

--- a/packages/typegpu/src/data/std140.ts
+++ b/packages/typegpu/src/data/std140.ts
@@ -22,11 +22,10 @@ export class SimpleTgpuData<TSchema extends AnySchema>
 {
   public readonly size: number;
   public readonly byteAlignment: number;
-  public readonly expressionCode: string;
 
   private readonly _innerSchema: TSchema;
   public readonly isLoose = false as const;
-  public readonly label?: string | undefined;
+  public readonly label: string;
 
   /**
    * byteAlignment has to be a power of 2
@@ -44,7 +43,6 @@ export class SimpleTgpuData<TSchema extends AnySchema>
 
     this._innerSchema = schema;
     this.byteAlignment = byteAlignment;
-    this.expressionCode = code;
     this.size = this.measure(MaxValue).size;
     this.label = code;
   }
@@ -71,6 +69,6 @@ export class SimpleTgpuData<TSchema extends AnySchema>
   }
 
   resolve(ctx: ResolutionCtx): string {
-    return this.expressionCode;
+    return this.label;
   }
 }

--- a/packages/typegpu/src/data/vector.ts
+++ b/packages/typegpu/src/data/vector.ts
@@ -30,7 +30,6 @@ interface VecSchemaOptions<ValueType> {
 
 type VecSchemaBase<ValueType> = TgpuData<ValueType> & {
   kind: string;
-  expressionCode: string; // TODO: to remove
   toString(): string;
 };
 
@@ -46,7 +45,6 @@ function makeVecSchema<ValueType extends vecBase>(
     label: options.label,
     byteAlignment: options.byteAlignment,
     kind: options.label,
-    expressionCode: options.label,
 
     resolveReferences(ctx: IRefResolver): void {
       throw new RecursiveDataTypeError();


### PR DESCRIPTION
closes #478 