### PR TITLE
docs: Removed (potentially) redundant `onSubmittedWorkDone`

### DIFF
--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -152,7 +152,6 @@ function createNetwork(layers: [LayerData, LayerData][]): Network {
       pass.end();
     }
     device.queue.submit([encoder.finish()]);
-    await device.queue.onSubmittedWorkDone();
 
     // Read the output
     return await output.read();


### PR DESCRIPTION
The example seems to work without the call to `onSubmittedWorkDone`.