### PR TITLE
chore: Hide internal resolve API

### DIFF
--- a/packages/typegpu/src/core/buffer/bufferUsage.ts
+++ b/packages/typegpu/src/core/buffer/bufferUsage.ts
@@ -6,7 +6,7 @@ import type { LayoutMembership } from '../../tgpuBindGroupLayout';
 import type {
   BindableBufferUsage,
   ResolutionCtx,
-  TgpuResolvable,
+  SelfResolvable,
 } from '../../types';
 import { type TgpuBuffer, type Uniform, isUsableAsUniform } from './buffer';
 
@@ -15,9 +15,9 @@ import { type TgpuBuffer, type Uniform, isUsableAsUniform } from './buffer';
 // ----------
 
 export interface TgpuBufferUsage<
-  TData extends BaseWgslData,
+  TData extends BaseWgslData = BaseWgslData,
   TUsage extends BindableBufferUsage = BindableBufferUsage,
-> extends TgpuResolvable {
+> {
   readonly resourceType: 'buffer-usage';
   readonly usage: TUsage;
   readonly '~repr': Infer<TData>;
@@ -59,7 +59,7 @@ const usageToVarTemplateMap: Record<BindableBufferUsage, string> = {
 class TgpuFixedBufferImpl<
   TData extends AnyWgslData,
   TUsage extends BindableBufferUsage,
-> implements TgpuBufferUsage<TData, TUsage>
+> implements TgpuBufferUsage<TData, TUsage>, SelfResolvable
 {
   /** Type-token, not available at runtime */
   public readonly '~repr'!: Infer<TData>;
@@ -78,7 +78,7 @@ class TgpuFixedBufferImpl<
     this.buffer.$name(label);
   }
 
-  resolve(ctx: ResolutionCtx): string {
+  '~resolve'(ctx: ResolutionCtx): string {
     const id = ctx.names.makeUnique(this.label);
     const { group, binding } = ctx.allocateFixedEntry(
       this.usage === 'uniform'
@@ -110,7 +110,7 @@ class TgpuFixedBufferImpl<
 export class TgpuLaidOutBufferImpl<
   TData extends BaseWgslData,
   TUsage extends BindableBufferUsage,
-> implements TgpuBufferUsage<TData, TUsage>
+> implements TgpuBufferUsage<TData, TUsage>, SelfResolvable
 {
   /** Type-token, not available at runtime */
   public readonly '~repr'!: Infer<TData>;
@@ -126,7 +126,7 @@ export class TgpuLaidOutBufferImpl<
     return this._membership.key;
   }
 
-  resolve(ctx: ResolutionCtx): string {
+  '~resolve'(ctx: ResolutionCtx): string {
     const id = ctx.names.makeUnique(this.label);
     const group = ctx.allocateLayoutEntry(this._membership.layout);
     const usage = usageToVarTemplateMap[this.usage];

--- a/packages/typegpu/src/core/constant/tgpuConstant.ts
+++ b/packages/typegpu/src/core/constant/tgpuConstant.ts
@@ -2,16 +2,15 @@ import type { AnyWgslData } from '../../data/wgslTypes';
 import { inGPUMode } from '../../gpuMode';
 import type { TgpuNamable } from '../../namable';
 import type { Infer } from '../../shared/repr';
-import type { ResolutionCtx, TgpuResolvable } from '../../types';
+import type { ResolutionCtx, SelfResolvable } from '../../types';
 import type { Exotic } from './../../data/exotic';
 
 // ----------
 // Public API
 // ----------
 
-export interface TgpuConst<TDataType extends AnyWgslData>
-  extends TgpuResolvable,
-    TgpuNamable {
+export interface TgpuConst<TDataType extends AnyWgslData = AnyWgslData>
+  extends TgpuNamable {
   readonly dataType: TDataType;
   readonly value: Infer<TDataType>;
 }
@@ -31,7 +30,7 @@ export function constant<TDataType extends AnyWgslData>(
 // --------------
 
 class TgpuConstImpl<TDataType extends AnyWgslData>
-  implements TgpuConst<TDataType>
+  implements TgpuConst<TDataType>, SelfResolvable
 {
   private _label: string | undefined;
 
@@ -49,7 +48,7 @@ class TgpuConstImpl<TDataType extends AnyWgslData>
     return this;
   }
 
-  resolve(ctx: ResolutionCtx): string {
+  '~resolve'(ctx: ResolutionCtx): string {
     const id = ctx.names.makeUnique(this._label);
     const resolvedValue = ctx.resolveValue(this._value, this.dataType);
 

--- a/packages/typegpu/src/core/declare/tgpuDeclare.ts
+++ b/packages/typegpu/src/core/declare/tgpuDeclare.ts
@@ -1,4 +1,4 @@
-import type { ResolutionCtx, TgpuResolvable } from '../../types';
+import type { ResolutionCtx, SelfResolvable } from '../../types';
 import {
   type ExternalMap,
   applyExternals,
@@ -13,7 +13,7 @@ import {
  * Extra declaration that shall be included in final WGSL code,
  * when resolving objects that use it.
  */
-export interface TgpuDeclare extends TgpuResolvable {
+export interface TgpuDeclare {
   $uses(dependencyMap: Record<string, unknown>): this;
 }
 
@@ -32,7 +32,7 @@ export function declare(declaration: string): TgpuDeclare {
 // Implementation
 // --------------
 
-class TgpuDeclareImpl implements TgpuDeclare {
+class TgpuDeclareImpl implements TgpuDeclare, SelfResolvable {
   private externalsToApply: ExternalMap[] = [];
 
   constructor(private declaration: string) {}
@@ -42,7 +42,7 @@ class TgpuDeclareImpl implements TgpuDeclare {
     return this;
   }
 
-  resolve(ctx: ResolutionCtx): string {
+  '~resolve'(ctx: ResolutionCtx): string {
     const externalMap: ExternalMap = {};
 
     for (const externals of this.externalsToApply) {

--- a/packages/typegpu/src/core/function/tgpuComputeFn.ts
+++ b/packages/typegpu/src/core/function/tgpuComputeFn.ts
@@ -81,7 +81,7 @@ function createComputeFn(
 
   const core = createFnCore(shell, implementation);
 
-  const result: This = {
+  return {
     shell,
 
     get label() {
@@ -108,7 +108,5 @@ function createComputeFn(
     toString() {
       return `computeFn:${this.label ?? '<unnamed>'}`;
     },
-  };
-
-  return result;
+  } as This;
 }

--- a/packages/typegpu/src/core/function/tgpuFn.ts
+++ b/packages/typegpu/src/core/function/tgpuFn.ts
@@ -3,7 +3,12 @@ import type { Exotic, ExoticArray } from '../../data/exotic';
 import type { AnyWgslData } from '../../data/wgslTypes';
 import { inGPUMode } from '../../gpuMode';
 import type { TgpuNamable } from '../../namable';
-import type { ResolutionCtx, TgpuResolvable, Wgsl } from '../../types';
+import type {
+  Labelled,
+  ResolutionCtx,
+  SelfResolvable,
+  Wgsl,
+} from '../../types';
 import type { TgpuBufferUsage } from '../buffer/bufferUsage';
 import {
   type Eventual,
@@ -47,10 +52,10 @@ export interface TgpuFnShell<
 interface TgpuFnBase<
   Args extends AnyWgslData[],
   Return extends AnyWgslData | undefined = undefined,
-> extends TgpuResolvable,
-    TgpuNamable {
-  readonly shell: TgpuFnShell<Args, Return>;
+> extends TgpuNamable,
+    Labelled {
   readonly resourceType: 'function';
+  readonly shell: TgpuFnShell<Args, Return>;
 
   $uses(dependencyMap: Record<string, unknown>): this;
   with<T>(slot: TgpuSlot<T>, value: Eventual<T>): TgpuFn<Args, Return>;
@@ -61,8 +66,8 @@ interface TgpuFnBase<
 }
 
 export type TgpuFn<
-  Args extends AnyWgslData[],
-  Return extends AnyWgslData | undefined = undefined,
+  Args extends AnyWgslData[] = AnyWgslData[],
+  Return extends AnyWgslData | undefined = AnyWgslData | undefined,
 > = TgpuFnBase<Args, Return> &
   ((...args: InferArgs<Args>) => InferReturn<Return>);
 
@@ -114,15 +119,15 @@ function createFn<
   shell: TgpuFnShell<Args, Return>,
   implementation: Implementation,
 ): TgpuFn<Args, Return> {
-  type This = TgpuFnBase<Args, Return>;
+  type This = TgpuFnBase<Args, Return> & SelfResolvable;
 
   const core = createFnCore(shell, implementation);
 
   const fnBase: This = {
     shell,
-    resourceType: 'function',
+    resourceType: 'function' as const,
 
-    $uses(newExternals) {
+    $uses(newExternals: Record<string, unknown>) {
       core.applyExternals(newExternals);
       return this;
     },
@@ -143,7 +148,7 @@ function createFn<
       );
     },
 
-    resolve(ctx: ResolutionCtx): string {
+    '~resolve'(ctx: ResolutionCtx): string {
       return core.resolve(ctx);
     },
   };
@@ -163,7 +168,7 @@ function createFn<
     return implementation(...args);
   };
 
-  const fn = Object.assign(call, fnBase) as TgpuFn<Args, Return>;
+  const fn = Object.assign(call, fnBase as This) as TgpuFn<Args, Return>;
 
   // Making the label available as a readonly property.
   Object.defineProperty(fn, 'label', {
@@ -185,11 +190,11 @@ function createBoundFunction<
   slot: TgpuSlot<unknown>,
   slotValue: unknown,
 ): TgpuFn<Args, Return> {
-  type This = TgpuFnBase<Args, Return>;
+  type This = TgpuFnBase<Args, Return> & SelfResolvable;
 
   const fnBase: This = {
-    shell: innerFn.shell,
     resourceType: 'function',
+    shell: innerFn.shell,
 
     $uses(newExternals) {
       innerFn.$uses(newExternals);
@@ -212,7 +217,7 @@ function createBoundFunction<
       );
     },
 
-    resolve(ctx: ResolutionCtx): string {
+    '~resolve'(ctx: ResolutionCtx): string {
       return ctx.withSlots([[slot, slotValue]], () => ctx.resolve(innerFn));
     },
   };
@@ -243,7 +248,7 @@ function createBoundFunction<
 }
 
 class FnCall<Args extends AnyWgslData[], Return extends AnyWgslData | undefined>
-  implements TgpuResolvable
+  implements SelfResolvable
 {
   constructor(
     private readonly _fn: TgpuFnBase<Args, Return>,
@@ -254,7 +259,7 @@ class FnCall<Args extends AnyWgslData[], Return extends AnyWgslData | undefined>
     return this._fn.label;
   }
 
-  resolve(ctx: ResolutionCtx): string {
+  '~resolve'(ctx: ResolutionCtx): string {
     return ctx.resolve(
       `${ctx.resolve(this._fn)}(${this._params.map((param) => ctx.resolve(param)).join(', ')})`,
     );

--- a/packages/typegpu/src/core/function/tgpuFragmentFn.ts
+++ b/packages/typegpu/src/core/function/tgpuFragmentFn.ts
@@ -1,7 +1,7 @@
 import type { OmitBuiltins } from '../../builtin';
 import { type Vec4f, isWgslStruct } from '../../data/wgslTypes';
 import type { TgpuNamable } from '../../namable';
-import type { ResolutionCtx, TgpuResolvable } from '../../types';
+import type { Labelled, ResolutionCtx, SelfResolvable } from '../../types';
 import { addReturnTypeToExternals } from '../resolve/externals';
 import { createFnCore } from './fnCore';
 import type {
@@ -48,8 +48,7 @@ export interface TgpuFragmentFnShell<
 export interface TgpuFragmentFn<
   Varying extends IOLayout = IOLayout,
   Output extends IOLayout<Vec4f> = IOLayout<Vec4f>,
-> extends TgpuResolvable,
-    TgpuNamable {
+> extends TgpuNamable {
   readonly shell: TgpuFragmentFnShell<Varying, Output>;
   readonly outputType: IOLayoutToOutputSchema<Output>;
 
@@ -96,7 +95,7 @@ function createFragmentFn(
   shell: TgpuFragmentFnShell<IOLayout, IOLayout<Vec4f>>,
   implementation: Implementation,
 ): TgpuFragmentFn {
-  type This = TgpuFragmentFn;
+  type This = TgpuFragmentFn & Labelled & SelfResolvable;
 
   const core = createFnCore(shell, implementation);
   const outputType = createOutputType(shell.returnType);
@@ -106,7 +105,7 @@ function createFragmentFn(
     );
   }
 
-  return {
+  const result: This = {
     shell,
     outputType,
 
@@ -127,7 +126,7 @@ function createFragmentFn(
       return this;
     },
 
-    resolve(ctx: ResolutionCtx): string {
+    '~resolve'(ctx: ResolutionCtx): string {
       return core.resolve(ctx, '@fragment ');
     },
 
@@ -135,4 +134,6 @@ function createFragmentFn(
       return `fragmentFn:${this.label ?? '<unnamed>'}`;
     },
   };
+
+  return result;
 }

--- a/packages/typegpu/src/core/function/tgpuVertexFn.ts
+++ b/packages/typegpu/src/core/function/tgpuVertexFn.ts
@@ -1,7 +1,7 @@
 import type { OmitBuiltins } from '../../builtin';
 import { isWgslStruct } from '../../data/wgslTypes';
 import type { TgpuNamable } from '../../namable';
-import type { ResolutionCtx, TgpuResolvable } from '../../types';
+import type { Labelled, ResolutionCtx, SelfResolvable } from '../../types';
 import { addReturnTypeToExternals } from '../resolve/externals';
 import { createFnCore } from './fnCore';
 import type {
@@ -48,8 +48,7 @@ export interface TgpuVertexFnShell<
 export interface TgpuVertexFn<
   VertexIn extends IOLayout = IOLayout,
   VertexOut extends IOLayout = IOLayout,
-> extends TgpuResolvable,
-    TgpuNamable {
+> extends TgpuNamable {
   readonly shell: TgpuVertexFnShell<VertexIn, VertexOut>;
   readonly outputType: IOLayoutToOutputSchema<VertexOut>;
 
@@ -95,7 +94,7 @@ function createVertexFn(
   shell: TgpuVertexFnShell<IOLayout, IOLayout>,
   implementation: Implementation,
 ): TgpuVertexFn<IOLayout, IOLayout> {
-  type This = TgpuVertexFn<IOLayout, IOLayout>;
+  type This = TgpuVertexFn<IOLayout, IOLayout> & Labelled & SelfResolvable;
 
   const core = createFnCore(shell, implementation);
   const outputType = createOutputType(shell.returnType);
@@ -105,7 +104,7 @@ function createVertexFn(
     );
   }
 
-  return {
+  const result: This = {
     shell,
     outputType,
 
@@ -126,7 +125,7 @@ function createVertexFn(
       return this;
     },
 
-    resolve(ctx: ResolutionCtx): string {
+    '~resolve'(ctx: ResolutionCtx): string {
       return core.resolve(ctx, '@vertex ');
     },
 
@@ -134,4 +133,6 @@ function createVertexFn(
       return `vertexFn:${this.label ?? '<unnamed>'}`;
     },
   };
+
+  return result;
 }

--- a/packages/typegpu/src/core/function/tgpuVertexFn.ts
+++ b/packages/typegpu/src/core/function/tgpuVertexFn.ts
@@ -104,7 +104,7 @@ function createVertexFn(
     );
   }
 
-  const result: This = {
+  return {
     shell,
     outputType,
 
@@ -132,7 +132,5 @@ function createVertexFn(
     toString() {
       return `vertexFn:${this.label ?? '<unnamed>'}`;
     },
-  };
-
-  return result;
+  } as This;
 }

--- a/packages/typegpu/src/core/pipeline/computePipeline.ts
+++ b/packages/typegpu/src/core/pipeline/computePipeline.ts
@@ -147,7 +147,7 @@ class ComputePipelineCore {
       // Resolving code
       const { code, bindGroupLayouts, catchall } = resolve(
         {
-          resolve: (ctx) => {
+          '~resolve': (ctx) => {
             ctx.withSlots(this._slotBindings, () => {
               ctx.resolve(this._entryFn);
             });

--- a/packages/typegpu/src/core/resolve/externals.ts
+++ b/packages/typegpu/src/core/resolve/externals.ts
@@ -80,10 +80,12 @@ export function replaceExternalsInWgsl(
   externalMap: ExternalMap,
   wgsl: string,
 ) {
-  return Object.entries(externalMap).reduce((acc, [externalName, external]) => {
-    return acc.replaceAll(
-      new RegExp(`(?<![\\w_.])${externalName}(?![\\w_])`, 'g'),
-      ctx.resolve(external),
-    );
-  }, wgsl);
+  return Object.entries(externalMap).reduce(
+    (acc, [externalName, external]) =>
+      acc.replaceAll(
+        new RegExp(`(?<![\\w_.])${externalName}(?![\\w_])`, 'g'),
+        ctx.resolve(external),
+      ),
+    wgsl,
+  );
 }

--- a/packages/typegpu/src/core/resolve/externals.ts
+++ b/packages/typegpu/src/core/resolve/externals.ts
@@ -82,7 +82,7 @@ export function replaceExternalsInWgsl(
 ) {
   return Object.entries(externalMap).reduce((acc, [externalName, external]) => {
     return acc.replaceAll(
-      new RegExp(`(?<![\\w_])${externalName}(?![\\w_])`, 'g'),
+      new RegExp(`(?<![\\w_.])${externalName}(?![\\w_])`, 'g'),
       ctx.resolve(external),
     );
   }, wgsl);

--- a/packages/typegpu/src/core/resolve/externals.ts
+++ b/packages/typegpu/src/core/resolve/externals.ts
@@ -1,7 +1,6 @@
-import { isWgslData, isWgslStruct } from '../../data/wgslTypes';
+import { isWgslStruct } from '../../data/wgslTypes';
 import { isNamable } from '../../namable';
-import { type ResolutionCtx, type Wgsl, isResolvable } from '../../types';
-import { isSlot } from '../slot/slotTypes';
+import type { ResolutionCtx } from '../../types';
 
 /**
  * A key-value mapping where keys represent identifiers within shader code,
@@ -82,14 +81,9 @@ export function replaceExternalsInWgsl(
   wgsl: string,
 ) {
   return Object.entries(externalMap).reduce((acc, [externalName, external]) => {
-    const resolvedExternal =
-      isResolvable(external) || isWgslData(external) || isSlot(external)
-        ? ctx.resolve(external as Wgsl)
-        : String(external);
-
     return acc.replaceAll(
-      new RegExp(`(?<![\\w_.])${externalName}(?![\\w_])`, 'g'),
-      resolvedExternal,
+      new RegExp(`(?<![\\w_])${externalName}(?![\\w_])`, 'g'),
+      ctx.resolve(external),
     );
   }, wgsl);
 }

--- a/packages/typegpu/src/core/resolve/tgpuResolve.ts
+++ b/packages/typegpu/src/core/resolve/tgpuResolve.ts
@@ -1,15 +1,14 @@
-import type { AnyWgslData } from '../../data/wgslTypes';
 import type { JitTranspiler } from '../../jitTranspiler';
 import { RandomNameRegistry, StrictNameRegistry } from '../../nameRegistry';
 import { resolve as resolveImpl } from '../../resolutionCtx';
-import type { TgpuResolvable } from '../../types';
+import type { SelfResolvable, Wgsl } from '../../types';
 import { applyExternals, replaceExternalsInWgsl } from './externals';
 
 export interface TgpuResolveOptions {
   /**
    * Map of external names to their resolvable values.
    */
-  externals: Record<string, TgpuResolvable | AnyWgslData | boolean | number>;
+  externals: Record<string, Wgsl>;
   /**
    * The code template to use for the resolution. All external names will be replaced with their resolved values.
    * @default ''
@@ -70,11 +69,11 @@ export function resolve(options: TgpuResolveOptions): string {
     unstable_jitTranspiler: jitTranspiler,
   } = options;
 
-  const dependencies = {} as Record<string, TgpuResolvable>;
+  const dependencies = {} as Record<string, Wgsl>;
   applyExternals(dependencies, externals ?? {});
 
-  const resolutionObj: TgpuResolvable = {
-    resolve(ctx) {
+  const resolutionObj: SelfResolvable = {
+    '~resolve'(ctx) {
       return replaceExternalsInWgsl(ctx, dependencies, template ?? '');
     },
 

--- a/packages/typegpu/src/core/root/init.ts
+++ b/packages/typegpu/src/core/root/init.ts
@@ -51,8 +51,8 @@ import {
   isAccessor,
 } from '../slot/slotTypes';
 import {
-  type INTERNAL_TgpuSampledTexture,
-  type INTERNAL_TgpuStorageTexture,
+  type INTERNAL_TgpuFixedSampledTexture,
+  type INTERNAL_TgpuFixedStorageTexture,
   type INTERNAL_TgpuTexture,
   INTERNAL_createTexture,
   type TgpuMutableTexture,
@@ -153,7 +153,7 @@ class WithVertexImpl implements WithVertex {
 class WithFragmentImpl implements WithFragment {
   constructor(private readonly _options: RenderPipelineCoreOptions) {}
 
-  withPrimitive(primitiveState: GPUPrimitiveState): WithFragment {
+  withPrimitive(primitiveState: GPUPrimitiveState | undefined): WithFragment {
     return new WithFragmentImpl({ ...this._options, primitiveState });
   }
 
@@ -321,11 +321,13 @@ class TgpuRootImpl extends WithBindingImpl implements ExperimentalTgpuRoot {
     }
 
     if (isStorageTextureView(resource)) {
-      return (resource as unknown as INTERNAL_TgpuStorageTexture).unwrap();
+      // TODO: Verify that `resource` is actually a fixed view, not a laid-out one
+      return (resource as unknown as INTERNAL_TgpuFixedStorageTexture).unwrap();
     }
 
     if (isSampledTextureView(resource)) {
-      return (resource as unknown as INTERNAL_TgpuSampledTexture).unwrap();
+      // TODO: Verify that `resource` is actually a fixed view, not a laid-out one
+      return (resource as unknown as INTERNAL_TgpuFixedSampledTexture).unwrap();
     }
 
     throw new Error(`Unknown resource type: ${resource}`);

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -77,7 +77,9 @@ export interface WithVertex<VertexOut extends IORecord = IORecord> {
 export interface WithFragment<
   Output extends IOLayout<Vec4f> = IOLayout<Vec4f>,
 > {
-  withPrimitive(primitiveState: GPUPrimitiveState): WithFragment<Output>;
+  withPrimitive(
+    primitiveState: GPUPrimitiveState | undefined,
+  ): WithFragment<Output>;
   createPipeline(): TgpuRenderPipeline<Output>;
 }
 

--- a/packages/typegpu/src/core/sampler/sampler.ts
+++ b/packages/typegpu/src/core/sampler/sampler.ts
@@ -4,7 +4,7 @@
 
 import type { TgpuNamable } from '../../namable';
 import type { LayoutMembership } from '../../tgpuBindGroupLayout';
-import type { ResolutionCtx, TgpuResolvable } from '../../types';
+import type { ResolutionCtx, SelfResolvable } from '../../types';
 
 export interface SamplerProps {
   addressModeU?: GPUAddressMode;
@@ -91,7 +91,7 @@ export interface ComparisonSamplerProps {
   maxAnisotropy?: number;
 }
 
-export interface TgpuSampler extends TgpuResolvable {
+export interface TgpuSampler {
   readonly resourceType: 'sampler';
 }
 
@@ -131,7 +131,7 @@ export function isComparisonSampler(
 // Implementation
 // --------------
 
-export class TgpuLaidOutSamplerImpl implements TgpuSampler {
+export class TgpuLaidOutSamplerImpl implements TgpuSampler, SelfResolvable {
   public readonly resourceType = 'sampler';
 
   constructor(private readonly _membership: LayoutMembership) {}
@@ -140,7 +140,7 @@ export class TgpuLaidOutSamplerImpl implements TgpuSampler {
     return this._membership.key;
   }
 
-  resolve(ctx: ResolutionCtx): string {
+  '~resolve'(ctx: ResolutionCtx): string {
     const id = ctx.names.makeUnique(this.label);
     const group = ctx.allocateLayoutEntry(this._membership.layout);
 
@@ -156,7 +156,9 @@ export class TgpuLaidOutSamplerImpl implements TgpuSampler {
   }
 }
 
-export class TgpuLaidOutComparisonSamplerImpl implements TgpuComparisonSampler {
+export class TgpuLaidOutComparisonSamplerImpl
+  implements TgpuComparisonSampler, SelfResolvable
+{
   public readonly resourceType = 'sampler-comparison';
 
   constructor(private readonly _membership: LayoutMembership) {}
@@ -165,7 +167,7 @@ export class TgpuLaidOutComparisonSamplerImpl implements TgpuComparisonSampler {
     return this._membership.key;
   }
 
-  resolve(ctx: ResolutionCtx): string {
+  '~resolve'(ctx: ResolutionCtx): string {
     const id = ctx.names.makeUnique(this.label);
     const group = ctx.allocateLayoutEntry(this._membership.layout);
 
@@ -181,7 +183,7 @@ export class TgpuLaidOutComparisonSamplerImpl implements TgpuComparisonSampler {
   }
 }
 
-class TgpuFixedSamplerImpl implements TgpuFixedSampler {
+class TgpuFixedSamplerImpl implements TgpuFixedSampler, SelfResolvable {
   public readonly resourceType = 'sampler';
 
   private _label: string | undefined;
@@ -204,7 +206,7 @@ class TgpuFixedSamplerImpl implements TgpuFixedSampler {
     return this;
   }
 
-  resolve(ctx: ResolutionCtx): string {
+  '~resolve'(ctx: ResolutionCtx): string {
     const id = ctx.names.makeUnique(this._label);
 
     const { group, binding } = ctx.allocateFixedEntry(
@@ -226,7 +228,9 @@ class TgpuFixedSamplerImpl implements TgpuFixedSampler {
   }
 }
 
-class TgpuFixedComparisonSamplerImpl implements TgpuFixedComparisonSampler {
+class TgpuFixedComparisonSamplerImpl
+  implements TgpuFixedComparisonSampler, SelfResolvable
+{
   public readonly resourceType = 'sampler-comparison';
 
   private _label: string | undefined;
@@ -242,7 +246,7 @@ class TgpuFixedComparisonSamplerImpl implements TgpuFixedComparisonSampler {
     return this;
   }
 
-  resolve(ctx: ResolutionCtx): string {
+  '~resolve'(ctx: ResolutionCtx): string {
     const id = ctx.names.makeUnique(this.label);
     const { group, binding } = ctx.allocateFixedEntry(
       { sampler: 'comparison' },

--- a/packages/typegpu/src/core/slot/accessor.ts
+++ b/packages/typegpu/src/core/slot/accessor.ts
@@ -2,7 +2,7 @@ import type { AnyWgslData } from '../../data';
 import type { Exotic } from '../../data/exotic';
 import { getResolutionCtx } from '../../gpuMode';
 import type { Infer } from '../../shared/repr';
-import type { ResolutionCtx } from '../../types';
+import type { ResolutionCtx, SelfResolvable } from '../../types';
 import { type TgpuBufferUsage, isBufferUsage } from '../buffer/bufferUsage';
 import { type TgpuFn, isTgpuFn } from '../function/tgpuFn';
 import { slot } from './slot';
@@ -27,7 +27,7 @@ export function accessor<T extends AnyWgslData>(
 // --------------
 
 export class TgpuAccessorImpl<T extends AnyWgslData>
-  implements TgpuAccessor<T>
+  implements TgpuAccessor<T>, SelfResolvable
 {
   readonly resourceType = 'accessor';
   public label?: string | undefined;
@@ -65,7 +65,7 @@ export class TgpuAccessorImpl<T extends AnyWgslData>
     return this as unknown as Infer<T>;
   }
 
-  resolve(ctx: ResolutionCtx): string {
+  '~resolve'(ctx: ResolutionCtx): string {
     const value = ctx.unwrap(this.slot);
 
     if (isBufferUsage(value)) {

--- a/packages/typegpu/src/core/slot/slotTypes.ts
+++ b/packages/typegpu/src/core/slot/slotTypes.ts
@@ -2,7 +2,6 @@ import type { AnyWgslData } from '../../data';
 import type { TgpuNamable } from '../../namable';
 import type { Infer } from '../../shared/repr';
 import type { TgpuFn } from '../function/tgpuFn';
-import type { TgpuResolvable } from './../../types';
 import type { TgpuBufferUsage } from './../buffer/bufferUsage';
 
 export interface TgpuSlot<T> extends TgpuNamable {
@@ -32,9 +31,8 @@ export interface TgpuDerived<T> {
   '~compute'(): T;
 }
 
-export interface TgpuAccessor<T extends AnyWgslData>
-  extends TgpuResolvable,
-    TgpuNamable {
+export interface TgpuAccessor<T extends AnyWgslData = AnyWgslData>
+  extends TgpuNamable {
   readonly resourceType: 'accessor';
 
   readonly schema: T;
@@ -54,7 +52,7 @@ export interface TgpuAccessor<T extends AnyWgslData>
  */
 export type Eventual<T> = T | TgpuSlot<T> | TgpuDerived<T>;
 
-export type SlotValuePair<T> = [TgpuSlot<T>, T];
+export type SlotValuePair<T = unknown> = [TgpuSlot<T>, T];
 
 export function isSlot<T>(value: unknown | TgpuSlot<T>): value is TgpuSlot<T> {
   return (value as TgpuSlot<T>)?.resourceType === 'slot';

--- a/packages/typegpu/src/core/slot/slotTypes.ts
+++ b/packages/typegpu/src/core/slot/slotTypes.ts
@@ -1,15 +1,15 @@
 import type { AnyWgslData } from '../../data';
 import type { TgpuNamable } from '../../namable';
 import type { Infer } from '../../shared/repr';
+import type { Labelled } from '../../types';
 import type { TgpuFn } from '../function/tgpuFn';
 import type { TgpuBufferUsage } from './../buffer/bufferUsage';
 
-export interface TgpuSlot<T> extends TgpuNamable {
+export interface TgpuSlot<T> extends TgpuNamable, Labelled {
   readonly resourceType: 'slot';
 
   readonly defaultValue: T | undefined;
 
-  readonly label?: string | undefined;
   /**
    * Used to determine if code generated using either value `a` or `b` in place
    * of the slot will be equivalent. Defaults to `Object.is`.
@@ -32,7 +32,8 @@ export interface TgpuDerived<T> {
 }
 
 export interface TgpuAccessor<T extends AnyWgslData = AnyWgslData>
-  extends TgpuNamable {
+  extends TgpuNamable,
+    Labelled {
   readonly resourceType: 'accessor';
 
   readonly schema: T;
@@ -43,7 +44,6 @@ export interface TgpuAccessor<T extends AnyWgslData = AnyWgslData>
     | undefined;
   readonly slot: TgpuSlot<TgpuFn<[], T> | TgpuBufferUsage<T> | Infer<T>>;
 
-  readonly label?: string | undefined;
   readonly value: Infer<T>;
 }
 

--- a/packages/typegpu/src/core/texture/externalTexture.ts
+++ b/packages/typegpu/src/core/texture/externalTexture.ts
@@ -1,5 +1,5 @@
 import type { LayoutMembership } from '../../tgpuBindGroupLayout';
-import type { ResolutionCtx } from '../../types';
+import type { ResolutionCtx, SelfResolvable } from '../../types';
 
 // ----------
 // Public API
@@ -19,7 +19,9 @@ export function isExternalTexture<T extends TgpuExternalTexture>(
 // Implementation
 // --------------
 
-export class TgpuExternalTextureImpl implements TgpuExternalTexture {
+export class TgpuExternalTextureImpl
+  implements TgpuExternalTexture, SelfResolvable
+{
   public readonly resourceType = 'external-texture';
 
   constructor(private readonly _membership: LayoutMembership) {}
@@ -28,7 +30,7 @@ export class TgpuExternalTextureImpl implements TgpuExternalTexture {
     return this._membership.key;
   }
 
-  resolve(ctx: ResolutionCtx): string {
+  '~resolve'(ctx: ResolutionCtx): string {
     const id = ctx.names.makeUnique(this.label);
     const group = ctx.allocateLayoutEntry(this._membership.layout);
 

--- a/packages/typegpu/src/core/variable/tgpuVariable.ts
+++ b/packages/typegpu/src/core/variable/tgpuVariable.ts
@@ -3,7 +3,7 @@ import type { AnyWgslData } from '../../data/wgslTypes';
 import { inGPUMode } from '../../gpuMode';
 import type { TgpuNamable } from '../../namable';
 import type { Infer } from '../../shared/repr';
-import type { ResolutionCtx, TgpuResolvable } from '../../types';
+import type { ResolutionCtx, SelfResolvable } from '../../types';
 
 // ----------
 // Public API
@@ -12,10 +12,9 @@ import type { ResolutionCtx, TgpuResolvable } from '../../types';
 export type VariableScope = 'private' | 'workgroup';
 
 export interface TgpuVar<
-  TScope extends VariableScope,
-  TDataType extends AnyWgslData,
-> extends TgpuResolvable,
-    TgpuNamable {
+  TScope extends VariableScope = VariableScope,
+  TDataType extends AnyWgslData = AnyWgslData,
+> extends TgpuNamable {
   value: Infer<TDataType>;
   readonly scope: TScope;
 }
@@ -50,7 +49,7 @@ export function workgroupVar<TDataType extends AnyWgslData>(
 // --------------
 
 class TgpuVarImpl<TScope extends VariableScope, TDataType extends AnyWgslData>
-  implements TgpuVar<TScope, TDataType>
+  implements TgpuVar<TScope, TDataType>, SelfResolvable
 {
   private _label: string | undefined;
 
@@ -65,11 +64,7 @@ class TgpuVarImpl<TScope extends VariableScope, TDataType extends AnyWgslData>
     return this;
   }
 
-  get label() {
-    return this._label;
-  }
-
-  resolve(ctx: ResolutionCtx): string {
+  '~resolve'(ctx: ResolutionCtx): string {
     const id = ctx.names.makeUnique(this._label);
 
     if (this._initialValue) {
@@ -83,6 +78,10 @@ class TgpuVarImpl<TScope extends VariableScope, TDataType extends AnyWgslData>
     }
 
     return id;
+  }
+
+  get label() {
+    return this._label;
   }
 
   toString() {

--- a/packages/typegpu/src/core/vertexLayout/vertexLayout.ts
+++ b/packages/typegpu/src/core/vertexLayout/vertexLayout.ts
@@ -12,6 +12,7 @@ import {
   kindToDefaultFormatMap,
   vertexFormats,
 } from '../../shared/vertexFormat';
+import type { Labelled } from '../../types';
 import type { ExoticIO } from '../function/fnTypes';
 import type {
   ArrayToContainedAttribs,
@@ -24,9 +25,9 @@ import type {
 
 export interface TgpuVertexLayout<
   TData extends WgslArray | Disarray = WgslArray | Disarray,
-> extends TgpuNamable {
+> extends TgpuNamable,
+    Labelled {
   readonly resourceType: 'vertex-layout';
-  readonly label?: string | undefined;
   readonly stride: number;
   readonly stepMode: 'vertex' | 'instance';
   readonly attrib: ArrayToContainedAttribs<TData>;

--- a/packages/typegpu/src/data/matrix.ts
+++ b/packages/typegpu/src/data/matrix.ts
@@ -1,3 +1,4 @@
+import { inGPUMode } from '../gpuMode';
 import { type VecKind, vec2f, vec3f, vec4f } from './vector';
 import type {
   Mat2x2f,
@@ -52,6 +53,10 @@ function createMatSchema<
   };
 
   const construct = (...args: (number | ColumnType)[]): ValueType => {
+    if (inGPUMode()) {
+      return `${MatSchema.type}(${args.join(', ')})` as unknown as ValueType;
+    }
+
     const elements: number[] = [];
 
     for (const arg of args) {
@@ -81,6 +86,7 @@ function createMatSchema<
 abstract class mat2x2Impl<TColumn extends v2f> implements mat2x2<TColumn> {
   public readonly columns: readonly [TColumn, TColumn];
   public readonly length = 4;
+  public abstract readonly kind: string;
   [n: number]: number;
 
   constructor(...elements: number[]) {
@@ -123,6 +129,12 @@ abstract class mat2x2Impl<TColumn extends v2f> implements mat2x2<TColumn> {
   set [3](value: number) {
     this.columns[1].y = value;
   }
+
+  '~resolve'(): string {
+    return `${this.kind}(${Array.from({ length: this.length })
+      .map((_, i) => this[i])
+      .join(', ')})`;
+  }
 }
 
 class mat2x2fImpl extends mat2x2Impl<v2f> implements m2x2f {
@@ -136,6 +148,7 @@ class mat2x2fImpl extends mat2x2Impl<v2f> implements m2x2f {
 abstract class mat3x3Impl<TColumn extends v3f> implements mat3x3<TColumn> {
   public readonly columns: readonly [TColumn, TColumn, TColumn];
   public readonly length = 12;
+  public abstract readonly kind: string;
   [n: number]: number;
 
   constructor(...elements: number[]) {
@@ -249,6 +262,10 @@ abstract class mat3x3Impl<TColumn extends v3f> implements mat3x3<TColumn> {
   }
 
   set [11](_: number) {}
+
+  '~resolve'(): string {
+    return `${this.kind}(${this[0]}, ${this[1]}, ${this[2]}, ${this[4]}, ${this[5]}, ${this[6]}, ${this[8]}, ${this[9]}, ${this[10]})`;
+  }
 }
 
 class mat3x3fImpl extends mat3x3Impl<v3f> implements m3x3f {
@@ -260,6 +277,7 @@ class mat3x3fImpl extends mat3x3Impl<v3f> implements m3x3f {
 
 abstract class mat4x4Impl<TColumn extends v4f> implements mat4x4<TColumn> {
   public readonly columns: readonly [TColumn, TColumn, TColumn, TColumn];
+  public abstract readonly kind: string;
 
   constructor(...elements: number[]) {
     this.columns = [
@@ -421,6 +439,12 @@ abstract class mat4x4Impl<TColumn extends v4f> implements mat4x4<TColumn> {
 
   set [15](value: number) {
     this.columns[3].w = value;
+  }
+
+  '~resolve'(): string {
+    return `${this.kind}(${Array.from({ length: this.length })
+      .map((_, i) => this[i])
+      .join(', ')})`;
   }
 }
 

--- a/packages/typegpu/src/data/matrix.ts
+++ b/packages/typegpu/src/data/matrix.ts
@@ -1,4 +1,5 @@
 import { inGPUMode } from '../gpuMode';
+import type { SelfResolvable } from '../types';
 import { type VecKind, vec2f, vec3f, vec4f } from './vector';
 import type {
   Mat2x2f,
@@ -83,7 +84,9 @@ function createMatSchema<
   } & MatConstructor<ValueType, ColumnType>;
 }
 
-abstract class mat2x2Impl<TColumn extends v2f> implements mat2x2<TColumn> {
+abstract class mat2x2Impl<TColumn extends v2f>
+  implements mat2x2<TColumn>, SelfResolvable
+{
   public readonly columns: readonly [TColumn, TColumn];
   public readonly length = 4;
   public abstract readonly kind: string;
@@ -145,7 +148,9 @@ class mat2x2fImpl extends mat2x2Impl<v2f> implements m2x2f {
   }
 }
 
-abstract class mat3x3Impl<TColumn extends v3f> implements mat3x3<TColumn> {
+abstract class mat3x3Impl<TColumn extends v3f>
+  implements mat3x3<TColumn>, SelfResolvable
+{
   public readonly columns: readonly [TColumn, TColumn, TColumn];
   public readonly length = 12;
   public abstract readonly kind: string;
@@ -275,7 +280,9 @@ class mat3x3fImpl extends mat3x3Impl<v3f> implements m3x3f {
   }
 }
 
-abstract class mat4x4Impl<TColumn extends v4f> implements mat4x4<TColumn> {
+abstract class mat4x4Impl<TColumn extends v4f>
+  implements mat4x4<TColumn>, SelfResolvable
+{
   public readonly columns: readonly [TColumn, TColumn, TColumn, TColumn];
   public abstract readonly kind: string;
 

--- a/packages/typegpu/src/data/vector.ts
+++ b/packages/typegpu/src/data/vector.ts
@@ -106,12 +106,12 @@ abstract class vec2Impl {
     this.y = value;
   }
 
-  resolve(): string {
+  '~resolve'(): string {
     return `${this.kind}(${this.x}, ${this.y})`;
   }
 
   toString() {
-    return this.resolve();
+    return this['~resolve']();
   }
 }
 
@@ -220,12 +220,12 @@ abstract class vec3Impl {
     this.z = value;
   }
 
-  resolve(): string {
+  '~resolve'(): string {
     return `${this.kind}(${this.x}, ${this.y}, ${this.z})`;
   }
 
   toString() {
-    return this.resolve();
+    return this['~resolve']();
   }
 }
 
@@ -344,12 +344,12 @@ abstract class vec4Impl {
     this.w = value;
   }
 
-  resolve(): string {
+  '~resolve'(): string {
     return `${this.kind}(${this.x}, ${this.y}, ${this.z}, ${this.w})`;
   }
 
   toString() {
-    return this.resolve();
+    return this['~resolve']();
   }
 }
 

--- a/packages/typegpu/src/data/vector.ts
+++ b/packages/typegpu/src/data/vector.ts
@@ -1,4 +1,5 @@
 import { inGPUMode } from '../gpuMode';
+import type { SelfResolvable } from '../types';
 import type {
   Vec2f,
   Vec2h,
@@ -74,7 +75,7 @@ function makeVecSchema<TType extends string, TValue>(
   return Object.assign(construct, VecSchema);
 }
 
-abstract class vec2Impl {
+abstract class vec2Impl implements SelfResolvable {
   public readonly length = 2;
   abstract readonly kind: `vec2${'f' | 'u' | 'i' | 'h'}`;
 
@@ -179,7 +180,7 @@ class vec2uImpl extends vec2Impl {
   }
 }
 
-abstract class vec3Impl {
+abstract class vec3Impl implements SelfResolvable {
   public readonly length = 3;
   abstract readonly kind: `vec3${'f' | 'u' | 'i' | 'h'}`;
   [n: number]: number;
@@ -293,7 +294,7 @@ class vec3uImpl extends vec3Impl {
   }
 }
 
-abstract class vec4Impl {
+abstract class vec4Impl implements SelfResolvable {
   public readonly length = 4;
   abstract readonly kind: `vec4${'f' | 'u' | 'i' | 'h'}`;
   [n: number]: number;

--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -473,12 +473,15 @@ export interface v4u extends NumberArrayView, Swizzle4<v2u, v3u, v4u> {
 
 export type AnyVecInstance =
   | v2f
+  | v2h
   | v2i
   | v2u
   | v3f
+  | v3h
   | v3i
   | v3u
   | v4f
+  | v4h
   | v4i
   | v4u;
 

--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -1,5 +1,4 @@
 import type { Infer, InferRecord } from '../shared/repr';
-import type { TgpuResolvable } from '../types';
 
 export interface NumberArrayView {
   readonly length: number;
@@ -332,10 +331,7 @@ interface Swizzle4<T2, T3, T4> extends Swizzle3<T2, T3, T4> {
  * Interface representing its WGSL vector type counterpart: vec2f or vec2<f32>.
  * A vector with 2 elements of type f32
  */
-export interface v2f
-  extends NumberArrayView,
-    Swizzle2<v2f, v3f, v4f>,
-    TgpuResolvable {
+export interface v2f extends NumberArrayView, Swizzle2<v2f, v3f, v4f> {
   /** use to distinguish between vectors of the same size on the type level */
   readonly kind: 'vec2f';
   x: number;
@@ -346,10 +342,7 @@ export interface v2f
  * Interface representing its WGSL vector type counterpart: vec2h or vec2<f16>.
  * A vector with 2 elements of type f16
  */
-export interface v2h
-  extends NumberArrayView,
-    Swizzle2<v2h, v3h, v4h>,
-    TgpuResolvable {
+export interface v2h extends NumberArrayView, Swizzle2<v2h, v3h, v4h> {
   /** use to distinguish between vectors of the same size on the type level */
   readonly kind: 'vec2h';
   x: number;
@@ -360,10 +353,7 @@ export interface v2h
  * Interface representing its WGSL vector type counterpart: vec2i or vec2<i32>.
  * A vector with 2 elements of type i32
  */
-export interface v2i
-  extends NumberArrayView,
-    Swizzle2<v2i, v3i, v4i>,
-    TgpuResolvable {
+export interface v2i extends NumberArrayView, Swizzle2<v2i, v3i, v4i> {
   /** use to distinguish between vectors of the same size on the type level */
   readonly kind: 'vec2i';
   x: number;
@@ -374,10 +364,7 @@ export interface v2i
  * Interface representing its WGSL vector type counterpart: vec2u or vec2<u32>.
  * A vector with 2 elements of type u32
  */
-export interface v2u
-  extends NumberArrayView,
-    Swizzle2<v2u, v3u, v4u>,
-    TgpuResolvable {
+export interface v2u extends NumberArrayView, Swizzle2<v2u, v3u, v4u> {
   /** use to distinguish between vectors of the same size on the type level */
   readonly kind: 'vec2u';
   x: number;
@@ -388,10 +375,7 @@ export interface v2u
  * Interface representing its WGSL vector type counterpart: vec3f or vec3<f32>.
  * A vector with 3 elements of type f32
  */
-export interface v3f
-  extends NumberArrayView,
-    Swizzle3<v2f, v3f, v4f>,
-    TgpuResolvable {
+export interface v3f extends NumberArrayView, Swizzle3<v2f, v3f, v4f> {
   /** use to distinguish between vectors of the same size on the type level */
   readonly kind: 'vec3f';
   x: number;
@@ -403,10 +387,7 @@ export interface v3f
  * Interface representing its WGSL vector type counterpart: vec3h or vec3<f16>.
  * A vector with 3 elements of type f16
  */
-export interface v3h
-  extends NumberArrayView,
-    Swizzle3<v2h, v3h, v4h>,
-    TgpuResolvable {
+export interface v3h extends NumberArrayView, Swizzle3<v2h, v3h, v4h> {
   /** use to distinguish between vectors of the same size on the type level */
   readonly kind: 'vec3h';
   x: number;
@@ -418,10 +399,7 @@ export interface v3h
  * Interface representing its WGSL vector type counterpart: vec3i or vec3<i32>.
  * A vector with 3 elements of type i32
  */
-export interface v3i
-  extends NumberArrayView,
-    Swizzle3<v2i, v3i, v4i>,
-    TgpuResolvable {
+export interface v3i extends NumberArrayView, Swizzle3<v2i, v3i, v4i> {
   /** use to distinguish between vectors of the same size on the type level */
   readonly kind: 'vec3i';
   x: number;
@@ -433,10 +411,7 @@ export interface v3i
  * Interface representing its WGSL vector type counterpart: vec3u or vec3<u32>.
  * A vector with 3 elements of type u32
  */
-export interface v3u
-  extends NumberArrayView,
-    Swizzle3<v2u, v3u, v4u>,
-    TgpuResolvable {
+export interface v3u extends NumberArrayView, Swizzle3<v2u, v3u, v4u> {
   /** use to distinguish between vectors of the same size on the type level */
   readonly kind: 'vec3u';
   x: number;
@@ -448,10 +423,7 @@ export interface v3u
  * Interface representing its WGSL vector type counterpart: vec4f or vec4<f32>.
  * A vector with 4 elements of type f32
  */
-export interface v4f
-  extends NumberArrayView,
-    Swizzle4<v2f, v3f, v4f>,
-    TgpuResolvable {
+export interface v4f extends NumberArrayView, Swizzle4<v2f, v3f, v4f> {
   /** use to distinguish between vectors of the same size on the type level */
   readonly kind: 'vec4f';
   x: number;
@@ -464,10 +436,7 @@ export interface v4f
  * Interface representing its WGSL vector type counterpart: vec4h or vec4<f16>.
  * A vector with 4 elements of type f16
  */
-export interface v4h
-  extends NumberArrayView,
-    Swizzle4<v2h, v3h, v4h>,
-    TgpuResolvable {
+export interface v4h extends NumberArrayView, Swizzle4<v2h, v3h, v4h> {
   /** use to distinguish between vectors of the same size on the type level */
   readonly kind: 'vec4h';
   x: number;
@@ -480,10 +449,7 @@ export interface v4h
  * Interface representing its WGSL vector type counterpart: vec4i or vec4<i32>.
  * A vector with 4 elements of type i32
  */
-export interface v4i
-  extends NumberArrayView,
-    Swizzle4<v2i, v3i, v4i>,
-    TgpuResolvable {
+export interface v4i extends NumberArrayView, Swizzle4<v2i, v3i, v4i> {
   /** use to distinguish between vectors of the same size on the type level */
   readonly kind: 'vec4i';
   x: number;
@@ -496,10 +462,7 @@ export interface v4i
  * Interface representing its WGSL vector type counterpart: vec4u or vec4<u32>.
  * A vector with 4 elements of type u32
  */
-export interface v4u
-  extends NumberArrayView,
-    Swizzle4<v2u, v3u, v4u>,
-    TgpuResolvable {
+export interface v4u extends NumberArrayView, Swizzle4<v2u, v3u, v4u> {
   /** use to distinguish between vectors of the same size on the type level */
   readonly kind: 'vec4u';
   x: number;
@@ -507,6 +470,17 @@ export interface v4u
   z: number;
   w: number;
 }
+
+export type AnyVecInstance =
+  | v2f
+  | v2i
+  | v2u
+  | v3f
+  | v3i
+  | v3u
+  | v4f
+  | v4i
+  | v4u;
 
 export interface matBase<TColumn> extends NumberArrayView {
   readonly columns: readonly TColumn[];
@@ -518,6 +492,7 @@ export interface matBase<TColumn> extends NumberArrayView {
  */
 export interface mat2x2<TColumn> extends matBase<TColumn> {
   readonly length: 4;
+  readonly kind: string;
   [n: number]: number;
 }
 
@@ -535,6 +510,7 @@ export interface m2x2f extends mat2x2<v2f> {
  */
 export interface mat3x3<TColumn> extends matBase<TColumn> {
   readonly length: 12;
+  readonly kind: string;
   [n: number]: number;
 }
 
@@ -552,6 +528,7 @@ export interface m3x3f extends mat3x3<v3f> {
  */
 export interface mat4x4<TColumn> extends matBase<TColumn> {
   readonly length: 16;
+  readonly kind: string;
   [n: number]: number;
 }
 
@@ -562,6 +539,8 @@ export interface mat4x4<TColumn> extends matBase<TColumn> {
 export interface m4x4f extends mat4x4<v4f> {
   readonly kind: 'mat4x4f';
 }
+
+export type AnyMatInstance = m2x2f | m3x3f | m4x4f;
 
 // #endregion
 

--- a/packages/typegpu/src/resolutionCtx.ts
+++ b/packages/typegpu/src/resolutionCtx.ts
@@ -468,7 +468,7 @@ class ResolutionCtxImpl implements ResolutionCtx {
       if (isWgslData(item)) {
         result = resolveData(this, item);
       } else if (isDerived(item) || isSlot(item)) {
-        result = this.resolve(this.unwrap(item));
+        result = this.resolve(item);
       } else if (isSelfResolvable(item)) {
         result = item['~resolve'](this);
       } else {

--- a/packages/typegpu/src/types.ts
+++ b/packages/typegpu/src/types.ts
@@ -1,11 +1,31 @@
 import type { Block } from 'tinyest';
+import type { TgpuBufferUsage } from './core/buffer/bufferUsage';
+import type { TgpuConst } from './core/constant/tgpuConstant';
+import type { TgpuDeclare } from './core/declare/tgpuDeclare';
+import type { TgpuComputeFn } from './core/function/tgpuComputeFn';
+import type { TgpuFn } from './core/function/tgpuFn';
+import type { TgpuFragmentFn } from './core/function/tgpuFragmentFn';
+import type { TgpuVertexFn } from './core/function/tgpuVertexFn';
+import type { TgpuComputePipeline } from './core/pipeline/computePipeline';
+import type { TgpuRenderPipeline } from './core/pipeline/renderPipeline';
+import type { TgpuSampler } from './core/sampler/sampler';
 import {
   type Eventual,
   type SlotValuePair,
+  type TgpuAccessor,
   isDerived,
   isSlot,
 } from './core/slot/slotTypes';
-import type { AnyWgslData, BaseWgslData } from './data/wgslTypes';
+import type { TgpuExternalTexture } from './core/texture/externalTexture';
+import type { TgpuAnyTextureView, TgpuTexture } from './core/texture/texture';
+import type { TgpuVar } from './core/variable/tgpuVariable';
+import {
+  type AnyMatInstance,
+  type AnyVecInstance,
+  type AnyWgslData,
+  type BaseWgslData,
+  isWgslData,
+} from './data/wgslTypes';
 import type { NameRegistry } from './nameRegistry';
 import type { Infer } from './shared/repr';
 import type {
@@ -13,9 +33,30 @@ import type {
   TgpuLayoutEntry,
 } from './tgpuBindGroupLayout';
 
-export type Wgsl = Eventual<
-  string | number | boolean | TgpuResolvable | AnyWgslData
->;
+export type ResolvableObject =
+  | SelfResolvable
+  | TgpuBufferUsage
+  | TgpuConst
+  | TgpuDeclare
+  | TgpuFn
+  | TgpuComputeFn
+  | TgpuFragmentFn
+  | TgpuComputePipeline
+  | TgpuRenderPipeline
+  | TgpuVertexFn
+  | TgpuSampler
+  | TgpuAccessor
+  | TgpuExternalTexture
+  | TgpuTexture
+  | TgpuAnyTextureView
+  | TgpuVar
+  | AnyVecInstance
+  | AnyMatInstance
+  | AnyWgslData
+  // biome-ignore lint/suspicious/noExplicitAny: <has to be more permissive than unknown>
+  | TgpuFn<any, any>;
+
+export type Wgsl = Eventual<string | number | boolean | ResolvableObject>;
 
 export const UnknownData = Symbol('Unknown data type');
 export type UnknownData = typeof UnknownData;
@@ -70,7 +111,7 @@ export interface ResolutionCtx {
    */
   unwrap<T>(eventual: Eventual<T>): T;
 
-  resolve(item: Wgsl): string;
+  resolve(item: unknown): string;
   resolveValue<T extends BaseWgslData>(value: Infer<T>, schema: T): string;
 
   transpileFn(fn: string): {
@@ -84,18 +125,22 @@ export interface ResolutionCtx {
   };
 }
 
-export interface TgpuResolvable {
-  readonly label?: string | undefined;
-  resolve(ctx: ResolutionCtx): string;
+/**
+ * Houses a method '~resolve` that returns a code string
+ * representing it, as opposed to offloading the resolution
+ * to another mechanism.
+ */
+export interface SelfResolvable {
+  '~resolve'(ctx: ResolutionCtx): string;
   toString(): string;
 }
 
-export function isResolvable(value: unknown): value is TgpuResolvable {
-  return (
-    !!value &&
-    (typeof value === 'object' || typeof value === 'function') &&
-    'resolve' in value
-  );
+export interface Labelled {
+  readonly label?: string | undefined;
+}
+
+export function isSelfResolvable(value: unknown): value is SelfResolvable {
+  return typeof (value as SelfResolvable)?.['~resolve'] === 'function';
 }
 
 export function isWgsl(value: unknown): value is Wgsl {
@@ -103,7 +148,8 @@ export function isWgsl(value: unknown): value is Wgsl {
     typeof value === 'number' ||
     typeof value === 'boolean' ||
     typeof value === 'string' ||
-    isResolvable(value) ||
+    isSelfResolvable(value) ||
+    isWgslData(value) ||
     isSlot(value) ||
     isDerived(value)
   );

--- a/packages/typegpu/tests/accessor.test.ts
+++ b/packages/typegpu/tests/accessor.test.ts
@@ -6,7 +6,6 @@ import tgpu, {
   ResolutionError,
   asUniform,
 } from '../src/experimental';
-import type { TgpuResolvable } from '../src/types';
 import { it } from './utils/extendedIt';
 import { parseResolved } from './utils/parseResolved';
 
@@ -17,7 +16,7 @@ const resolutionRootMock = {
   toString() {
     return '<root>';
   },
-} as TgpuResolvable;
+};
 
 describe('tgpu.accessor', () => {
   it('resolves to invocation of provided function', () => {

--- a/packages/typegpu/tests/matrix.test.ts
+++ b/packages/typegpu/tests/matrix.test.ts
@@ -1,6 +1,8 @@
 import { BufferReader, BufferWriter } from 'typed-binary';
 import { describe, expect, it } from 'vitest';
+import tgpu from '../src';
 import * as d from '../src/data';
+
 import { readData, writeData } from '../src/data/dataIO';
 
 describe('mat2x2f', () => {
@@ -76,6 +78,17 @@ describe('mat2x2f', () => {
     expect(mat.columns[0]).toEqual(d.vec2f(4, 5));
     expect(mat.columns[1]).toEqual(d.vec2f(6, 7));
     expect(d.matToArray(mat)).toEqual([4, 5, 6, 7]);
+  });
+
+  it('creates a matrix that resolves properly', () => {
+    const mat = d.mat2x2f(
+      d.vec2f(0, 1), // column 0
+      d.vec2f(2, 3), // column 1
+    );
+
+    expect(tgpu.resolve({ template: 'mat', externals: { mat } })).toContain(
+      'mat2x2f(0, 1, 2, 3)',
+    );
   });
 });
 
@@ -179,6 +192,18 @@ describe('mat3x3f', () => {
     expect(mat.columns[1]).toEqual(d.vec3f(12, 13, 14));
     expect(mat.columns[2]).toEqual(d.vec3f(15, 16, 17));
     expect(d.matToArray(mat)).toEqual([9, 10, 11, 12, 13, 14, 15, 16, 17]);
+  });
+
+  it('creates a matrix that resolves properly', () => {
+    const mat = d.mat3x3f(
+      d.vec3f(0, 1, 2), // column 0
+      d.vec3f(3, 4, 5), // column 1
+      d.vec3f(6, 7, 8), // column 2
+    );
+
+    expect(tgpu.resolve({ template: 'mat', externals: { mat } })).toContain(
+      'mat3x3f(0, 1, 2, 3, 4, 5, 6, 7, 8)',
+    );
   });
 });
 
@@ -297,5 +322,18 @@ describe('mat4x4f', () => {
     expect(d.matToArray(mat)).toEqual([
       16, 17, 18, 19, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
     ]);
+  });
+
+  it('creates a matrix that resolves properly', () => {
+    const mat = d.mat4x4f(
+      d.vec4f(0, 1, 2, 3), // column 0
+      d.vec4f(4, 5, 6, 7), // column 1
+      d.vec4f(8, 9, 10, 11), // column 2
+      d.vec4f(12, 13, 14, 15), // column 3
+    );
+
+    expect(tgpu.resolve({ template: 'mat', externals: { mat } })).toContain(
+      'mat4x4f(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)',
+    );
   });
 });

--- a/packages/typegpu/tests/resolve.test.ts
+++ b/packages/typegpu/tests/resolve.test.ts
@@ -32,7 +32,7 @@ describe('tgpu resolve', () => {
         return this;
       },
 
-      resolve(ctx: ResolutionCtx) {
+      '~resolve'(ctx: ResolutionCtx) {
         ctx.addDeclaration(
           '@group(0) @binding(0) var<uniform> intensity_1: f32;',
         );

--- a/packages/typegpu/tests/slot.test.ts
+++ b/packages/typegpu/tests/slot.test.ts
@@ -135,7 +135,6 @@ describe('tgpu.slot', () => {
       new ResolutionError(new MissingSlotValueError(colorSlot), [
         resolutionRootMock,
         getColor,
-        colorSlot,
       ]),
     );
   });

--- a/packages/typegpu/tests/slot.test.ts
+++ b/packages/typegpu/tests/slot.test.ts
@@ -5,7 +5,6 @@ import tgpu, {
   MissingSlotValueError,
   ResolutionError,
 } from '../src/experimental';
-import type { TgpuResolvable } from '../src/types';
 import { parseResolved } from './utils/parseResolved';
 
 const RED = 'vec3f(1., 0., 0.)';
@@ -20,7 +19,7 @@ const resolutionRootMock = {
   toString() {
     return '<root>';
   },
-} as TgpuResolvable;
+};
 
 describe('tgpu.slot', () => {
   it('resolves to default value if no value provided', () => {
@@ -136,6 +135,7 @@ describe('tgpu.slot', () => {
       new ResolutionError(new MissingSlotValueError(colorSlot), [
         resolutionRootMock,
         getColor,
+        colorSlot,
       ]),
     );
   });


### PR DESCRIPTION
## Why?
Since we have objects that are resolved by an external mechanism (resolveData for schemas) and objects that can resolve themselves (fns, vector and matrix instances, slots, ...), the `resolve` method seems more and more like an internal API.

## This PR
- Makes the `resolve` method hidden from the public API,
- Alters the type we accept as externals in `tgpu.resolve`
- (BONUS) Makes matrix instances resolvable