### PR TITLE
Deprecate `populate` method on bindGroupLayout

### DIFF
--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -117,14 +117,14 @@ function createNetwork(layers: [LayerData, LayerData][]): Network {
   const output = buffers[buffers.length - 1].state;
 
   const ioBindGroups = buffers.map((_, i) =>
-    ioLayout.populate({
+    root.createBindGroup(ioLayout, {
       input: i === 0 ? input : buffers[i - 1].state,
       output: buffers[i].state,
     }),
   );
 
   const weightsBindGroups = buffers.map((layer) =>
-    weightsBiasesLayout.populate({
+    root.createBindGroup(weightsBiasesLayout, {
       weights: layer.weights,
       biases: layer.biases,
     }),

--- a/apps/typegpu-docs/src/content/examples/simulation/boids/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/boids/index.ts
@@ -330,14 +330,14 @@ const computePipeline = root.device.createComputePipeline({
 });
 
 const renderBindGroups = [0, 1].map((idx) =>
-  renderBindGroupLayout.populate({
+  root.createBindGroup(renderBindGroupLayout, {
     trianglePos: trianglePosBuffers[idx],
     colorPalette: colorPaletteBuffer,
   }),
 );
 
 const computeBindGroups = [0, 1].map((idx) =>
-  computeBindGroupLayout.populate({
+  root.createBindGroup(computeBindGroupLayout, {
     currentTrianglePos: trianglePosBuffers[idx],
     nextTrianglePos: trianglePosBuffers[1 - idx],
     params: paramsBuffer,

--- a/packages/typegpu/src/experimental/index.ts
+++ b/packages/typegpu/src/experimental/index.ts
@@ -17,6 +17,7 @@ import {
 import type { ExperimentalTgpuRoot } from '../core/root/rootTypes';
 import { vertexLayout } from '../core/vertexLayout/vertexLayout';
 import { bindGroupLayout } from '../tgpuBindGroupLayout';
+import { slot } from '../tgpuSlot';
 
 export const tgpu = {
   /** @deprecated Use `'uniform'` string literal instead. */
@@ -33,6 +34,7 @@ export const tgpu = {
   computeFn,
   vertexLayout,
   bindGroupLayout,
+  slot,
 
   init: init as (
     options?: InitOptions | undefined,

--- a/packages/typegpu/src/experimental/index.ts
+++ b/packages/typegpu/src/experimental/index.ts
@@ -17,7 +17,6 @@ import {
 import type { ExperimentalTgpuRoot } from '../core/root/rootTypes';
 import { vertexLayout } from '../core/vertexLayout/vertexLayout';
 import { bindGroupLayout } from '../tgpuBindGroupLayout';
-import { slot } from '../tgpuSlot';
 
 export const tgpu = {
   /** @deprecated Use `'uniform'` string literal instead. */
@@ -34,7 +33,6 @@ export const tgpu = {
   computeFn,
   vertexLayout,
   bindGroupLayout,
-  slot,
 
   init: init as (
     options?: InitOptions | undefined,

--- a/packages/typegpu/src/resolutionCtx.ts
+++ b/packages/typegpu/src/resolutionCtx.ts
@@ -9,6 +9,7 @@ import { naturalsExcept } from './shared/generators';
 import { generateFunction } from './smol';
 import {
   type TgpuBindGroup,
+  TgpuBindGroupImpl,
   type TgpuBindGroupLayout,
   type TgpuLayoutEntry,
   bindGroupLayout,
@@ -484,7 +485,8 @@ export function resolve(
 
     return [
       catchallIdx,
-      catchallLayout.populate(
+      new TgpuBindGroupImpl(
+        catchallLayout,
         Object.fromEntries(
           ctx.fixedBindings.map(
             (binding, idx) =>

--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -150,6 +150,9 @@ export interface TgpuBindGroupLayout<
    */
   readonly index: number | undefined;
 
+  /**
+   * @deprecated Use the `root.createBindGroup` API instead, accessible through `await tgpu.init()`
+   */
   populate(
     entries: {
       [K in keyof OmitProps<Entries, null>]: LayoutEntryToInput<Entries[K]>;


### PR DESCRIPTION
references #631 