### PR TITLE
Fix misleading error message when texture validation fails due to missing usage.

### DIFF
--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -273,17 +273,17 @@ export type LayoutEntryToInput<T extends TgpuLayoutEntry | null> =
         : T extends TgpuLayoutTexture
           ?
               | GPUTextureView
-              | (TgpuTexture<
-                  Prettify<TextureProps & GetTextureRestriction<T>>
-                > &
-                  Sampled)
+              | (Sampled &
+                  TgpuTexture<
+                    Prettify<TextureProps & GetTextureRestriction<T>>
+                  >)
           : T extends TgpuLayoutStorageTexture
             ?
                 | GPUTextureView
-                | (TgpuTexture<
-                    Prettify<TextureProps & GetStorageTextureRestriction<T>>
-                  > &
-                    Storage)
+                | (Storage &
+                    TgpuTexture<
+                      Prettify<TextureProps & GetStorageTextureRestriction<T>>
+                    >)
             : T extends TgpuLayoutExternalTexture
               ? GPUExternalTexture
               : never;


### PR DESCRIPTION
When missing the proper usage in texture we are getting a misleading error message. Fixed by swapping the order of intersection type.

Before:
<img width="680" alt="Screenshot 2024-12-19 at 15 10 23" src="https://github.com/user-attachments/assets/cb3dbd62-8035-48ae-ab59-900dd1866f45" />

After:
<img width="675" alt="Screenshot 2024-12-19 at 15 10 02" src="https://github.com/user-attachments/assets/20c1d0dd-e1d1-4b1e-b0a6-032d049251cd" />
