### PR TITLE
docs: Document `copyFrom` method

### DIFF
--- a/apps/typegpu-docs/src/content/docs/fundamentals/buffers.mdx
+++ b/apps/typegpu-docs/src/content/docs/fundamentals/buffers.mdx
@@ -173,6 +173,14 @@ If you pass an unmapped buffer, the data will be written to the buffer using `GP
 If you passed your own buffer to the `root.createBuffer` function, you need to ensure it has the `GPUBufferUsage.COPY_DST` usage flag if you want to write to it using the `write` method.
 :::
 
+There's also an option to copy value from another typed buffer using the `.copyFrom(buffer)` method, 
+if the other buffer has a matching data schema.
+
+```ts
+const backupParticleBuffer = root.createBuffer(Particle);
+backupParticleBuffer.copyFrom(particleBuffer);
+```
+
 ## Reading from a buffer
 
 To read data from a buffer, you can use the `.read()` method.


### PR DESCRIPTION
closes #623 