### PR TITLE
Add @interpolate attribute

### DIFF
--- a/packages/typegpu/src/data/attributes.ts
+++ b/packages/typegpu/src/data/attributes.ts
@@ -16,7 +16,13 @@ import {
   type BaseWgslData,
   type Builtin,
   type Decorated,
+  type FlatInterpolatableData,
+  type FlatInterpolationType,
+  type Interpolate,
+  type InterpolationType,
   type Location,
+  type PerspectiveOrLinearInterpolatableData,
+  type PerspectiveOrLinearInterpolationType,
   type Size,
   type WgslTypeLiteral,
   isAlignAttrib,
@@ -53,7 +59,8 @@ export type AnyAttribute =
   | Align<number>
   | Size<number>
   | Location<number>
-  | Builtin<BuiltinName>;
+  | Builtin<BuiltinName>
+  | Interpolate<InterpolationType>;
 
 export type ExtractAttributes<T> = T extends {
   readonly attribs: unknown[];
@@ -184,6 +191,68 @@ export function location<TLocation extends number, TData extends AnyData>(
 ): Decorate<Exotic<TData>, Location<TLocation>> {
   // biome-ignore lint/suspicious/noExplicitAny: <tired of lying to types>
   return attribute(data, { type: '@location', value: location }) as any;
+}
+
+/**
+ * Specifies how user-defined vertex shader output (fragment shader input)
+ * must be interpolated.
+ *
+ * Tip: Integer outputs cannot be interpolated.
+ *
+ * @example
+ * const Data = d.ioStruct({
+ *   a: d.f32, // has implicit 'perspective, center' interpolation
+ *   b: d.interpolate('linear, sample', d.f32),
+ * });
+ *
+ * @param location The explicit numeric location.
+ * @param data The data-type to wrap.
+ */
+export function interpolate<
+  TInterpolation extends PerspectiveOrLinearInterpolationType,
+  TData extends PerspectiveOrLinearInterpolatableData,
+>(
+  interpolationType: TInterpolation,
+  data: TData,
+): Decorate<Exotic<TData>, Interpolate<TInterpolation>>;
+
+/**
+ * Specifies how user-defined vertex shader output (fragment shader input)
+ * must be interpolated.
+ *
+ * Tip: Default sampling method of `flat` is `first`. Unless you specifically
+ * need deterministic behavior provided by `'flat, first'`, prefer explicit
+ * `'flat, either'` as it could be slightly faster in hardware.
+ *
+ * @example
+ * const Data = d.ioStruct({
+ *   a: d.f32, // has implicit 'perspective, center' interpolation
+ *   b: d.interpolate('flat, either', d.u32), // integer outputs cannot interpolate
+ * });
+ *
+ * @param location The explicit numeric location.
+ * @param data The data-type to wrap.
+ */
+export function interpolate<
+  TInterpolation extends FlatInterpolationType,
+  TData extends FlatInterpolatableData,
+>(
+  interpolationType: TInterpolation,
+  data: TData,
+): Decorate<Exotic<TData>, Interpolate<TInterpolation>>;
+
+export function interpolate<
+  TInterpolation extends InterpolationType,
+  TData extends AnyData,
+>(
+  interpolationType: TInterpolation,
+  data: TData,
+): Decorate<Exotic<TData>, Interpolate<TInterpolation>> {
+  return attribute(data, {
+    type: '@interpolate',
+    value: interpolationType,
+    // biome-ignore lint/suspicious/noExplicitAny: <tired of lying to types>
+  }) as any;
 }
 
 export function isBuiltin<

--- a/packages/typegpu/src/data/attributes.ts
+++ b/packages/typegpu/src/data/attributes.ts
@@ -176,11 +176,11 @@ export function size<TSize extends number, TData extends AnyData>(
  * Assigns an explicit numeric location to a struct member or a parameter that has this type.
  *
  * @example
- * const Data = d.struct({
+ * const VertexOutput = {
  *   a: d.u32, // has implicit location 0
  *   b: d.location(5, d.u32),
  *   c: d.u32, // has implicit location 6
- * });
+ * };
  *
  * @param location The explicit numeric location.
  * @param data The data-type to wrap.

--- a/packages/typegpu/src/data/attributes.ts
+++ b/packages/typegpu/src/data/attributes.ts
@@ -176,7 +176,7 @@ export function size<TSize extends number, TData extends AnyData>(
  * Assigns an explicit numeric location to a struct member or a parameter that has this type.
  *
  * @example
- * const Data = d.ioStruct({
+ * const Data = d.struct({
  *   a: d.u32, // has implicit location 0
  *   b: d.location(5, d.u32),
  *   c: d.u32, // has implicit location 6
@@ -200,12 +200,12 @@ export function location<TLocation extends number, TData extends AnyData>(
  * Tip: Integer outputs cannot be interpolated.
  *
  * @example
- * const Data = d.ioStruct({
+ * const VertexOutput = {
  *   a: d.f32, // has implicit 'perspective, center' interpolation
  *   b: d.interpolate('linear, sample', d.f32),
- * });
+ * };
  *
- * @param location The explicit numeric location.
+ * @param interpolationType How data should be interpolated.
  * @param data The data-type to wrap.
  */
 export function interpolate<
@@ -225,12 +225,12 @@ export function interpolate<
  * `'flat, either'` as it could be slightly faster in hardware.
  *
  * @example
- * const Data = d.ioStruct({
+ * const VertexOutput = {
  *   a: d.f32, // has implicit 'perspective, center' interpolation
  *   b: d.interpolate('flat, either', d.u32), // integer outputs cannot interpolate
- * });
+ * };
  *
- * @param location The explicit numeric location.
+ * @param interpolationType How data should be interpolated.
  * @param data The data-type to wrap.
  */
 export function interpolate<

--- a/packages/typegpu/src/data/index.ts
+++ b/packages/typegpu/src/data/index.ts
@@ -12,6 +12,7 @@ export {
   isAlignAttrib,
   isBuiltinAttrib,
   isLocationAttrib,
+  isInterpolateAttrib,
   isSizeAttrib,
 } from './wgslTypes';
 export type {
@@ -101,6 +102,7 @@ export {
   align,
   size,
   location,
+  interpolate,
   isBuiltin,
   AnyAttribute,
   IsBuiltin,

--- a/packages/typegpu/src/data/index.ts
+++ b/packages/typegpu/src/data/index.ts
@@ -45,6 +45,7 @@ export type {
   Align,
   Builtin,
   Location,
+  Interpolate,
   AnyWgslData,
   v2f,
   v2i,

--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -733,6 +733,18 @@ export interface Location<T extends number> {
   readonly value: T;
 }
 
+export type PerspectiveOrLinearInterpolationType =
+  `${'perspective' | 'linear'}${'' | ', center' | ', centroid' | ', sample'}`;
+export type FlatInterpolationType = `flat${'' | ', first' | ', either'}`;
+export type InterpolationType =
+  | PerspectiveOrLinearInterpolationType
+  | FlatInterpolationType;
+
+export interface Interpolate<T extends InterpolationType> {
+  readonly type: '@interpolate';
+  readonly value: T;
+}
+
 export interface Builtin<T extends string> {
   readonly type: '@builtin';
   readonly value: T;
@@ -777,6 +789,27 @@ export const wgslTypeLiterals = [
 ] as const;
 
 export type WgslTypeLiteral = (typeof wgslTypeLiterals)[number];
+
+export type PerspectiveOrLinearInterpolatableData =
+  | F32
+  | F16
+  | Vec2f
+  | Vec2h
+  | Vec3f
+  | Vec3h
+  | Vec4f
+  | Vec4h;
+
+export type FlatInterpolatableData =
+  | PerspectiveOrLinearInterpolatableData
+  | I32
+  | U32
+  | Vec2i
+  | Vec2u
+  | Vec3i
+  | Vec3u
+  | Vec4i
+  | Vec4u;
 
 export type AnyWgslData =
   | Bool
@@ -875,6 +908,12 @@ export function isLocationAttrib<T extends Location<number>>(
   value: unknown | T,
 ): value is T {
   return (value as T)?.type === '@location';
+}
+
+export function isInterpolateAttrib<T extends Interpolate<InterpolationType>>(
+  value: unknown | T,
+): value is T {
+  return (value as T)?.type === '@interpolate';
 }
 
 export function isBuiltinAttrib<T extends Builtin<string>>(

--- a/packages/typegpu/tests/interpolate.test.ts
+++ b/packages/typegpu/tests/interpolate.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import * as d from '../src/data';
+import { StrictNameRegistry } from '../src/experimental';
+import { resolve } from '../src/resolutionCtx';
+
+describe('d.interpolate', () => {
+  it('adds @interpolate (only interpolation type) attribute for struct members', () => {
+    const s1 = d
+      .struct({
+        a: d.u32,
+        b: d.interpolate('flat', d.u32),
+        c: d.u32,
+      })
+      .$name('s1');
+
+    expectTypeOf(s1).toEqualTypeOf<
+      d.TgpuStruct<{
+        a: d.U32;
+        b: d.Decorated<d.U32, [d.Interpolate<'flat'>]>;
+        c: d.U32;
+      }>
+    >();
+
+    const opts = {
+      names: new StrictNameRegistry(),
+    };
+
+    expect(resolve(s1, opts).code).toContain('@interpolate(flat) b: u32,');
+  });
+
+  it('adds @interpolate (with interpolation type and sampling method) attribute for struct members', () => {
+    const s1 = d
+      .struct({
+        a: d.u32,
+        b: d.interpolate('linear, sample', d.f32),
+        c: d.u32,
+      })
+      .$name('s1');
+
+    expectTypeOf(s1).toEqualTypeOf<
+      d.TgpuStruct<{
+        a: d.U32;
+        b: d.Decorated<d.F32, [d.Interpolate<'linear, sample'>]>;
+        c: d.U32;
+      }>
+    >();
+
+    // @ts-expect-error integer values can't interpolate
+    d.interpolate('linear, sample', d.u32);
+    // @ts-expect-error integer values can't interpolate
+    d.interpolate('linear, sample', d.i32);
+
+    const opts = {
+      names: new StrictNameRegistry(),
+    };
+
+    expect(resolve(s1, opts).code).toContain(
+      '@interpolate(linear, sample) b: f32,',
+    );
+  });
+});


### PR DESCRIPTION
I tried making it as typesafe as I can, by preventing usage of `perspective` or `linear` with integer types. We could also not handle this to simplify the code a bit. Let me know what you prefer.

Example usage:
```typescript
const Data = d.struct({
  a: d.f32, // has implicit 'perspective, center' interpolation
  b: d.interpolate('linear, sample', d.f32),
});
```

The only unsafe thing I see potentially is that this attribute [must](https://www.w3.org/TR/WGSL/#interpolate-attr) be defined together with `@location`:
```
Must only be applied to a declaration that has a location attribute applied.
```

I didn't know how to enforce this.

I also considered using `['perspective', 'sample']` approach, but typescript would not narrow down after writing `['perspective', ...]`. Then I considered an object approach, but that just felt too clunky. For me, string approach feels just right.