### PR TITLE
Rename loose data to `unstruct` and `disarray`

### DIFF
--- a/packages/typegpu/src/core/vertexLayout/vertexAttribute.ts
+++ b/packages/typegpu/src/core/vertexLayout/vertexAttribute.ts
@@ -1,4 +1,4 @@
-import type { LooseArray, LooseStruct } from '../../data/dataTypes';
+import type { TgpuDisarray, TgpuUnstruct } from '../../data/dataTypes';
 import type { WgslArray, WgslStruct } from '../../data/wgslTypes';
 import type {
   KindToAcceptedAttribMap,
@@ -15,7 +15,7 @@ import type {
  * - TgpuStruct<{ a: Vec3f, b: unorm8x2 }>
  * - TgpuStruct<{ nested: TgpuStruct<{ a: Vec3f }> }>
  */
-export type DataToContainedAttribs<T> = T extends WgslStruct | LooseStruct
+export type DataToContainedAttribs<T> = T extends WgslStruct | TgpuUnstruct
   ? {
       [Key in keyof T['propTypes']]: DataToContainedAttribs<
         T['propTypes'][Key]
@@ -30,7 +30,7 @@ export type DataToContainedAttribs<T> = T extends WgslStruct | LooseStruct
 /**
  * Interprets an array as a set of vertex attributes.
  */
-export type ArrayToContainedAttribs<T extends WgslArray | LooseArray> =
+export type ArrayToContainedAttribs<T extends WgslArray | TgpuDisarray> =
   DataToContainedAttribs<T['elementType']>;
 
 export type LayoutToAllowedAttribs<T> = T extends {

--- a/packages/typegpu/src/core/vertexLayout/vertexLayout.ts
+++ b/packages/typegpu/src/core/vertexLayout/vertexLayout.ts
@@ -1,6 +1,6 @@
 import { alignmentOf, customAlignmentOf } from '../../data/alignmentOf';
-import { isLooseDecorated, isLooseStruct } from '../../data/dataTypes';
-import type { LooseArray } from '../../data/dataTypes';
+import { isLooseDecorated, isUnstruct } from '../../data/dataTypes';
+import type { TgpuDisarray } from '../../data/dataTypes';
 import { sizeOf } from '../../data/sizeOf';
 import { isDecorated, isWgslStruct } from '../../data/wgslTypes';
 import type { BaseWgslData, WgslArray } from '../../data/wgslTypes';
@@ -23,7 +23,7 @@ import type {
 // ----------
 
 export interface TgpuVertexLayout<
-  TData extends WgslArray | LooseArray = WgslArray | LooseArray,
+  TData extends WgslArray | TgpuDisarray = WgslArray | TgpuDisarray,
 > extends TgpuNamable {
   readonly resourceType: 'vertex-layout';
   readonly label?: string | undefined;
@@ -37,7 +37,7 @@ export interface INTERNAL_TgpuVertexAttrib {
   readonly _layout: TgpuVertexLayout;
 }
 
-export function vertexLayout<TData extends WgslArray | LooseArray>(
+export function vertexLayout<TData extends WgslArray | TgpuDisarray>(
   schemaForCount: (count: number) => TData,
   stepMode: 'vertex' | 'instance' = 'vertex',
 ): TgpuVertexLayout<ExoticIO<TData>> {
@@ -58,7 +58,7 @@ export function isVertexLayout<T extends TgpuVertexLayout>(
 // --------------
 
 function dataToContainedAttribs<
-  TLayoutData extends WgslArray | LooseArray,
+  TLayoutData extends WgslArray | TgpuDisarray,
   TData extends BaseWgslData,
 >(
   layout: TgpuVertexLayout<TLayoutData>,
@@ -89,7 +89,7 @@ function dataToContainedAttribs<
     ) as DataToContainedAttribs<TData>;
   }
 
-  if (isLooseStruct(data)) {
+  if (isUnstruct(data)) {
     let memberOffset = offset;
 
     return Object.fromEntries(
@@ -132,7 +132,7 @@ function dataToContainedAttribs<
   throw new Error(`Unsupported data used in vertex layout: ${String(data)}`);
 }
 
-class TgpuVertexLayoutImpl<TData extends WgslArray | LooseArray>
+class TgpuVertexLayoutImpl<TData extends WgslArray | TgpuDisarray>
   implements TgpuVertexLayout<TData>
 {
   public readonly resourceType = 'vertex-layout';

--- a/packages/typegpu/src/data/alignmentOf.ts
+++ b/packages/typegpu/src/data/alignmentOf.ts
@@ -1,9 +1,9 @@
 import {
   type AnyData,
   getCustomAlignment,
-  isLooseArray,
+  isDisarray,
   isLooseDecorated,
-  isLooseStruct,
+  isUnstruct,
 } from './dataTypes';
 import { packedFormats } from './vertexFormatData';
 import {
@@ -53,13 +53,13 @@ function computeAlignment(data: object): number {
     return alignmentOf(data.elementType);
   }
 
-  if (isLooseStruct(data)) {
+  if (isUnstruct(data)) {
     // A loose struct is aligned to its first property.
     const firstProp = Object.values(data.propTypes)[0];
     return firstProp ? getCustomAlignment(firstProp) ?? 1 : 1;
   }
 
-  if (isLooseArray(data)) {
+  if (isDisarray(data)) {
     return getCustomAlignment(data.elementType) ?? 1;
   }
 
@@ -77,13 +77,13 @@ function computeAlignment(data: object): number {
 }
 
 function computeCustomAlignment(data: BaseWgslData): number {
-  if (isLooseStruct(data)) {
+  if (isUnstruct(data)) {
     // A loose struct is aligned to its first property.
     const firstProp = Object.values(data.propTypes)[0];
     return firstProp ? customAlignmentOf(firstProp) : 1;
   }
 
-  if (isLooseArray(data)) {
+  if (isDisarray(data)) {
     return customAlignmentOf(data.elementType);
   }
 

--- a/packages/typegpu/src/data/dataIO.ts
+++ b/packages/typegpu/src/data/dataIO.ts
@@ -4,9 +4,9 @@ import alignIO from './alignIO';
 import { alignmentOf, customAlignmentOf } from './alignmentOf';
 import type {
   AnyData,
-  LooseArray,
   LooseDecorated,
-  LooseStruct,
+  TgpuDisarray,
+  TgpuUnstruct,
 } from './dataTypes';
 import { mat2x2f, mat3x3f, mat4x4f } from './matrix';
 import { sizeOf } from './sizeOf';
@@ -392,7 +392,7 @@ const dataWriters = {
     output.writeUint8(value.w * 255);
   },
 
-  'loose-array'(output, schema: LooseArray, value: unknown[]) {
+  disarray(output, schema: TgpuDisarray, value: unknown[]) {
     const alignment = alignmentOf(schema);
 
     alignIO(output, alignment);
@@ -409,7 +409,7 @@ const dataWriters = {
     output.seekTo(beginning + sizeOf(schema));
   },
 
-  'loose-struct'(output, schema: LooseStruct, value) {
+  unstruct(output, schema: TgpuUnstruct, value) {
     for (const [key, property] of Object.entries(schema.propTypes)) {
       dataWriters[property.type]?.(output, property, value[key]);
     }
@@ -728,7 +728,7 @@ const dataReaders = {
     return vec4f(r, g, b, a);
   },
 
-  'loose-struct'(input, schema: LooseStruct) {
+  'unstruct'(input, schema: TgpuUnstruct) {
     const result = {} as Record<string, unknown>;
 
     for (const [key, property] of Object.entries(schema.propTypes)) {
@@ -738,7 +738,7 @@ const dataReaders = {
     return result as InferRecord<Record<string, wgsl.BaseWgslData>>;
   },
 
-  'loose-array'(input, schema: LooseArray) {
+  'disarray'(input, schema: TgpuDisarray) {
     const alignment = alignmentOf(schema);
     const elements: unknown[] = [];
 

--- a/packages/typegpu/src/data/dataTypes.ts
+++ b/packages/typegpu/src/data/dataTypes.ts
@@ -4,37 +4,37 @@ import type { PackedData } from './vertexFormatData';
 import * as wgsl from './wgslTypes';
 
 /**
- * Array schema constructed via `d.looseArrayOf` function.
+ * Array schema constructed via `d.disarrayOf` function.
  *
  * Useful for defining vertex buffers.
  * Elements in the schema are not aligned in respect to their `byteAlignment`,
  * unless they are explicitly decorated with the custom align attribute
  * via `d.align` function.
  */
-export interface LooseArray<
+export interface TgpuDisarray<
   TElement extends wgsl.BaseWgslData = wgsl.BaseWgslData,
 > {
-  readonly type: 'loose-array';
+  readonly type: 'disarray';
   readonly elementCount: number;
   readonly elementType: TElement;
   readonly '~repr': Infer<TElement>[];
 }
 
 /**
- * Struct schema constructed via `d.looseStruct` function.
+ * Struct schema constructed via `d.unstruct` function.
  *
  * Useful for defining vertex buffers, as the standard layout restrictions do not apply.
  * Members are not aligned in respect to their `byteAlignment`,
  * unless they are explicitly decorated with the custom align attribute
  * via `d.align` function.
  */
-export interface LooseStruct<
+export interface TgpuUnstruct<
   TProps extends Record<string, wgsl.BaseWgslData> = Record<
     string,
     wgsl.BaseWgslData
   >,
 > {
-  readonly type: 'loose-struct';
+  readonly type: 'unstruct';
   readonly propTypes: TProps;
   readonly '~repr': InferRecord<TProps>;
 }
@@ -50,8 +50,8 @@ export interface LooseDecorated<
 }
 
 const looseTypeLiterals = [
-  'loose-struct',
-  'loose-array',
+  'unstruct',
+  'disarray',
   'loose-decorated',
   ...vertexFormats,
 ] as const;
@@ -59,8 +59,8 @@ const looseTypeLiterals = [
 export type LooseTypeLiteral = (typeof looseTypeLiterals)[number];
 
 export type AnyLooseData =
-  | LooseArray
-  | LooseStruct
+  | TgpuDisarray
+  | TgpuUnstruct
   | LooseDecorated
   | PackedData;
 
@@ -69,41 +69,41 @@ export function isLooseData(data: unknown): data is AnyLooseData {
 }
 
 /**
- * Checks whether the passed in value is a loose-array schema,
+ * Checks whether the passed in value is a disarray schema,
  * as opposed to, e.g., a regular array schema.
  *
  * Array schemas can be used to describe uniform and storage buffers,
- * whereas looseArray schemas cannot. Loose arrays are useful for
+ * whereas disarray schemas cannot. Disarrays are useful for
  * defining vertex buffers instead.
  *
  * @example
- * isLooseArray(d.arrayOf(d.u32, 4)) // false
- * isLooseArray(d.looseArrayOf(d.u32, 4)) // true
- * isLooseArray(d.vec3f) // false
+ * isDisarray(d.arrayOf(d.u32, 4)) // false
+ * isDisarray(d.disarrayOf(d.u32, 4)) // true
+ * isDisarray(d.vec3f) // false
  */
-export function isLooseArray<T extends LooseArray>(
+export function isDisarray<T extends TgpuDisarray>(
   schema: T | unknown,
 ): schema is T {
-  return (schema as LooseArray)?.type === 'loose-array';
+  return (schema as TgpuDisarray)?.type === 'disarray';
 }
 
 /**
- * Checks whether passed in value is a looseStruct schema,
+ * Checks whether passed in value is a unstruct schema,
  * as opposed to, e.g., a struct schema.
  *
  * Struct schemas can be used to describe uniform and storage buffers,
- * whereas looseStruct schemas cannot. Loose structs are useful for
+ * whereas unstruct schemas cannot. Unstructs are useful for
  * defining vertex buffers instead.
  *
  * @example
- * isLooseStruct(d.struct({ a: d.u32 })) // false
- * isLooseStruct(d.looseStruct({ a: d.u32 })) // true
- * isLooseStruct(d.vec3f) // false
+ * isUnstruct(d.struct({ a: d.u32 })) // false
+ * isUnstruct(d.unstruct({ a: d.u32 })) // true
+ * isUnstruct(d.vec3f) // false
  */
-export function isLooseStruct<T extends LooseStruct>(
+export function isUnstruct<T extends TgpuUnstruct>(
   schema: T | unknown,
 ): schema is T {
-  return (schema as T)?.type === 'loose-struct';
+  return (schema as T)?.type === 'unstruct';
 }
 
 export function isLooseDecorated<T extends LooseDecorated>(

--- a/packages/typegpu/src/data/disarray.ts
+++ b/packages/typegpu/src/data/disarray.ts
@@ -1,5 +1,5 @@
 import type { Infer } from '../shared/repr';
-import type { AnyData, LooseArray } from './dataTypes';
+import type { AnyData, TgpuDisarray } from './dataTypes';
 import type { Exotic } from './exotic';
 
 // ----------
@@ -15,26 +15,28 @@ import type { Exotic } from './exotic';
  * via `d.align` function.
  *
  * @example
- * const looseArray = d.looseArrayOf(d.vec3f, 3); // packed array of vec3f
+ * const disarray = d.disarrayOf(d.vec3f, 3); // packed array of vec3f
  *
  * @example
- * const looseArray = d.looseArrayOf(d.align(16, d.vec3f), 3);
+ * const disarray = d.disarrayOf(d.align(16, d.vec3f), 3);
  *
  * @param elementType The type of elements in the array.
  * @param count The number of elements in the array.
  */
-export const looseArrayOf = <TElement extends AnyData>(
+export const disarrayOf = <TElement extends AnyData>(
   elementType: TElement,
   count: number,
-): LooseArray<Exotic<TElement>> =>
-  new LooseArrayImpl(elementType as Exotic<TElement>, count);
+): TgpuDisarray<Exotic<TElement>> =>
+  new TgpuDisarrayImpl(elementType as Exotic<TElement>, count);
 
 // --------------
 // Implementation
 // --------------
 
-class LooseArrayImpl<TElement extends AnyData> implements LooseArray<TElement> {
-  public readonly type = 'loose-array';
+class TgpuDisarrayImpl<TElement extends AnyData>
+  implements TgpuDisarray<TElement>
+{
+  public readonly type = 'disarray';
   /** Type-token, not available at runtime */
   public readonly '~repr'!: Infer<TElement>[];
 

--- a/packages/typegpu/src/data/index.ts
+++ b/packages/typegpu/src/data/index.ts
@@ -66,8 +66,8 @@ export {
   arrayOf,
 } from './array';
 export type {
-  LooseArray,
-  LooseStruct,
+  TgpuDisarray,
+  TgpuUnstruct,
   LooseDecorated,
   AnyData,
   AnyLooseData,
@@ -86,8 +86,8 @@ export {
   vec4i,
   vec4u,
 } from './vector';
-export { looseArrayOf } from './looseArray';
-export { looseStruct } from './looseStruct';
+export { disarrayOf } from './disarray';
+export { unstruct } from './unstruct';
 export {
   mat2x2f,
   mat3x3f,
@@ -106,8 +106,8 @@ export {
   HasCustomLocation,
 } from './attributes';
 export {
-  isLooseArray,
-  isLooseStruct,
+  isDisarray,
+  isUnstruct,
   isLooseDecorated,
   isData,
   isLooseData,

--- a/packages/typegpu/src/data/sizeOf.ts
+++ b/packages/typegpu/src/data/sizeOf.ts
@@ -1,11 +1,11 @@
 import { roundUp } from '../mathUtils';
 import { alignmentOf, customAlignmentOf } from './alignmentOf';
-import type { AnyData, LooseStruct, LooseTypeLiteral } from './dataTypes';
+import type { AnyData, LooseTypeLiteral, TgpuUnstruct } from './dataTypes';
 import {
   getCustomSize,
-  isLooseArray,
+  isDisarray,
   isLooseDecorated,
-  isLooseStruct,
+  isUnstruct,
 } from './dataTypes';
 import type { BaseWgslData, WgslStruct, WgslTypeLiteral } from './wgslTypes';
 import { isDecorated, isWgslArray, isWgslStruct } from './wgslTypes';
@@ -92,7 +92,7 @@ function sizeOfStruct(struct: WgslStruct) {
   return roundUp(size, alignmentOf(struct));
 }
 
-function sizeOfLooseStruct(data: LooseStruct) {
+function sizeOfUnstruct(data: TgpuUnstruct) {
   let size = 0;
 
   for (const property of Object.values(data.propTypes)) {
@@ -115,8 +115,8 @@ function computeSize(data: object): number {
     return sizeOfStruct(data);
   }
 
-  if (isLooseStruct(data)) {
-    return sizeOfLooseStruct(data);
+  if (isUnstruct(data)) {
+    return sizeOfUnstruct(data);
   }
 
   if (isWgslArray(data)) {
@@ -129,7 +129,7 @@ function computeSize(data: object): number {
     return stride * data.elementCount;
   }
 
-  if (isLooseArray(data)) {
+  if (isDisarray(data)) {
     const alignment = customAlignmentOf(data.elementType);
     const stride = roundUp(sizeOf(data.elementType), alignment);
     return stride * data.elementCount;

--- a/packages/typegpu/src/data/struct.ts
+++ b/packages/typegpu/src/data/struct.ts
@@ -23,7 +23,7 @@ export interface TgpuStruct<TProps extends Record<string, BaseWgslData>>
 
 /**
  * Creates a struct schema that can be used to construct GPU buffers.
- * Ensures proper alignment and padding of properties (as opposed to a `d.looseStruct` schema).
+ * Ensures proper alignment and padding of properties (as opposed to a `d.unstruct` schema).
  * The order of members matches the passed in properties object.
  *
  * @example

--- a/packages/typegpu/src/data/unstruct.ts
+++ b/packages/typegpu/src/data/unstruct.ts
@@ -1,5 +1,5 @@
 import type { InferRecord } from '../shared/repr';
-import type { LooseStruct } from './dataTypes';
+import type { TgpuUnstruct } from './dataTypes';
 import type { ExoticRecord } from './exotic';
 import type { BaseWgslData } from './wgslTypes';
 
@@ -17,27 +17,27 @@ import type { BaseWgslData } from './wgslTypes';
  * via `d.align` function.
  *
  * @example
- * const CircleStruct = d.looseStruct({ radius: d.f32, pos: d.vec3f }); // packed struct with no padding
+ * const CircleStruct = d.unstruct({ radius: d.f32, pos: d.vec3f }); // packed struct with no padding
  *
  * @example
- * const CircleStruct = d.looseStruct({ radius: d.f32, pos: d.align(16, d.vec3f) });
+ * const CircleStruct = d.unstruct({ radius: d.f32, pos: d.align(16, d.vec3f) });
  *
  * @param properties Record with `string` keys and `TgpuData` or `TgpuLooseData` values,
  * each entry describing one struct member.
  */
-export const looseStruct = <TProps extends Record<string, BaseWgslData>>(
+export const unstruct = <TProps extends Record<string, BaseWgslData>>(
   properties: TProps,
-): LooseStruct<ExoticRecord<TProps>> =>
-  new LooseStructImpl(properties as ExoticRecord<TProps>);
+): TgpuUnstruct<ExoticRecord<TProps>> =>
+  new TgpuUnstructImpl(properties as ExoticRecord<TProps>);
 
 // --------------
 // Implementation
 // --------------
 
-class LooseStructImpl<TProps extends Record<string, BaseWgslData>>
-  implements LooseStruct<TProps>
+class TgpuUnstructImpl<TProps extends Record<string, BaseWgslData>>
+  implements TgpuUnstruct<TProps>
 {
-  public readonly type = 'loose-struct';
+  public readonly type = 'unstruct';
   /** Type-token, not available at runtime */
   public readonly '~repr'!: InferRecord<TProps>;
 

--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -775,14 +775,14 @@ export function isWgslData(value: unknown): value is AnyWgslData {
 
 /**
  * Checks whether passed in value is an array schema,
- * as opposed to, e.g., a looseArray schema.
+ * as opposed to, e.g., a disarray schema.
  *
  * Array schemas can be used to describe uniform and storage buffers,
- * whereas looseArray schemas cannot.
+ * whereas disarray schemas cannot.
  *
  * @example
  * isWgslArray(d.arrayOf(d.u32, 4)) // true
- * isWgslArray(d.looseArrayOf(d.u32, 4)) // false
+ * isWgslArray(d.disarray(d.u32, 4)) // false
  * isWgslArray(d.vec3f) // false
  */
 export function isWgslArray<T extends WgslArray>(
@@ -793,14 +793,14 @@ export function isWgslArray<T extends WgslArray>(
 
 /**
  * Checks whether passed in value is a struct schema,
- * as opposed to, e.g., a looseStruct schema.
+ * as opposed to, e.g., an unstruct schema.
  *
  * Struct schemas can be used to describe uniform and storage buffers,
- * whereas looseStruct schemas cannot.
+ * whereas unstruct schemas cannot.
  *
  * @example
  * isWgslStruct(d.struct({ a: d.u32 })) // true
- * isWgslStruct(d.looseStruct({ a: d.u32 })) // false
+ * isWgslStruct(d.unstruct({ a: d.u32 })) // false
  * isWgslStruct(d.vec3f) // false
  */
 export function isWgslStruct<T extends WgslStruct>(

--- a/packages/typegpu/tests/align.test.ts
+++ b/packages/typegpu/tests/align.test.ts
@@ -1,31 +1,17 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import {
-  type Align,
-  type Decorated,
-  type LooseArray,
-  type LooseDecorated,
-  type Vec3f,
-  type WgslArray,
-  align,
-  arrayOf,
-  f32,
-  isLooseData,
-  looseArrayOf,
-  sizeOf,
-  struct,
-  u32,
-  vec3f,
-} from '../src/data';
+import * as d from '../src/data';
 import { alignmentOf } from '../src/data/alignmentOf';
 import tgpu from '../src/experimental';
 
 describe('d.align', () => {
   it('adds @align attribute for custom aligned struct members', () => {
-    const s1 = struct({
-      a: u32,
-      b: align(16, u32),
-      c: u32,
-    }).$name('s1');
+    const s1 = d
+      .struct({
+        a: d.u32,
+        b: d.align(16, d.u32),
+        c: d.u32,
+      })
+      .$name('s1');
 
     expect(tgpu.resolve({ input: s1, names: 'strict' })).toContain(
       '@align(16) b: u32,',
@@ -35,20 +21,20 @@ describe('d.align', () => {
   it('changes alignment of a struct containing aligned member', () => {
     expect(
       alignmentOf(
-        struct({
-          a: u32,
-          b: u32,
-          c: u32,
+        d.struct({
+          a: d.u32,
+          b: d.u32,
+          c: d.u32,
         }),
       ),
     ).toEqual(4);
 
     expect(
       alignmentOf(
-        struct({
-          a: u32,
-          b: align(16, u32),
-          c: u32,
+        d.struct({
+          a: d.u32,
+          b: d.align(16, d.u32),
+          c: d.u32,
         }),
       ),
     ).toEqual(16);
@@ -56,57 +42,57 @@ describe('d.align', () => {
 
   it('changes size of a struct containing aligned member', () => {
     expect(
-      sizeOf(
-        struct({
-          a: u32,
-          b: u32,
-          c: u32,
+      d.sizeOf(
+        d.struct({
+          a: d.u32,
+          b: d.u32,
+          c: d.u32,
         }),
       ),
     ).toEqual(12);
 
     expect(
-      sizeOf(
-        struct({
-          a: u32,
-          b: align(16, u32),
-          c: u32,
+      d.sizeOf(
+        d.struct({
+          a: d.u32,
+          b: d.align(16, d.u32),
+          c: d.u32,
         }),
       ),
     ).toEqual(32);
 
     expect(
-      sizeOf(
-        struct({
-          a: u32,
-          b: align(16, u32),
-          c: align(16, u32),
+      d.sizeOf(
+        d.struct({
+          a: d.u32,
+          b: d.align(16, d.u32),
+          c: d.align(16, d.u32),
         }),
       ),
     ).toEqual(48);
 
     // nested
     expect(
-      sizeOf(
-        struct({
-          a: u32,
-          b: struct({
-            c: f32,
-            d: align(16, f32),
+      d.sizeOf(
+        d.struct({
+          a: d.u32,
+          b: d.struct({
+            c: d.f32,
+            d: d.align(16, d.f32),
           }),
         }),
       ),
     ).toEqual(48);
 
     expect(
-      sizeOf(
-        struct({
-          a: u32,
-          b: align(
+      d.sizeOf(
+        d.struct({
+          a: d.u32,
+          b: d.align(
             32,
-            struct({
-              c: f32,
-              d: align(16, f32),
+            d.struct({
+              c: d.f32,
+              d: d.align(16, d.f32),
             }),
           ),
         }),
@@ -115,42 +101,42 @@ describe('d.align', () => {
   });
 
   it('throws for invalid align values', () => {
-    expect(() => align(11, u32)).toThrow();
-    expect(() => align(8, vec3f)).toThrow();
-    expect(() => align(-2, u32)).toThrow();
+    expect(() => d.align(11, d.u32)).toThrow();
+    expect(() => d.align(8, d.vec3f)).toThrow();
+    expect(() => d.align(-2, d.u32)).toThrow();
   });
 
   it('allows aligning loose data without losing the looseness information', () => {
-    const array = arrayOf(vec3f, 2);
-    const alignedArray = align(16, array);
+    const array = d.arrayOf(d.vec3f, 2);
+    const alignedArray = d.align(16, array);
 
-    const looseArray = looseArrayOf(vec3f, 2);
-    const alignedLooseArray = align(16, looseArray);
+    const disarray = d.disarrayOf(d.vec3f, 2);
+    const alignedDisarray = d.align(16, disarray);
 
     expectTypeOf(alignedArray).toEqualTypeOf<
-      Decorated<WgslArray<Vec3f>, [Align<16>]>
+      d.Decorated<d.WgslArray<d.Vec3f>, [d.Align<16>]>
     >();
-    expect(isLooseData(alignedArray)).toEqual(false);
+    expect(d.isLooseData(alignedArray)).toEqual(false);
 
-    expectTypeOf(alignedLooseArray).toEqualTypeOf<
-      LooseDecorated<LooseArray<Vec3f>, [Align<16>]>
+    expectTypeOf(alignedDisarray).toEqualTypeOf<
+      d.LooseDecorated<d.TgpuDisarray<d.Vec3f>, [d.Align<16>]>
     >();
-    expect(isLooseData(alignedLooseArray)).toEqual(true);
+    expect(d.isLooseData(alignedDisarray)).toEqual(true);
   });
 
   it('does not allow aligned loose data as non-loose struct members', () => {
-    const array = arrayOf(u32, 2);
-    const alignedArray = align(16, array);
+    const array = d.arrayOf(d.u32, 2);
+    const alignedArray = d.align(16, array);
 
-    const looseArray = looseArrayOf(u32, 2);
-    const alignedLooseArray = align(16, looseArray);
+    const disarray = d.disarrayOf(d.u32, 2);
+    const alignedDisarray = d.align(16, disarray);
 
-    struct({
+    d.struct({
       // @ts-expect-error
-      a: alignedLooseArray,
+      a: alignedDisarray,
     });
 
-    struct({
+    d.struct({
       a: alignedArray,
     });
   });

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -176,7 +176,7 @@ describe('TgpuBuffer', () => {
   it('should restrict the usage to Vertex given loose data', ({ root }) => {
     expect(() => {
       const buffer = root
-        .createBuffer(d.looseStruct({ a: d.unorm16x2, b: d.snorm8x2 }))
+        .createBuffer(d.unstruct({ a: d.unorm16x2, b: d.snorm8x2 }))
         // @ts-expect-error
         .$usage('storage');
     }).toThrow();

--- a/packages/typegpu/tests/disarray.test.ts
+++ b/packages/typegpu/tests/disarray.test.ts
@@ -1,55 +1,47 @@
 import { BufferReader, BufferWriter } from 'typed-binary';
 import { describe, expect } from 'vitest';
-import {
-  type Infer,
-  align,
-  looseArrayOf,
-  size,
-  sizeOf,
-  vec3f,
-  vec3u,
-} from '../src/data';
+import * as d from '../src/data';
 import { readData, writeData } from '../src/data/dataIO';
 import { it } from './utils/extendedIt';
 
-describe('loose', () => {
+describe('disarray', () => {
   it('does not take element alignment into account when measuring', () => {
-    const TestArray = looseArrayOf(vec3u, 3);
-    expect(sizeOf(TestArray)).toEqual(36);
+    const TestArray = d.disarrayOf(d.vec3u, 3);
+    expect(d.sizeOf(TestArray)).toEqual(36);
   });
 
   it('takes element alignment into account when measuring with custom aligned elements', () => {
-    const TestArray = looseArrayOf(align(16, vec3u), 3);
-    expect(sizeOf(TestArray)).toEqual(48);
+    const TestArray = d.disarrayOf(d.align(16, d.vec3u), 3);
+    expect(d.sizeOf(TestArray)).toEqual(48);
   });
 
   it('properly handles calculating nested loose array size', () => {
-    const TestArray = looseArrayOf(looseArrayOf(vec3u, 3), 3);
-    expect(sizeOf(TestArray)).toEqual(108);
+    const TestArray = d.disarrayOf(d.disarrayOf(d.vec3u, 3), 3);
+    expect(d.sizeOf(TestArray)).toEqual(108);
   });
 
   it('does not align array elements when writing', () => {
-    const TestArray = looseArrayOf(vec3u, 3);
-    const buffer = new ArrayBuffer(sizeOf(TestArray));
+    const TestArray = d.disarrayOf(d.vec3u, 3);
+    const buffer = new ArrayBuffer(d.sizeOf(TestArray));
     const writer = new BufferWriter(buffer);
 
     writeData(writer, TestArray, [
-      vec3u(1, 2, 3),
-      vec3u(4, 5, 6),
-      vec3u(7, 8, 9),
+      d.vec3u(1, 2, 3),
+      d.vec3u(4, 5, 6),
+      d.vec3u(7, 8, 9),
     ]);
     expect([...new Uint32Array(buffer)]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
   });
 
   it('aligns array elements when writing with custom aligned elements', () => {
-    const TestArray = looseArrayOf(align(16, vec3u), 3);
-    const buffer = new ArrayBuffer(sizeOf(TestArray));
+    const TestArray = d.disarrayOf(d.align(16, d.vec3u), 3);
+    const buffer = new ArrayBuffer(d.sizeOf(TestArray));
     const writer = new BufferWriter(buffer);
 
     writeData(writer, TestArray, [
-      vec3u(1, 2, 3),
-      vec3u(4, 5, 6),
-      vec3u(7, 8, 9),
+      d.vec3u(1, 2, 3),
+      d.vec3u(4, 5, 6),
+      d.vec3u(7, 8, 9),
     ]);
     expect([...new Uint32Array(buffer)]).toEqual([
       1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0,
@@ -57,58 +49,58 @@ describe('loose', () => {
   });
 
   it('does not align array elements when reading', () => {
-    const TestArray = looseArrayOf(vec3u, 3);
-    const buffer = new ArrayBuffer(sizeOf(TestArray));
+    const TestArray = d.disarrayOf(d.vec3u, 3);
+    const buffer = new ArrayBuffer(d.sizeOf(TestArray));
     const reader = new BufferReader(buffer);
 
     new Uint32Array(buffer).set([1, 2, 3, 0, 4, 5, 6, 0, 7]);
 
     expect(readData(reader, TestArray)).toEqual([
-      vec3u(1, 2, 3),
-      vec3u(0, 4, 5),
-      vec3u(6, 0, 7),
+      d.vec3u(1, 2, 3),
+      d.vec3u(0, 4, 5),
+      d.vec3u(6, 0, 7),
     ]);
   });
 
   it('aligns array elements when reading with custom aligned elements', () => {
-    const TestArray = looseArrayOf(align(16, vec3u), 3);
-    const buffer = new ArrayBuffer(sizeOf(TestArray));
+    const TestArray = d.disarrayOf(d.align(16, d.vec3u), 3);
+    const buffer = new ArrayBuffer(d.sizeOf(TestArray));
     const reader = new BufferReader(buffer);
 
     new Uint32Array(buffer).set([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0]);
 
     expect(readData(reader, TestArray)).toEqual([
-      vec3u(1, 2, 3),
-      vec3u(4, 5, 6),
-      vec3u(7, 8, 9),
+      d.vec3u(1, 2, 3),
+      d.vec3u(4, 5, 6),
+      d.vec3u(7, 8, 9),
     ]);
   });
 
   it('aligns array elements when reading with custom aligned elements and other attributes', () => {
-    const TestArray = looseArrayOf(size(12, align(16, vec3u)), 3);
-    const buffer = new ArrayBuffer(sizeOf(TestArray));
+    const TestArray = d.disarrayOf(d.size(12, d.align(16, d.vec3u)), 3);
+    const buffer = new ArrayBuffer(d.sizeOf(TestArray));
     const reader = new BufferReader(buffer);
 
     new Uint32Array(buffer).set([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0]);
 
     expect(readData(reader, TestArray)).toEqual([
-      vec3u(1, 2, 3),
-      vec3u(4, 5, 6),
-      vec3u(7, 8, 9),
+      d.vec3u(1, 2, 3),
+      d.vec3u(4, 5, 6),
+      d.vec3u(7, 8, 9),
     ]);
   });
 
   it('encodes and decodes arrays properly', () => {
-    const TestArray = looseArrayOf(vec3f, 5);
+    const TestArray = d.disarrayOf(d.vec3f, 5);
 
-    const buffer = new ArrayBuffer(sizeOf(TestArray));
+    const buffer = new ArrayBuffer(d.sizeOf(TestArray));
 
-    const value: Infer<typeof TestArray> = [
-      vec3f(1.5, 2, 3.5),
-      vec3f(),
-      vec3f(-1.5, 2, 3.5),
-      vec3f(1.5, -2, 3.5),
-      vec3f(1.5, 2, 15),
+    const value: d.Infer<typeof TestArray> = [
+      d.vec3f(1.5, 2, 3.5),
+      d.vec3f(),
+      d.vec3f(-1.5, 2, 3.5),
+      d.vec3f(1.5, -2, 3.5),
+      d.vec3f(1.5, 2, 15),
     ];
 
     writeData(new BufferWriter(buffer), TestArray, value);

--- a/packages/typegpu/tests/size.test.ts
+++ b/packages/typegpu/tests/size.test.ts
@@ -87,26 +87,26 @@ describe('d.size', () => {
   });
 
   it('changes size of loose array element', () => {
-    const s1 = d.looseArrayOf(d.size(11, d.u32), 10);
+    const s1 = d.disarrayOf(d.size(11, d.u32), 10);
 
     expect(d.sizeOf(s1)).toEqual(110);
     expectTypeOf(s1).toEqualTypeOf<
-      d.LooseArray<d.Decorated<d.U32, [d.Size<11>]>>
+      d.TgpuDisarray<d.Decorated<d.U32, [d.Size<11>]>>
     >();
   });
 
   it('changes size of loose struct member of type loose array', () => {
-    const s1 = d.looseStruct({
+    const s1 = d.unstruct({
       a: d.u32, // 4
-      b: d.size(20, d.looseArrayOf(d.u32, 4)), // 20
+      b: d.size(20, d.disarrayOf(d.u32, 4)), // 20
       c: d.u32, // 4
     });
 
     expect(d.sizeOf(s1)).toEqual(28);
     expectTypeOf(s1).toEqualTypeOf<
-      d.LooseStruct<{
+      d.TgpuUnstruct<{
         a: d.U32;
-        b: d.LooseDecorated<d.LooseArray<d.U32>, [d.Size<20>]>;
+        b: d.LooseDecorated<d.TgpuDisarray<d.U32>, [d.Size<20>]>;
         c: d.U32;
       }>
     >();

--- a/packages/typegpu/tests/unstruct.test.ts
+++ b/packages/typegpu/tests/unstruct.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest';
 import * as d from '../src/data';
 import { readData, writeData } from '../src/data/dataIO';
 
-describe('d.looseStruct', () => {
+describe('d.unstruct', () => {
   it('properly calculates size with only loose members', () => {
-    const s = d.looseStruct({
+    const s = d.unstruct({
       a: d.unorm8x2, // 1 byte * 2 = 2
       b: d.sint16x2, // 2 bytes * 2 = 4
       c: d.float32x3, // 4 bytes * 3 = 12
@@ -13,14 +13,14 @@ describe('d.looseStruct', () => {
     });
     expect(d.sizeOf(s)).toEqual(18);
 
-    const s2 = d.looseStruct({
+    const s2 = d.unstruct({
       a: d.unorm10_10_10_2, // 4 bytes
       b: d.sint16x4, // 2 bytes * 4 = 8
       // Total: 4 + 8 = 12
     });
     expect(d.sizeOf(s2)).toEqual(12);
 
-    const s3 = d.looseStruct({
+    const s3 = d.unstruct({
       a: d.vec2f, // 8 bytes
       b: d.vec3u, // 12 bytes
       // Total: 8 + 12 = 20
@@ -29,7 +29,7 @@ describe('d.looseStruct', () => {
   });
 
   it('properly calculates size with only aligned members', () => {
-    const s = d.looseStruct({
+    const s = d.unstruct({
       a: d.align(16, d.unorm8x2), // 2 bytes
       b: d.align(16, d.sint16x2), // 14 padding bytes + 4 bytes = 18
       c: d.align(16, d.float32x3), // 12 padding bytes + 12 bytes = 24
@@ -37,7 +37,7 @@ describe('d.looseStruct', () => {
     });
     expect(d.sizeOf(s)).toEqual(44);
 
-    const s2 = d.looseStruct({
+    const s2 = d.unstruct({
       a: d.align(16, d.unorm10_10_10_2), // 4 bytes
       b: d.align(16, d.sint16x4), // 12 padding bytes + 8 bytes = 20
       c: d.align(16, d.vec3f), // 8 padding bytes + 12 bytes = 20
@@ -47,7 +47,7 @@ describe('d.looseStruct', () => {
   });
 
   it('properly calculates size with mixed members', () => {
-    const s = d.looseStruct({
+    const s = d.unstruct({
       a: d.unorm8x2, // 2 bytes
       b: d.align(16, d.sint16x2), // 14 padding bytes + 4 bytes = 18
       c: d.float32x3, // 12 bytes
@@ -55,7 +55,7 @@ describe('d.looseStruct', () => {
     });
     expect(d.sizeOf(s)).toEqual(32);
 
-    const s2 = d.looseStruct({
+    const s2 = d.unstruct({
       a: d.align(16, d.unorm10_10_10_2), // 4 bytes
       b: d.sint16x4, // 8 bytes
       c: d.vec3f, // 12 bytes
@@ -63,7 +63,7 @@ describe('d.looseStruct', () => {
     });
     expect(d.sizeOf(s2)).toEqual(24);
 
-    const s3 = d.looseStruct({
+    const s3 = d.unstruct({
       a: d.vec2f, // 8 bytes
       b: d.align(16, d.vec3u), // 8 padding bytes + 12 bytes = 20
       c: d.unorm10_10_10_2, // 4 bytes
@@ -72,31 +72,31 @@ describe('d.looseStruct', () => {
     expect(d.sizeOf(s3)).toEqual(32);
   });
 
-  it('properly calculates size when nested and combined with d.looseArrayOf', () => {
-    const s = d.looseStruct({
+  it('properly calculates size when nested and combined with d.disarray', () => {
+    const s = d.unstruct({
       a: d.unorm8x2, // 2 bytes
       b: d.align(16, d.sint16x2), // 14 padding bytes + 4 bytes = 18
-      c: d.looseArrayOf(d.vec3f, 2), // 12 bytes * 2 = 24
+      c: d.disarrayOf(d.vec3f, 2), // 12 bytes * 2 = 24
       // Total: 2 + 18 + 24 = 44
     });
     expect(d.sizeOf(s)).toEqual(44);
 
-    const s2 = d.looseStruct({
+    const s2 = d.unstruct({
       a: d.align(16, d.unorm10_10_10_2), // 4 bytes
       b: d.sint16x4, // 8 bytes
-      c: d.looseArrayOf(d.vec3f, 2), // 12 bytes * 2 = 24
+      c: d.disarrayOf(d.vec3f, 2), // 12 bytes * 2 = 24
       // Total: 4 + 8 + 24 = 36
     });
     expect(d.sizeOf(s2)).toEqual(36);
 
-    const s3 = d.looseStruct({
+    const s3 = d.unstruct({
       a: d.vec2f, // 8 bytes
       b: d.align(16, d.vec3u), // 8 padding bytes + 12 bytes = 20
       // Total: 8 + 20 = 28
     });
     expect(d.sizeOf(s3)).toEqual(28);
 
-    const s4 = d.looseStruct({
+    const s4 = d.unstruct({
       a: d.vec2f, // 8 bytes
       b: d.align(16, d.vec3u), // 8 padding bytes + 12 bytes = 20
       c: s2, // 4 padding bytes + 36 bytes = 40
@@ -106,7 +106,7 @@ describe('d.looseStruct', () => {
   });
 
   it('properly writes and reads data', () => {
-    const s = d.looseStruct({
+    const s = d.unstruct({
       a: d.unorm8x2,
       b: d.align(16, d.snorm16x2),
       c: d.float32x3,
@@ -134,10 +134,10 @@ describe('d.looseStruct', () => {
   });
 
   it('properly writes and reads data with nested structs', () => {
-    const s = d.looseStruct({
+    const s = d.unstruct({
       a: d.unorm8x2,
       b: d.align(16, d.snorm16x2),
-      c: d.looseStruct({
+      c: d.unstruct({
         a: d.float32x3,
         b: d.vec2i,
       }),
@@ -172,13 +172,13 @@ describe('d.looseStruct', () => {
   it('can be custom aligned and behaves properly', () => {
     const s = d.align(
       16,
-      d.looseStruct({
+      d.unstruct({
         a: d.unorm8x2, // 2 bytes
         b: d.align(8, d.snorm16x2), // 6 padding bytes + 4 bytes = 10
       }),
     );
 
-    const a = d.looseArrayOf(s, 8);
+    const a = d.disarrayOf(s, 8);
 
     expect(d.sizeOf(s)).toEqual(12);
     // since the struct is aligned to 16 bytes, the array stride should be 16 not 12
@@ -206,7 +206,7 @@ describe('d.looseStruct', () => {
   });
 
   it('works properly in conjunction with f16 based attributes', () => {
-    const s = d.looseStruct({
+    const s = d.unstruct({
       a: d.float16x2,
       b: d.unorm8x4_bgra,
       c: d.align(16, d.snorm16x2),

--- a/packages/typegpu/tests/vertexLayout.test.ts
+++ b/packages/typegpu/tests/vertexLayout.test.ts
@@ -7,13 +7,13 @@ import type { TgpuVertexAttrib } from '../src/shared/vertexFormat';
 
 describe('ArrayToContainedAttribs', () => {
   it('processes a loose array of uint8x2', () => {
-    type Result = ArrayToContainedAttribs<d.LooseArray<d.uint8x2>>;
+    type Result = ArrayToContainedAttribs<d.TgpuDisarray<d.uint8x2>>;
 
     expectTypeOf<Result>().toEqualTypeOf<TgpuVertexAttrib<'uint8x2'>>();
   });
 
   it('processes a loose array of unorm10-10-10-2', () => {
-    type Result = ArrayToContainedAttribs<d.LooseArray<d.unorm10_10_10_2>>;
+    type Result = ArrayToContainedAttribs<d.TgpuDisarray<d.unorm10_10_10_2>>;
 
     expectTypeOf<Result>().toEqualTypeOf<TgpuVertexAttrib<'unorm10-10-10-2'>>();
   });
@@ -25,14 +25,14 @@ describe('ArrayToContainedAttribs', () => {
   });
 
   it('processes a loose array of f32s', () => {
-    type Result = ArrayToContainedAttribs<d.LooseArray<d.F32>>;
+    type Result = ArrayToContainedAttribs<d.TgpuDisarray<d.F32>>;
 
     expectTypeOf<Result>().toEqualTypeOf<TgpuVertexAttrib<'float32'>>();
   });
 
   it('processes a loose array of structs', () => {
     type Result = ArrayToContainedAttribs<
-      d.LooseArray<d.WgslStruct<{ a: d.F32; b: d.F32 }>>
+      d.TgpuDisarray<d.WgslStruct<{ a: d.F32; b: d.F32 }>>
     >;
 
     expectTypeOf<Result>().toEqualTypeOf<{
@@ -43,7 +43,7 @@ describe('ArrayToContainedAttribs', () => {
 
   it('processes a loose array of loose struct', () => {
     type Result = ArrayToContainedAttribs<
-      d.LooseArray<d.LooseStruct<{ a: d.F32; b: d.F32 }>>
+      d.TgpuDisarray<d.TgpuUnstruct<{ a: d.F32; b: d.F32 }>>
     >;
 
     expectTypeOf<Result>().toEqualTypeOf<{
@@ -54,7 +54,7 @@ describe('ArrayToContainedAttribs', () => {
 
   it('processes an array of structs', () => {
     type Result = ArrayToContainedAttribs<
-      d.LooseArray<d.LooseStruct<{ a: d.F32; b: d.F32 }>>
+      d.TgpuDisarray<d.TgpuUnstruct<{ a: d.F32; b: d.F32 }>>
     >;
 
     expectTypeOf<Result>().toEqualTypeOf<{
@@ -70,7 +70,7 @@ describe('ArrayToContainedAttribs', () => {
   });
 
   it('processes a loose array of snorm16x2', () => {
-    type Result = ArrayToContainedAttribs<d.LooseArray<d.snorm16x2>>;
+    type Result = ArrayToContainedAttribs<d.TgpuDisarray<d.snorm16x2>>;
 
     expectTypeOf<Result>().toEqualTypeOf<TgpuVertexAttrib<'snorm16x2'>>();
   });
@@ -79,7 +79,7 @@ describe('ArrayToContainedAttribs', () => {
 describe('tgpu.vertexLayout', () => {
   it('creates attributes from loose array of vec3f', () => {
     const vertexLayout = tgpu.vertexLayout((count: number) =>
-      d.looseArrayOf(d.vec3f, count),
+      d.disarrayOf(d.vec3f, count),
     );
 
     expect(vertexLayout.stride).toEqual(12);
@@ -98,7 +98,7 @@ describe('tgpu.vertexLayout', () => {
     });
 
     const vertexLayout = tgpu.vertexLayout((count: number) =>
-      d.looseArrayOf(VertexData, count),
+      d.disarrayOf(VertexData, count),
     );
 
     expect(vertexLayout.stride).toEqual(32);
@@ -122,14 +122,14 @@ describe('tgpu.vertexLayout', () => {
   });
 
   it('creates attributes from loose array of loose structs', () => {
-    const VertexData = d.looseStruct({
+    const VertexData = d.unstruct({
       a: d.u32, // +4
       b: d.vec3f, // + 12
       c: d.f32, // + 4
     });
 
     const vertexLayout = tgpu.vertexLayout((count: number) =>
-      d.looseArrayOf(VertexData, count),
+      d.disarrayOf(VertexData, count),
     );
 
     expect(vertexLayout.stride).toEqual(20);
@@ -154,7 +154,7 @@ describe('tgpu.vertexLayout', () => {
 
   it('creates attributes from loose array with f16 variants', () => {
     const vertexLayout = tgpu.vertexLayout((count: number) =>
-      d.looseArrayOf(d.float16x4, count),
+      d.disarrayOf(d.float16x4, count),
     );
 
     expect(vertexLayout.stride).toEqual(8);
@@ -192,7 +192,7 @@ describe('connectAttributesToShader', () => {
 
   it('connects a single vec4f attribute (with custom shader location)', () => {
     const shaderInputLayout = d.location(3, d.vec4f);
-    const layout = tgpu.vertexLayout((n) => d.looseArrayOf(d.unorm16x4, n));
+    const layout = tgpu.vertexLayout((n) => d.disarrayOf(d.unorm16x4, n));
     const attrib = layout.attrib;
 
     expect(connectAttributesToShader(shaderInputLayout, attrib)).toEqual({
@@ -221,8 +221,8 @@ describe('connectAttributesToShader', () => {
     };
 
     const layout = tgpu.vertexLayout((n) =>
-      d.looseArrayOf(
-        d.looseStruct({
+      d.disarrayOf(
+        d.unstruct({
           alpha: d.f32, // 4 bytes
           beta: d.unorm8x2, // 2 bytes
           gamma: d.u32, // 4 bytes
@@ -275,8 +275,8 @@ describe('connectAttributesToShader', () => {
     };
 
     const alphaBetaLayout = tgpu.vertexLayout((n) =>
-      d.looseArrayOf(
-        d.looseStruct({
+      d.disarrayOf(
+        d.unstruct({
           alpha: d.f32, // 4 bytes
           beta: d.unorm8x2, // 2 bytes
         }),
@@ -329,7 +329,7 @@ describe('connectAttributesToShader', () => {
 
   it('connects a single vec4h attribute', () => {
     const shaderInputLayout = d.vec4h;
-    const layout = tgpu.vertexLayout((n) => d.looseArrayOf(d.float16x4, n));
+    const layout = tgpu.vertexLayout((n) => d.disarrayOf(d.float16x4, n));
     const attrib = layout.attrib;
 
     expect(connectAttributesToShader(shaderInputLayout, attrib)).toEqual({
@@ -359,8 +359,8 @@ describe('connectAttributesToShader', () => {
     };
 
     const layout = tgpu.vertexLayout((n) =>
-      d.looseArrayOf(
-        d.looseStruct({
+      d.disarrayOf(
+        d.unstruct({
           alpha: d.f16, // 2 bytes
           beta: d.float16x2, // 4 bytes
           gamma: d.u32, // 4 bytes
@@ -412,8 +412,6 @@ describe('connectAttributesToShader', () => {
   });
 
   it('throws when trying to use type that has no attribute representation', () => {
-    expect(() =>
-      tgpu.vertexLayout((n) => d.looseArrayOf(d.vec3h, n)),
-    ).toThrow();
+    expect(() => tgpu.vertexLayout((n) => d.disarrayOf(d.vec3h, n))).toThrow();
   });
 });


### PR DESCRIPTION
closes #716 

>[!note]
>The name "loose" prevails as the name for the union of disarray and unstruct types (UnOrDis doesn't work)