### PR TITLE
Slot bindings on new pipelines.

### DIFF
--- a/apps/typegpu-docs/src/content/examples/simple/increment-tgsl/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simple/increment-tgsl/index.ts
@@ -12,7 +12,7 @@ const counterBuffer = root.createBuffer(vec2f, vec2f(0, 1)).$usage('storage');
 const counter = asMutable(counterBuffer);
 
 const increment = tgpu
-  .computeFn([1])
+  .computeFn([], { workgroupSize: [1] })
   .does(() => {
     const tmp = counter.value.x;
     counter.value.x = counter.value.y;

--- a/apps/typegpu-docs/src/content/examples/simulation/boids-next/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/boids-next/index.ts
@@ -214,7 +214,7 @@ const computeBindGroupLayout = tgpu
 const { currentTrianglePos, nextTrianglePos } = computeBindGroupLayout.bound;
 
 const mainCompute = tgpu
-  .computeFn([1])
+  .computeFn([], { workgroupSize: [1] })
   .does(/* wgsl */ `(@builtin(global_invocation_id) gid: vec3u) {
     let index = gid.x;
     var instanceInfo = currentTrianglePos[index];

--- a/apps/typegpu-docs/src/content/examples/simulation/fluid-double-buffering/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/fluid-double-buffering/index.ts
@@ -1,5 +1,3 @@
-// TODO: Reenable type checking when new pipelines are implemented.
-
 import { JitTranspiler } from '@typegpu/jit';
 import {
   type Parsed,

--- a/apps/typegpu-docs/src/content/examples/simulation/fluid-double-buffering/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/fluid-double-buffering/index.ts
@@ -473,45 +473,6 @@ const mainCompute = tgpu
     outputGridSlot,
   });
 
-const mainFragment = wgsl.fn`
-  (x: i32, y: i32) -> vec4f {
-    let index = ${coordsToIndex}(x, y);
-    let cell = ${inputGridSlot}[index];
-    let velocity = cell.xy;
-    let density = max(0., cell.z);
-
-    let obstacle_color = vec4f(0.1, 0.1, 0.1, 1.);
-
-    let background = vec4f(0.9, 0.9, 0.9, 1.);
-    let first_color = vec4f(0.2, 0.6, 1., 1.);
-    let second_color = vec4f(0.2, 0.3, 0.6, 1.);
-    let third_color = vec4f(0.1, 0.2, 0.4, 1.);
-
-    let first_threshold = 2.;
-    let second_threshold = 10.;
-    let third_threshold = 20.;
-
-    if (${isInsideObstacle}(x, y)) {
-      return obstacle_color;
-    }
-
-    if (density <= 0.) {
-      return background;
-    }
-
-    if (density <= first_threshold) {
-      let t = 1 - pow(1 - density / first_threshold, 2.);
-      return mix(background, first_color, t);
-    }
-
-    if (density <= second_threshold) {
-      return mix(first_color, second_color, (density - first_threshold) / (second_threshold - first_threshold));
-    }
-
-    return mix(second_color, third_color, min((density - second_threshold) / third_threshold, 1.));
-  }
-`.$name('main_fragment');
-
 const OBSTACLE_BOX = 0;
 const OBSTACLE_LEFT_WALL = 1;
 

--- a/apps/typegpu-docs/src/content/examples/simulation/fluid-double-buffering/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/fluid-double-buffering/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // TODO: Reenable type checking when new pipelines are implemented.
 
 import { JitTranspiler } from '@typegpu/jit';
@@ -15,13 +14,14 @@ import {
   vec4f,
 } from 'typegpu/data';
 import tgpu, {
-  type TgpuBufferUsage,
   asMutable,
   asReadonly,
   asUniform,
   builtin,
   wgsl,
   std,
+  type TgpuBufferReadonly,
+  type TgpuBufferMutable,
 } from 'typegpu/experimental';
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
@@ -85,8 +85,10 @@ const gridSizeUniform = asUniform(gridSizeBuffer);
 const gridAlphaBuffer = root.createBuffer(GridData).$usage('storage');
 const gridBetaBuffer = root.createBuffer(GridData).$usage('storage');
 
-const inputGridSlot = wgsl.slot<TgpuBufferUsage<GridData>>();
-const outputGridSlot = wgsl.slot<TgpuBufferUsage<GridData, 'mutable'>>();
+const inputGridSlot = wgsl.slot<
+  TgpuBufferReadonly<GridData> | TgpuBufferMutable<GridData>
+>();
+const outputGridSlot = wgsl.slot<TgpuBufferMutable<GridData>>();
 
 const MAX_OBSTACLES = 4;
 
@@ -179,6 +181,7 @@ const flowFromCell = wgsl.fn`
 `.$name('flow_from_cell');
 
 const timeBuffer = root.createBuffer(f32).$usage('uniform');
+const timeUniform = asUniform(timeBuffer);
 
 const isInsideObstacle = wgsl.fn`
   (x: i32, y: i32) -> bool {
@@ -217,7 +220,7 @@ const isValidFlowOut = wgsl.fn`
 
     return true;
   }
-`.$name('is_valid_flow_out');
+`;
 
 const computeVelocity = tgpu
   .fn([i32, i32], vec2f)
@@ -269,32 +272,36 @@ const computeVelocity = tgpu
 `)
   .$uses({ getCell, isValidFlowOut, isValidCoord, rand01 });
 
-const mainInitWorld = wgsl.fn`
-  (x: i32, y: i32) {
-    let index = ${coordsToIndex}(x, y);
+const mainInitWorld = tgpu
+  .computeFn([builtin.globalInvocationId], { workgroupSize: [1] })
+  .does(`(@builtin(global_invocation_id) gid: vec3u) {
+    let x = i32(gid.x);
+    let y = i32(gid.y);
+    let index = coordsToIndex(x, y);
 
     var value = vec4f();
 
-    if (!${isValidFlowOut}(x, y)) {
+    if (!isValidFlowOut(x, y)) {
       value = vec4f(0., 0., 0., 0.);
     }
     else {
       // Ocean
-      if (y < i32(${gridSizeUniform}) / 2) {
-        let depth = 1. - f32(y) / (f32(${gridSizeUniform}) / 2.);
+      if (y < i32(gridSizeUniform) / 2) {
+        let depth = 1. - f32(y) / (f32(gridSizeUniform) / 2.);
         value = vec4f(0., 0., 10. + depth * 10., 0.);
       }
     }
 
-    ${outputGridSlot}[index] = value;
-  }
-`;
+    outputGridSlot[index] = value;
+  }`)
+  .$uses({ coordsToIndex, isValidFlowOut, gridSizeUniform, outputGridSlot });
 
-const mainMoveObstacles = wgsl.fn`
-  () {
-    for (var obs_idx = 0; obs_idx < ${MAX_OBSTACLES}; obs_idx += 1) {
-      let obs = ${prevObstacleReadonly}[obs_idx];
-      let next_obs = ${obstaclesReadonly}[obs_idx];
+const mainMoveObstacles = tgpu
+  .computeFn([], { workgroupSize: [1] })
+  .does(`() {
+    for (var obs_idx = 0; obs_idx < MAX_OBSTACLES; obs_idx += 1) {
+      let obs = prevObstacleReadonly[obs_idx];
+      let next_obs = obstaclesReadonly[obs_idx];
 
       if (obs.enabled == 0) {
         continue;
@@ -317,13 +324,13 @@ const mainMoveObstacles = wgsl.fn`
         for (var y = min_y; y <= max_y; y += 1) {
           var row_density = 0.;
           for (var x = max_x; x <= next_max_x; x += 1) {
-            var cell = ${getCell}(x, y);
+            var cell = getCell(x, y);
             row_density += cell.z;
             cell.z = 0;
-            ${setCell}(x, y, cell);
+            setCell(x, y, cell);
           }
 
-          ${addDensity}(next_max_x + 1, y, row_density);
+          addDensity(next_max_x + 1, y, row_density);
         }
       }
 
@@ -332,13 +339,13 @@ const mainMoveObstacles = wgsl.fn`
         for (var y = min_y; y <= max_y; y += 1) {
           var row_density = 0.;
           for (var x = next_min_x; x < min_x; x += 1) {
-            var cell = ${getCell}(x, y);
+            var cell = getCell(x, y);
             row_density += cell.z;
             cell.z = 0;
-            ${setCell}(x, y, cell);
+            setCell(x, y, cell);
           }
 
-          ${addDensity}(next_min_x - 1, y, row_density);
+          addDensity(next_min_x - 1, y, row_density);
         }
       }
 
@@ -347,13 +354,13 @@ const mainMoveObstacles = wgsl.fn`
         for (var x = min_x; x <= max_x; x += 1) {
           var col_density = 0.;
           for (var y = max_y; y <= next_max_y; y += 1) {
-            var cell = ${getCell}(x, y);
+            var cell = getCell(x, y);
             col_density += cell.z;
             cell.z = 0;
-            ${setCell}(x, y, cell);
+            setCell(x, y, cell);
           }
 
-          ${addDensity}(x, next_max_y + 1, col_density);
+          addDensity(x, next_max_y + 1, col_density);
         }
       }
 
@@ -362,13 +369,13 @@ const mainMoveObstacles = wgsl.fn`
         for (var x = min_x; x <= max_x; x += 1) {
           var col_density = 0.;
           for (var y = next_min_y; y < min_y; y += 1) {
-            var cell = ${getCell}(x, y);
+            var cell = getCell(x, y);
             col_density += cell.z;
             cell.z = 0;
-            ${setCell}(x, y, cell);
+            setCell(x, y, cell);
           }
 
-          ${addDensity}(x, next_min_y - 1, col_density);
+          addDensity(x, next_min_y - 1, col_density);
         }
       }
 
@@ -377,18 +384,28 @@ const mainMoveObstacles = wgsl.fn`
 
       // left column
       for (var y = next_min_y; y <= next_max_y; y += 1) {
-        let new_vel = ${computeVelocity}(next_min_x - 1, y);
-        ${setVelocity}(next_min_x - 1, y, new_vel);
+        let new_vel = computeVelocity(next_min_x - 1, y);
+        setVelocity(next_min_x - 1, y, new_vel);
       }
 
       // right column
-      for (var y = max(1, next_min_y); y <= min(next_max_y, ${gridSizeUniform} - 2); y += 1) {
-        let new_vel = ${computeVelocity}(next_max_x + 2, y);
-        ${setVelocity}(next_max_x + 2, y, new_vel);
+      for (var y = max(1, next_min_y); y <= min(next_max_y, gridSizeUniform - 2); y += 1) {
+        let new_vel = computeVelocity(next_max_x + 2, y);
+        setVelocity(next_max_x + 2, y, new_vel);
       }
     }
-  }
-`.$name('main_move_obstacles');
+  }`)
+  .$uses({
+    MAX_OBSTACLES,
+    prevObstacleReadonly,
+    obstaclesReadonly,
+    getCell,
+    setCell,
+    addDensity,
+    computeVelocity,
+    setVelocity,
+    gridSizeUniform,
+  });
 
 let sourceIntensity = 0.1;
 let sourceRadius = 0.01;
@@ -418,32 +435,45 @@ const getMinimumInFlow = wgsl.fn`
   }
 `;
 
-const mainCompute = wgsl.fn`
-  (x: i32, y: i32) {
-    let index = ${coordsToIndex}(x, y);
+const mainCompute = tgpu
+  .computeFn([builtin.globalInvocationId], { workgroupSize: [8, 8] })
+  .does(`(@builtin(global_invocation_id) gid: vec3u) {
+    let x = i32(gid.x);
+    let y = i32(gid.y);
+    let index = coordsToIndex(x, y);
 
-    ${setupRandomSeed}(vec2f(f32(index), ${asUniform(timeBuffer)}));
+    setupRandomSeed(vec2f(f32(index), timeUniform));
 
-    var next = ${getCell}(x, y);
+    var next = getCell(x, y);
 
-    let next_velocity = ${computeVelocity}(x, y);
+    let next_velocity = computeVelocity(x, y);
     next.x = next_velocity.x;
     next.y = next_velocity.y;
 
     // Processing in-flow
 
-    next.z = ${flowFromCell}(x, y, x, y);
-    next.z += ${flowFromCell}(x, y, x, y + 1);
-    next.z += ${flowFromCell}(x, y, x, y - 1);
-    next.z += ${flowFromCell}(x, y, x + 1, y);
-    next.z += ${flowFromCell}(x, y, x - 1, y);
+    next.z = flowFromCell(x, y, x, y);
+    next.z += flowFromCell(x, y, x, y + 1);
+    next.z += flowFromCell(x, y, x, y - 1);
+    next.z += flowFromCell(x, y, x + 1, y);
+    next.z += flowFromCell(x, y, x - 1, y);
 
-    let min_inflow = ${getMinimumInFlow}(x, y);
+    let min_inflow = getMinimumInFlow(x, y);
     next.z = max(min_inflow, next.z);
 
-    ${outputGridSlot}[index] = next;
+    outputGridSlot[index] = next;
   }
-`.$name('main_compute');
+`)
+  .$uses({
+    coordsToIndex,
+    setupRandomSeed,
+    timeUniform,
+    getCell,
+    computeVelocity,
+    flowFromCell,
+    getMinimumInFlow,
+    outputGridSlot,
+  });
 
 const mainFragment = wgsl.fn`
   (x: i32, y: i32) -> vec4f {
@@ -517,100 +547,121 @@ const limitedBoxX = () => {
 let boxY = 0.2;
 let leftWallX = 0;
 
+const vertexMain = tgpu
+  .vertexFn({ idx: builtin.vertexIndex }, { pos: builtin.position, uv: vec2f })
+  .does(/* wgsl */ `(@builtin(vertex_index) idx: u32) -> VertexOut {
+    var pos = array<vec2f, 4>(
+      vec2(1, 1), // top-right
+      vec2(-1, 1), // top-left
+      vec2(1, -1), // bottom-right
+      vec2(-1, -1) // bottom-left
+    );
+
+    var uv = array<vec2f, 4>(
+      vec2(1., 1.), // top-right
+      vec2(0., 1.), // top-left
+      vec2(1., 0.), // bottom-right
+      vec2(0., 0.) // bottom-left
+    );
+
+    var output: VertexOut;
+    output.pos = vec4f(pos[idx].x, pos[idx].y, 0.0, 1.0);
+    output.uv = uv[idx];
+    return output;
+  }`)
+  .$uses({
+    get VertexOut() {
+      return vertexMain.Output;
+    },
+  });
+
+const fragmentMain = tgpu
+  .fragmentFn(
+    {
+      pos: builtin.position /* TODO: Remove once builtins are properly purged from the types */,
+      uv: vec2f,
+    },
+    vec4f,
+  )
+  .does(`(@location(0) uv: vec2f) -> @location(0) vec4f {
+    let x = i32(uv.x * f32(gridSizeUniform));
+    let y = i32(uv.y * f32(gridSizeUniform));
+
+    let index = coordsToIndex(x, y);
+    let cell = inputGridSlot[index];
+    let velocity = cell.xy;
+    let density = max(0., cell.z);
+
+    let obstacle_color = vec4f(0.1, 0.1, 0.1, 1.);
+
+    let background = vec4f(0.9, 0.9, 0.9, 1.);
+    let first_color = vec4f(0.2, 0.6, 1., 1.);
+    let second_color = vec4f(0.2, 0.3, 0.6, 1.);
+    let third_color = vec4f(0.1, 0.2, 0.4, 1.);
+
+    let first_threshold = 2.;
+    let second_threshold = 10.;
+    let third_threshold = 20.;
+
+    if (isInsideObstacle(x, y)) {
+      return obstacle_color;
+    }
+
+    if (density <= 0.) {
+      return background;
+    }
+
+    if (density <= first_threshold) {
+      let t = 1 - pow(1 - density / first_threshold, 2.);
+      return mix(background, first_color, t);
+    }
+
+    if (density <= second_threshold) {
+      return mix(first_color, second_color, (density - first_threshold) / (second_threshold - first_threshold));
+    }
+
+    return mix(second_color, third_color, min((density - second_threshold) / third_threshold, 1.));
+  }`)
+  .$uses({ gridSizeUniform, coordsToIndex, inputGridSlot, isInsideObstacle });
+
 function makePipelines(
-  inputGridReadonly: TgpuBufferUsage<GridData, 'readonly'>,
-  outputGridMutable: TgpuBufferUsage<GridData, 'mutable'>,
+  inputGridReadonly: TgpuBufferReadonly<GridData>,
+  outputGridMutable: TgpuBufferMutable<GridData>,
 ) {
-  const initWorldFn = mainInitWorld
+  const initWorldPipeline = root
     .with(inputGridSlot, outputGridMutable)
-    .with(outputGridSlot, outputGridMutable);
+    .with(outputGridSlot, outputGridMutable)
+    .withCompute(mainInitWorld)
+    .createPipeline();
 
-  const initWorldPipeline = root.makeComputePipeline({
-    code: wgsl`
-      ${initWorldFn}(i32(${builtin.globalInvocationId}.x), i32(${builtin.globalInvocationId}.y));
-    `,
-  });
-
-  const mainComputeWithIO = mainCompute
+  const computePipeline = root
     .with(inputGridSlot, inputGridReadonly)
-    .with(outputGridSlot, outputGridMutable);
+    .with(outputGridSlot, outputGridMutable)
+    .withCompute(mainCompute)
+    .createPipeline();
 
-  const computeWorkgroupSize = 8;
-  const computePipeline = root.makeComputePipeline({
-    workgroupSize: [computeWorkgroupSize, computeWorkgroupSize],
-    code: wgsl`
-      ${mainComputeWithIO}(i32(${builtin.globalInvocationId}.x), i32(${builtin.globalInvocationId}.y));
-    `,
-  });
-
-  const moveObstaclesFn = mainMoveObstacles
+  const moveObstaclesPipeline = root
     .with(inputGridSlot, outputGridMutable)
-    .with(outputGridSlot, outputGridMutable);
+    .with(outputGridSlot, outputGridMutable)
+    .withCompute(mainMoveObstacles)
+    .createPipeline();
 
-  const moveObstaclesPipeline = root.makeComputePipeline({
-    code: wgsl`
-      ${moveObstaclesFn}();
-    `,
-  });
-
-  const mainFragmentWithInput = mainFragment.with(
-    inputGridSlot,
-    inputGridReadonly,
-  );
-
-  const renderPipeline = root.makeRenderPipeline({
-    vertex: {
-      code: wgsl`
-        var pos = array<vec2f, 4>(
-          vec2(1, 1), // top-right
-          vec2(-1, 1), // top-left
-          vec2(1, -1), // bottom-right
-          vec2(-1, -1) // bottom-left
-        );
-
-        var uv = array<vec2f, 4>(
-          vec2(1., 1.), // top-right
-          vec2(0., 1.), // top-left
-          vec2(1., 0.), // bottom-right
-          vec2(0., 0.) // bottom-left
-        );
-
-        let outPos = vec4f(pos[${builtin.vertexIndex}].x, pos[${builtin.vertexIndex}].y, 0.0, 1.0);
-        let outUv = uv[${builtin.vertexIndex}];
-      `,
-      output: {
-        [builtin.position.s]: 'outPos',
-        outUv: vec2f,
-      },
-    },
-
-    fragment: {
-      code: wgsl.code`
-        let x = i32(outUv.x * f32(${gridSizeUniform}));
-        let y = i32(outUv.y * f32(${gridSizeUniform}));
-        return ${mainFragmentWithInput}(x, y);
-      `,
-      target: [
-        {
-          format: presentationFormat,
-        },
-      ],
-    },
-
-    primitive: {
-      topology: 'triangle-strip',
-    },
-  });
+  const renderPipeline = root
+    .with(inputGridSlot, inputGridReadonly)
+    .withVertex(vertexMain, {})
+    .withFragment(fragmentMain, { format: presentationFormat })
+    .withPrimitive({ topology: 'triangle-strip' })
+    .createPipeline();
 
   return {
     init() {
-      initWorldPipeline.execute({ workgroups: [gridSize, gridSize] });
+      initWorldPipeline.dispatchWorkgroups(gridSize, gridSize);
       root.flush();
     },
 
     applyMovedObstacles(bufferData: Parsed<BoxObstacle>[]) {
       obstaclesBuffer.write(bufferData);
-      moveObstaclesPipeline.execute();
+      moveObstaclesPipeline.dispatchWorkgroups(1);
       root.flush();
 
       prevObstaclesBuffer.write(bufferData);
@@ -618,29 +669,23 @@ function makePipelines(
     },
 
     compute() {
-      computePipeline.execute({
-        workgroups: [
-          gridSize / computeWorkgroupSize,
-          gridSize / computeWorkgroupSize,
-        ],
-      });
+      computePipeline.dispatchWorkgroups(
+        gridSize / mainCompute.shell.workgroupSize[0],
+        gridSize / mainCompute.shell.workgroupSize[1],
+      );
     },
 
     render() {
       const textureView = context.getCurrentTexture().createView();
 
-      renderPipeline.execute({
-        colorAttachments: [
-          {
-            view: textureView,
-            clearValue: [0, 0, 0, 1],
-            loadOp: 'clear',
-            storeOp: 'store',
-          },
-        ],
-
-        vertexCount: 4,
-      });
+      renderPipeline
+        .withColorAttachment({
+          view: textureView,
+          clearValue: [0, 0, 0, 1],
+          loadOp: 'clear',
+          storeOp: 'store',
+        })
+        .draw(4);
     },
   };
 }

--- a/packages/typegpu/src/core/buffer/bufferUsage.ts
+++ b/packages/typegpu/src/core/buffer/bufferUsage.ts
@@ -1,6 +1,7 @@
 import type { Unwrap } from 'typed-binary';
 import { type Storage, isUsableAsStorage } from '../../extension';
 import { inGPUMode } from '../../gpuMode';
+import type { Infer } from '../../repr';
 import type { LayoutMembership } from '../../tgpuBindGroupLayout';
 import type {
   AnyTgpuData,
@@ -20,6 +21,7 @@ export interface TgpuBufferUsage<
 > extends TgpuResolvable {
   readonly resourceType: 'buffer-usage';
   readonly usage: TUsage;
+  readonly __repr: Infer<TData>;
   value: Unwrap<TData>;
 }
 
@@ -60,6 +62,8 @@ class TgpuFixedBufferImpl<
   TUsage extends BindableBufferUsage,
 > implements TgpuBufferUsage<TData, TUsage>
 {
+  /** Type-token, not available at runtime */
+  public readonly __repr!: Infer<TData>;
   public readonly resourceType = 'buffer-usage' as const;
 
   constructor(
@@ -109,6 +113,8 @@ export class TgpuLaidOutBufferImpl<
   TUsage extends BindableBufferUsage,
 > implements TgpuBufferUsage<TData, TUsage>
 {
+  /** Type-token, not available at runtime */
+  public readonly __repr!: Infer<TData>;
   public readonly resourceType = 'buffer-usage' as const;
 
   constructor(

--- a/packages/typegpu/src/core/function/tgpuComputeFn.ts
+++ b/packages/typegpu/src/core/function/tgpuComputeFn.ts
@@ -1,4 +1,5 @@
 import type { Block } from 'tinyest';
+import type { AnyBuiltin } from '../../builtin';
 import type { TgpuNamable } from '../../namable';
 import type { ResolutionCtx, TgpuResolvable } from '../../types';
 import { createFnCore } from './fnCore';
@@ -14,6 +15,7 @@ import type { Implementation } from './fnTypes';
 export interface TgpuComputeFnShell {
   readonly argTypes: [];
   readonly returnType: undefined;
+  readonly workgroupSize: [number, number, number];
 
   /**
    * Creates a type-safe implementation of this signature
@@ -36,6 +38,10 @@ export interface TgpuComputeFn extends TgpuResolvable, TgpuNamable {
   $__ast(argNames: string[], body: Block): this;
 }
 
+export interface ComputeFnOptions {
+  workgroupSize: number[];
+}
+
 /**
  * Creates a shell of a typed entry function for the compute shader stage. Any function
  * that implements this shell can perform general-purpose computation.
@@ -43,10 +49,20 @@ export interface TgpuComputeFn extends TgpuResolvable, TgpuNamable {
  * @param workgroupSize
  *   Size of blocks that the thread grid will be divided into (up to 3 dimensions).
  */
-export function computeFn(workgroupSize: number[]): TgpuComputeFnShell {
+export function computeFn<Args extends AnyBuiltin[] | []>(
+  argTypes: Args,
+  options: ComputeFnOptions,
+): TgpuComputeFnShell {
+  const { workgroupSize } = options;
+
   return {
     argTypes: [],
     returnType: undefined,
+    workgroupSize: [
+      workgroupSize[0] ?? 1,
+      workgroupSize[1] ?? 1,
+      workgroupSize[2] ?? 1,
+    ],
 
     does(implementation) {
       return createComputeFn(this, workgroupSize, implementation);

--- a/packages/typegpu/src/core/function/tgpuComputeFn.ts
+++ b/packages/typegpu/src/core/function/tgpuComputeFn.ts
@@ -49,8 +49,8 @@ export interface ComputeFnOptions {
  * @param workgroupSize
  *   Size of blocks that the thread grid will be divided into (up to 3 dimensions).
  */
-export function computeFn<Args extends AnyBuiltin[] | []>(
-  argTypes: Args,
+export function computeFn(
+  argTypes: AnyBuiltin[],
   options: ComputeFnOptions,
 ): TgpuComputeFnShell {
   const { workgroupSize } = options;

--- a/packages/typegpu/src/core/pipeline/computePipeline.ts
+++ b/packages/typegpu/src/core/pipeline/computePipeline.ts
@@ -5,6 +5,7 @@ import type {
   TgpuBindGroup,
   TgpuBindGroupLayout,
 } from '../../tgpuBindGroupLayout';
+import type { TgpuSlot } from '../../types';
 import type { TgpuComputeFn } from '../function/tgpuComputeFn';
 import type { ExperimentalTgpuRoot } from '../root/rootTypes';
 
@@ -34,10 +35,11 @@ export interface INTERNAL_TgpuComputePipeline {
 
 export function INTERNAL_createComputePipeline(
   branch: ExperimentalTgpuRoot,
+  slotBindings: [TgpuSlot<unknown>, unknown][],
   entryFn: TgpuComputeFn,
 ) {
   return new TgpuComputePipelineImpl(
-    new ComputePipelineCore(branch, entryFn),
+    new ComputePipelineCore(branch, slotBindings, entryFn),
     {},
   );
 }
@@ -134,6 +136,7 @@ class ComputePipelineCore {
 
   constructor(
     public readonly branch: ExperimentalTgpuRoot,
+    private readonly _slotBindings: [TgpuSlot<unknown>, unknown][],
     private readonly _entryFn: TgpuComputeFn,
   ) {}
 
@@ -145,7 +148,7 @@ class ComputePipelineCore {
       const { code, bindGroupLayouts, catchall } = resolve(
         {
           resolve: (ctx) => {
-            ctx.resolve(this._entryFn);
+            ctx.resolve(this._entryFn, this._slotBindings);
             return '';
           },
         },

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -12,7 +12,7 @@ import type {
   Unsubscribe,
 } from '../../tgpuPlumTypes';
 import type { TgpuSampler } from '../../tgpuSampler';
-import type { AnyTgpuData, TgpuSlot } from '../../types';
+import type { AnyTgpuData, Eventual, TgpuSlot } from '../../types';
 import type { Unwrapper } from '../../unwrapper';
 import type { Mutable, OmitProps, Prettify } from '../../utilityTypes';
 import type { TgpuBuffer } from '../buffer/buffer';
@@ -53,7 +53,7 @@ export interface WithFragment<
 }
 
 export interface WithBinding {
-  with<T>(slot: TgpuSlot<T>, value: T): WithBinding;
+  with<T>(slot: TgpuSlot<T>, value: Eventual<T>): WithBinding;
 
   withCompute(entryFn: TgpuComputeFn): WithCompute;
 

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -12,7 +12,7 @@ import type {
   Unsubscribe,
 } from '../../tgpuPlumTypes';
 import type { TgpuSampler } from '../../tgpuSampler';
-import type { AnyTgpuData } from '../../types';
+import type { AnyTgpuData, TgpuSlot } from '../../types';
 import type { Unwrapper } from '../../unwrapper';
 import type { Mutable, OmitProps, Prettify } from '../../utilityTypes';
 import type { TgpuBuffer } from '../buffer/buffer';
@@ -48,7 +48,19 @@ export interface WithVertex<Varying extends IOLayout = IOLayout> {
 export interface WithFragment<
   Output extends IOLayout<Vec4f> = IOLayout<Vec4f>,
 > {
+  withPrimitive(primitiveState: GPUPrimitiveState): WithFragment<Output>;
   createPipeline(): TgpuRenderPipeline<Output>;
+}
+
+export interface WithBinding {
+  with<T>(slot: TgpuSlot<T>, value: T): WithBinding;
+
+  withCompute(entryFn: TgpuComputeFn): WithCompute;
+
+  withVertex<Attribs extends IOLayout, Varying extends IOLayout>(
+    entryFn: TgpuVertexFn<Attribs, Varying>,
+    attribs: LayoutToAllowedAttribs<OmitBuiltins<Attribs>>,
+  ): WithVertex<Varying>;
 }
 
 export type CreateTextureOptions<
@@ -196,7 +208,7 @@ export interface TgpuRoot extends Unwrapper {
   destroy(): void;
 }
 
-export interface ExperimentalTgpuRoot extends TgpuRoot {
+export interface ExperimentalTgpuRoot extends TgpuRoot, WithBinding {
   readonly jitTranspiler?: JitTranspiler | undefined;
   readonly nameRegistry: NameRegistry;
   /**
@@ -218,13 +230,6 @@ export interface ExperimentalTgpuRoot extends TgpuRoot {
   ): Unsubscribe;
 
   samplerFor(sampler: TgpuSampler): GPUSampler;
-
-  withCompute(entryFn: TgpuComputeFn): WithCompute;
-
-  withVertex<Attribs extends IOLayout, Varying extends IOLayout>(
-    entryFn: TgpuVertexFn<Attribs, Varying>,
-    attribs: LayoutToAllowedAttribs<OmitBuiltins<Attribs>>,
-  ): WithVertex<Varying>;
 
   /**
    * Causes all commands enqueued by pipelines to be

--- a/packages/typegpu/src/data/array.ts
+++ b/packages/typegpu/src/data/array.ts
@@ -138,6 +138,8 @@ class TgpuArrayImpl<TElement extends AnyTgpuData>
   extends Schema<Unwrap<TElement>[]>
   implements TgpuArray<TElement>
 {
+  /** Type-token, not available at runtime */
+  public readonly __repr!: Unwrap<TElement>[];
   private _size: number;
   public readonly isRuntimeSized: boolean;
   public readonly byteAlignment: number;
@@ -213,6 +215,8 @@ class TgpuLooseArrayImpl<TElement extends AnyTgpuData | AnyTgpuLooseData>
   extends Schema<Unwrap<TElement>[]>
   implements TgpuLooseArray<TElement>
 {
+  /** Type-token, not available at runtime */
+  public readonly __repr!: Unwrap<TElement>[];
   public readonly byteAlignment: number;
   public readonly size: number;
   public readonly stride: number;

--- a/packages/typegpu/src/data/atomic.ts
+++ b/packages/typegpu/src/data/atomic.ts
@@ -58,6 +58,8 @@ class AtomicImpl<TSchema extends U32 | I32>
   extends Schema<Unwrap<TSchema>>
   implements Atomic<TSchema>
 {
+  /** Type-token, not available at runtime */
+  public readonly __repr!: Unwrap<TSchema>;
   public readonly size: number;
   public readonly byteAlignment: number;
   public readonly isLoose = false as const;

--- a/packages/typegpu/src/data/attributes.ts
+++ b/packages/typegpu/src/data/attributes.ts
@@ -411,6 +411,8 @@ class DecoratedImpl<TInner extends AnyTgpuData, TAttribs extends AnyAttribute[]>
   extends BaseDecoratedImpl<TInner, TAttribs>
   implements Decorated<TInner, TAttribs>
 {
+  /** Type-token, not available at runtime */
+  public readonly __repr!: Unwrap<TInner>;
   public readonly isLoose = false as const;
 
   resolve(ctx: ResolutionCtx): string {
@@ -425,5 +427,7 @@ class LooseDecoratedImpl<
   extends BaseDecoratedImpl<TInner, TAttribs>
   implements LooseDecorated<TInner, TAttribs>
 {
+  /** Type-token, not available at runtime */
+  public readonly __repr!: Unwrap<TInner>;
   public readonly isLoose = true as const;
 }

--- a/packages/typegpu/src/data/matrix.ts
+++ b/packages/typegpu/src/data/matrix.ts
@@ -36,6 +36,8 @@ function createMatSchema<
   options: MatSchemaOptions<ValueType, ColumnType>,
 ): MatSchema<ValueType, ColumnType> {
   const MatSchema: TgpuData<ValueType> = {
+    /** Type-token, not available at runtime */
+    __repr: undefined as unknown as ValueType,
     // Type-token, not available at runtime.
     __unwrapped: undefined as unknown as ValueType,
     isLoose: false as const,

--- a/packages/typegpu/src/data/numeric.ts
+++ b/packages/typegpu/src/data/numeric.ts
@@ -9,6 +9,8 @@ const primitiveNumeric = <TKind extends string>(
   code: TKind,
 ) => {
   return {
+    /** Type-token, not available at runtime */
+    __repr: undefined as unknown as number,
     // Type-token, not available at runtime
     __unwrapped: undefined as unknown as number,
 

--- a/packages/typegpu/src/data/std140.ts
+++ b/packages/typegpu/src/data/std140.ts
@@ -20,6 +20,8 @@ export class SimpleTgpuData<TSchema extends AnySchema>
   extends Schema<Unwrap<TSchema>>
   implements TgpuData<Unwrap<TSchema>>
 {
+  /** Type-token, not available at runtime */
+  public readonly __repr!: Unwrap<TSchema>;
   public readonly size: number;
   public readonly byteAlignment: number;
 

--- a/packages/typegpu/src/data/struct.ts
+++ b/packages/typegpu/src/data/struct.ts
@@ -149,6 +149,8 @@ class TgpuStructImpl<TProps extends Record<string, AnyTgpuData>>
 {
   private _label: string | undefined;
 
+  /** Type-token, not available at runtime */
+  public readonly __repr!: UnwrapRecord<TProps>;
   private _size: number;
   public readonly byteAlignment: number;
   public readonly isLoose = false as const;
@@ -268,6 +270,8 @@ class TgpuLooseStructImpl<
 {
   private _label: string | undefined;
 
+  /** Type-token, not available at runtime */
+  public readonly __repr!: UnwrapRecord<TProps>;
   public readonly byteAlignment = 1;
   public readonly isLoose = true as const;
   public readonly size: number;

--- a/packages/typegpu/src/data/vector.ts
+++ b/packages/typegpu/src/data/vector.ts
@@ -37,6 +37,8 @@ function makeVecSchema<ValueType extends vecBase>(
   options: VecSchemaOptions<ValueType>,
 ): VecSchemaBase<ValueType> & ((...args: number[]) => ValueType) {
   const VecSchema: VecSchemaBase<ValueType> = {
+    /** Type-token, not available at runtime */
+    __repr: undefined as unknown as ValueType,
     // Type-token, not available at runtime
     __unwrapped: undefined as unknown as ValueType,
     isLoose: false as const,

--- a/packages/typegpu/src/data/vertexFormatData.ts
+++ b/packages/typegpu/src/data/vertexFormatData.ts
@@ -42,6 +42,9 @@ class TgpuVertexFormatDataImpl<T extends VertexFormat>
   extends Schema<FormatToWGSLType<T>>
   implements TgpuVertexFormatData<T>
 {
+  /** Type-token, not available at runtime */
+  public readonly __repr!: FormatToWGSLType<T>;
+
   private underlyingType: FormatToWGSLType<T>;
   private elementSize: 1 | 2 | 4;
   private elementCount: number;

--- a/packages/typegpu/src/repr.ts
+++ b/packages/typegpu/src/repr.ts
@@ -1,0 +1,9 @@
+/**
+ * Extracts the inferred representation of a resource.
+ * @example
+ * type A = Infer<TgpuBufferReadonly<F32>> // => number
+ * type B = Infer<TgpuBufferReadonly<TgpuArray<F32>>> // => number[]
+ */
+export type Infer<T> = T extends { readonly __repr: infer TRepr }
+  ? TRepr
+  : never;

--- a/packages/typegpu/src/tgpuSlot.ts
+++ b/packages/typegpu/src/tgpuSlot.ts
@@ -1,4 +1,5 @@
 import { inGPUMode } from './gpuMode';
+import type { Infer } from './repr';
 import {
   type ResolutionCtx,
   type TgpuResolvable,
@@ -55,10 +56,10 @@ class TgpuSlotImpl<T> implements TgpuResolvable, TgpuSlot<T> {
     return `slot:${this.label ?? '<unnamed>'}`;
   }
 
-  get value(): T {
+  get value(): Infer<T> {
     if (!inGPUMode()) {
       throw new Error(`Cannot access wgsl.slot's value directly in JS.`);
     }
-    return this as unknown as T;
+    return this as unknown as Infer<T>;
   }
 }

--- a/packages/typegpu/src/types.ts
+++ b/packages/typegpu/src/types.ts
@@ -2,6 +2,7 @@ import type { Block } from 'tinyest';
 import type { ISchema } from 'typed-binary';
 import type { TgpuNamable } from './namable';
 import type { NameRegistry } from './nameRegistry';
+import type { Infer } from './repr';
 import type {
   TgpuBindGroupLayout,
   TgpuLayoutEntry,
@@ -119,12 +120,16 @@ export type BindableBufferUsage = 'uniform' | 'readonly' | 'mutable';
 export type BufferUsage = 'uniform' | 'readonly' | 'mutable' | 'vertex';
 
 export interface TgpuData<TInner> extends ISchema<TInner>, TgpuResolvable {
+  /** Type-token, not available at runtime */
+  readonly __repr: TInner;
   readonly isLoose: false;
   readonly byteAlignment: number;
   readonly size: number;
 }
 
 export interface TgpuLooseData<TInner> extends ISchema<TInner> {
+  /** Type-token, not available at runtime */
+  readonly __repr: TInner;
   readonly isLoose: true;
   readonly byteAlignment: number;
   readonly size: number;
@@ -178,7 +183,7 @@ export interface TgpuSlot<T> extends TgpuNamable {
    */
   areEqual(a: T, b: T): boolean;
 
-  readonly value: T;
+  readonly value: Infer<T>;
 }
 
 export function isSlot<T>(value: unknown | TgpuSlot<T>): value is TgpuSlot<T> {

--- a/packages/typegpu/tests/bufferUsage.test.ts
+++ b/packages/typegpu/tests/bufferUsage.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expectTypeOf, it, vi } from 'vitest';
+import tgpu from '../src';
+import { f32 } from '../src/data';
+import { type ExperimentalTgpuRoot, asUniform } from '../src/experimental';
+import type { Infer } from '../src/repr';
+
+const mockBuffer = {
+  getMappedRange: vi.fn(() => new ArrayBuffer(8)),
+  unmap: vi.fn(),
+  mapAsync: vi.fn(),
+};
+
+const mockCommandEncoder = {
+  beginComputePass: vi.fn(() => mockComputePassEncoder),
+  beginRenderPass: vi.fn(() => mockRenderPassEncoder),
+  copyBufferToBuffer: vi.fn(),
+  copyBufferToTexture: vi.fn(),
+  copyTextureToBuffer: vi.fn(),
+  copyTextureToTexture: vi.fn(),
+  finish: vi.fn(),
+};
+
+const mockComputePassEncoder = {
+  dispatchWorkgroups: vi.fn(),
+  end: vi.fn(),
+  setBindGroup: vi.fn(),
+  setPipeline: vi.fn(),
+};
+
+const mockRenderPassEncoder = {
+  draw: vi.fn(),
+  end: vi.fn(),
+  setBindGroup: vi.fn(),
+  setPipeline: vi.fn(),
+  setVertexBuffer: vi.fn(),
+};
+
+const mockDevice = {
+  createBindGroup: vi.fn(() => 'mockBindGroup'),
+  createBindGroupLayout: vi.fn(() => 'mockBindGroupLayout'),
+  createBuffer: vi.fn(() => mockBuffer),
+  createCommandEncoder: vi.fn(() => mockCommandEncoder),
+  createComputePipeline: vi.fn(() => 'mockComputePipeline'),
+  createPipelineLayout: vi.fn(() => 'mockPipelineLayout'),
+  createRenderPipeline: vi.fn(() => 'mockRenderPipeline'),
+  createSampler: vi.fn(() => 'mockSampler'),
+  createShaderModule: vi.fn(() => 'mockShaderModule'),
+  createTexture: vi.fn(() => 'mockTexture'),
+  importExternalTexture: vi.fn(() => 'mockExternalTexture'),
+  queue: {
+    copyExternalImageToTexture: vi.fn(),
+    onSubmittedWorkDone: vi.fn(),
+    submit: vi.fn(),
+    writeBuffer: vi.fn(),
+    writeTexture: vi.fn(),
+  },
+};
+
+function useRoot() {
+  let root: ExperimentalTgpuRoot;
+
+  beforeEach(() => {
+    root = tgpu.initFromDevice({
+      device: mockDevice as unknown as GPUDevice,
+    });
+  });
+
+  afterEach(() => {
+    root.destroy();
+    vi.resetAllMocks();
+  });
+
+  return () => root;
+}
+
+describe('TgpuBufferReadonly', () => {
+  const getRoot = useRoot();
+
+  it('represents a `number` value', () => {
+    const root = getRoot();
+    const buffer = root.createBuffer(f32).$usage('uniform');
+    const uniform = asUniform(buffer);
+
+    expectTypeOf<Infer<typeof uniform>>().toEqualTypeOf<number>();
+  });
+});

--- a/packages/typegpu/tests/bufferUsage.test.ts
+++ b/packages/typegpu/tests/bufferUsage.test.ts
@@ -3,6 +3,7 @@ import tgpu from '../src';
 import { f32 } from '../src/data';
 import { type ExperimentalTgpuRoot, asUniform } from '../src/experimental';
 import type { Infer } from '../src/repr';
+import './utils/webgpuGlobals';
 
 const mockBuffer = {
   getMappedRange: vi.fn(() => new ArrayBuffer(8)),

--- a/packages/typegpu/tests/computePipeline.test.ts
+++ b/packages/typegpu/tests/computePipeline.test.ts
@@ -78,7 +78,7 @@ describe('TgpuComputePipeline', () => {
 
   it('can be created with a compute entry function', () => {
     const entryFn = tgpu
-      .computeFn([32])
+      .computeFn([], { workgroupSize: [32] })
       .does(() => {
         // do something
       })


### PR DESCRIPTION
### Changes
- `withPrimitive()` on render pipelines,
- `with()` on root to allow for slot bindings,
- Migrated fluid double buffering to new pipelines.
- A new `Infer<T>` type for "parsing", and a "__repr" type token to replace "__unwrapped"
- Making slot.value **double infer**.

### Additional Context
Changing "Parsed" to "Infer": https://github.com/software-mansion/TypeGPU/discussions/580
Making slot.value **double infer**: https://github.com/software-mansion/TypeGPU/discussions/586