### PR TITLE
`root.createBindGroup` API replacing `layout.populate`

### DIFF
--- a/apps/typegpu-docs/src/content/examples/algorithms/matrix-multiplication/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/matrix-multiplication/index.ts
@@ -89,7 +89,7 @@ const pipeline = device.createComputePipeline({
   },
 });
 
-const bindGroup = layout.populate({
+const bindGroup = root.createBindGroup(layout, {
   firstMatrix: firstMatrixBuffer,
   secondMatrix: secondMatrixBuffer,
   resultMatrix: resultMatrixBuffer,

--- a/apps/typegpu-docs/src/content/examples/image-processing/blur/index.ts
+++ b/apps/typegpu-docs/src/content/examples/image-processing/blur/index.ts
@@ -197,7 +197,7 @@ const computePipeline = device.createComputePipeline({
   },
 });
 
-const uniformBindGroup = uniformLayout.populate({
+const uniformBindGroup = root.createBindGroup(uniformLayout, {
   settings: settingsBuffer,
   sampling: sampler,
 });
@@ -206,24 +206,24 @@ const zeroBuffer = root.createBuffer(u32, 0).$usage('uniform');
 const oneBuffer = root.createBuffer(u32, 1).$usage('uniform');
 
 const ioBindGroups = [
-  ioLayout.populate({
+  root.createBindGroup(ioLayout, {
     flip: zeroBuffer,
     inTexture: imageTexture,
     outTexture: textures[0],
   }),
-  ioLayout.populate({
+  root.createBindGroup(ioLayout, {
     flip: oneBuffer,
     inTexture: textures[0],
     outTexture: textures[1],
   }),
-  ioLayout.populate({
+  root.createBindGroup(ioLayout, {
     flip: zeroBuffer,
     inTexture: textures[1],
     outTexture: textures[0],
   }),
 ];
 
-const renderBindGroup = renderLayout.populate({
+const renderBindGroup = root.createBindGroup(renderLayout, {
   texture: textures[1],
   sampling: sampler,
 });

--- a/apps/typegpu-docs/src/content/examples/image-processing/camera-thresholding/index.ts
+++ b/apps/typegpu-docs/src/content/examples/image-processing/camera-thresholding/index.ts
@@ -75,7 +75,7 @@ const thresholdBuffer = root
   .$name('threshold')
   .$usage('uniform');
 
-const rareBindGroup = rareLayout.populate({
+const rareBindGroup = root.createBindGroup(rareLayout, {
   sampling: sampler,
   threshold: thresholdBuffer,
 });
@@ -145,7 +145,7 @@ function run() {
   pass.setBindGroup(
     1,
     root.unwrap(
-      frequentLayout.populate({
+      root.createBindGroup(frequentLayout, {
         inputTexture: device.importExternalTexture({ source: video }),
       }),
     ),

--- a/apps/typegpu-docs/src/content/examples/image-processing/chroma-keying/index.ts
+++ b/apps/typegpu-docs/src/content/examples/image-processing/chroma-keying/index.ts
@@ -139,7 +139,7 @@ const sampler = device.createSampler({
   minFilter: 'linear',
 });
 
-const rareBindGroup = rareLayout.populate({
+const rareBindGroup = root.createBindGroup(rareLayout, {
   color: colorBuffer,
   sampling: sampler,
   threshold: thresholdBuffer,
@@ -194,7 +194,7 @@ async function drawFrame() {
   pass.setBindGroup(
     1,
     root.unwrap(
-      frequentLayout.populate({
+      root.createBindGroup(frequentLayout, {
         inputTexture: device.importExternalTexture({ source: frame }),
       }),
     ),

--- a/apps/typegpu-docs/src/content/examples/rendering/box-raytracing/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/box-raytracing/index.ts
@@ -101,7 +101,7 @@ const renderBindGroupLayout = tgpu.bindGroupLayout({
   boxSize: { uniform: boxSizeBuffer.dataType },
 });
 
-const renderBindGroup = renderBindGroupLayout.populate({
+const renderBindGroup = root.createBindGroup(renderBindGroupLayout, {
   boxMatrix: boxMatrixBuffer,
   cameraPosition: cameraPositionBuffer,
   cameraAxes: cameraAxesBuffer,

--- a/apps/typegpu-docs/src/content/examples/simple/increment/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simple/increment/index.ts
@@ -27,7 +27,7 @@ const pipeline = device.createComputePipeline({
 });
 
 const counterBuffer = root.createBuffer(u32, 0).$usage('storage');
-const bindGroup = layout.populate({
+const bindGroup = root.createBindGroup(layout, {
   counter: counterBuffer,
 });
 

--- a/apps/typegpu-docs/src/content/examples/simulation/boids-next/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/boids-next/index.ts
@@ -274,14 +274,14 @@ const mainCompute = tgpu
 const computePipeline = root.withCompute(mainCompute).createPipeline();
 
 const renderBindGroups = [0, 1].map((idx) =>
-  renderBindGroupLayout.populate({
+  root.createBindGroup(renderBindGroupLayout, {
     trianglePos: trianglePosBuffers[idx],
     colorPalette: colorPaletteBuffer,
   }),
 );
 
 const computeBindGroups = [0, 1].map((idx) =>
-  computeBindGroupLayout.populate({
+  root.createBindGroup(computeBindGroupLayout, {
     currentTrianglePos: trianglePosBuffers[idx],
     nextTrianglePos: trianglePosBuffers[1 - idx],
   }),

--- a/apps/typegpu-docs/src/content/examples/simulation/game-of-life/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/game-of-life/index.ts
@@ -184,19 +184,19 @@ const resetGameData = () => {
     .createBuffer(arrayOf(u32, length))
     .$usage('storage', 'vertex');
 
-  const bindGroup0 = bindGroupLayoutCompute.populate({
+  const bindGroup0 = root.createBindGroup(bindGroupLayoutCompute, {
     size: sizeBuffer,
     current: buffer0,
     next: buffer1,
   });
 
-  const bindGroup1 = bindGroupLayoutCompute.populate({
+  const bindGroup1 = root.createBindGroup(bindGroupLayoutCompute, {
     size: sizeBuffer,
     current: buffer1,
     next: buffer0,
   });
 
-  const uniformBindGroup = bindGroupLayoutRender.populate({
+  const uniformBindGroup = root.createBindGroup(bindGroupLayoutRender, {
     size: sizeBuffer,
   });
 

--- a/packages/typegpu/src/core/root/init.ts
+++ b/packages/typegpu/src/core/root/init.ts
@@ -10,10 +10,16 @@ import {
 import type { Infer } from '../../shared/repr';
 import type { AnyVertexAttribs } from '../../shared/vertexFormat';
 import type {
+  LayoutEntryToInput,
   TgpuBindGroup,
   TgpuBindGroupLayout,
+  TgpuLayoutEntry,
 } from '../../tgpuBindGroupLayout';
-import { isBindGroup, isBindGroupLayout } from '../../tgpuBindGroupLayout';
+import {
+  TgpuBindGroupImpl,
+  isBindGroup,
+  isBindGroupLayout,
+} from '../../tgpuBindGroupLayout';
 import type { TgpuSlot } from '../../types';
 import { type TgpuBuffer, createBufferImpl, isBuffer } from '../buffer/buffer';
 import type { IOLayout } from '../function/fnTypes';
@@ -223,6 +229,20 @@ class TgpuRootImpl extends WithBindingImpl implements ExperimentalTgpuRoot {
     this._disposables.push(texture);
     // biome-ignore lint/suspicious/noExplicitAny: <too much type wrangling>
     return texture as any;
+  }
+
+  createBindGroup<
+    Entries extends Record<string, TgpuLayoutEntry | null> = Record<
+      string,
+      TgpuLayoutEntry | null
+    >,
+  >(
+    layout: TgpuBindGroupLayout<Entries>,
+    entries: {
+      [K in keyof Entries]: LayoutEntryToInput<Entries[K]>;
+    },
+  ) {
+    return new TgpuBindGroupImpl(layout, entries);
   }
 
   destroy() {

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -6,6 +6,12 @@ import type { JitTranspiler } from '../../jitTranspiler';
 import type { NameRegistry } from '../../nameRegistry';
 import type { Infer } from '../../shared/repr';
 import type { Mutable, OmitProps, Prettify } from '../../shared/utilityTypes';
+import type {
+  LayoutEntryToInput,
+  TgpuBindGroup,
+  TgpuBindGroupLayout,
+  TgpuLayoutEntry,
+} from '../../tgpuBindGroupLayout';
 import type { Eventual, TgpuSlot } from '../../types';
 import type { Unwrapper } from '../../unwrapper';
 import type { TgpuBuffer } from '../buffer/buffer';
@@ -195,6 +201,18 @@ export interface TgpuRoot extends Unwrapper {
       TDimension
     >
   >;
+
+  createBindGroup<
+    Entries extends Record<string, TgpuLayoutEntry | null> = Record<
+      string,
+      TgpuLayoutEntry | null
+    >,
+  >(
+    layout: TgpuBindGroupLayout<Entries>,
+    entries: {
+      [K in keyof OmitProps<Entries, null>]: LayoutEntryToInput<Entries[K]>;
+    },
+  ): TgpuBindGroup<Entries>;
 
   destroy(): void;
 }

--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -500,7 +500,7 @@ class TgpuBindGroupLayoutImpl<
   }
 }
 
-class TgpuBindGroupImpl<
+export class TgpuBindGroupImpl<
   Entries extends Record<string, TgpuLayoutEntry | null> = Record<
     string,
     TgpuLayoutEntry | null

--- a/packages/typegpu/tests/bindGroupLayout.test.ts
+++ b/packages/typegpu/tests/bindGroupLayout.test.ts
@@ -97,7 +97,7 @@ describe('TgpuBindGroupLayout', () => {
     const aBuffer = root.createBuffer(arrayOf(u32, 4)).$usage('storage');
     const bBuffer = root.createBuffer(arrayOf(vec3f, 4)).$usage('storage');
 
-    const bindGroup = layout.populate({
+    const bindGroup = root.createBindGroup(layout, {
       a: aBuffer,
       b: bBuffer,
     });
@@ -233,7 +233,9 @@ describe('TgpuBindGroup', () => {
 
     it('populates a simple layout with a raw buffer', ({ root }) => {
       const buffer = root.createBuffer(vec3f).$usage('uniform');
-      const bindGroup = layout.populate({ foo: root.unwrap(buffer) });
+      const bindGroup = root.createBindGroup(layout, {
+        foo: root.unwrap(buffer),
+      });
 
       expect(root.device.createBindGroupLayout).not.toBeCalled();
       root.unwrap(bindGroup);
@@ -255,7 +257,7 @@ describe('TgpuBindGroup', () => {
 
     it('populates a simple layout with a typed buffer', ({ root }) => {
       const buffer = root.createBuffer(vec3f).$usage('uniform');
-      const bindGroup = layout.populate({ foo: buffer });
+      const bindGroup = root.createBindGroup(layout, { foo: buffer });
 
       expect(root.device.createBindGroupLayout).not.toBeCalled();
       root.unwrap(bindGroup);
@@ -290,7 +292,7 @@ describe('TgpuBindGroup', () => {
     it('populates a simple layout with a raw sampler', ({ root }) => {
       const sampler = root.device.createSampler();
 
-      const bindGroup = layout.populate({
+      const bindGroup = root.createBindGroup(layout, {
         foo: sampler,
       });
 
@@ -331,7 +333,7 @@ describe('TgpuBindGroup', () => {
         })
         .createView();
 
-      const bindGroup = layout.populate({
+      const bindGroup = root.createBindGroup(layout, {
         foo: view,
       });
 
@@ -372,7 +374,7 @@ describe('TgpuBindGroup', () => {
         })
         .createView();
 
-      const bindGroup = layout.populate({
+      const bindGroup = root.createBindGroup(layout, {
         foo: view,
       });
 
@@ -411,7 +413,7 @@ describe('TgpuBindGroup', () => {
         source: undefined as unknown as HTMLVideoElement,
       });
 
-      const bindGroup = layout.populate({
+      const bindGroup = root.createBindGroup(layout, {
         foo: externalTexture,
       });
 
@@ -457,7 +459,7 @@ describe('TgpuBindGroup', () => {
 
       expect(() => {
         // @ts-expect-error
-        const bindGroup = layout.populate({
+        const bindGroup = root.createBindGroup(layout, {
           a: aBuffer,
           b: bBuffer,
         });
@@ -471,7 +473,7 @@ describe('TgpuBindGroup', () => {
       const bBuffer = root.createBuffer(u32).$usage('storage');
       const dBuffer = root.createBuffer(f32).$usage('storage');
 
-      const bindGroup = layout.populate({
+      const bindGroup = root.createBindGroup(layout, {
         // purposefully out of order
         d: dBuffer,
         b: bBuffer,


### PR DESCRIPTION
closes #631 