### PR TITLE
Implement partial IO

### DIFF
--- a/apps/typegpu-docs/src/pages/benchmark/benchmark-app.tsx
+++ b/apps/typegpu-docs/src/pages/benchmark/benchmark-app.tsx
@@ -24,7 +24,7 @@ async function runBench(params: BenchParameterSet): Promise<BenchResults> {
 
   const bench = new Bench({
     name: stringifyLocator('typegpu', params.typegpu),
-    time: 1000,
+    time: 10000,
   });
 
   const amountOfBoids = 10000;

--- a/packages/typegpu/src/data/array.ts
+++ b/packages/typegpu/src/data/array.ts
@@ -1,4 +1,4 @@
-import type { Infer } from '../shared/repr';
+import type { Infer, InferPartial } from '../shared/repr';
 import type { Exotic } from './exotic';
 import { sizeOf } from './sizeOf';
 import type { AnyWgslData, WgslArray } from './wgslTypes';
@@ -46,6 +46,8 @@ class TgpuArrayImpl<TElement extends AnyWgslData>
   public readonly type = 'array';
   /** Type-token, not available at runtime */
   public readonly '~repr'!: Infer<TElement>[];
+  /** Type-token, not available at runtime */
+  public readonly '~reprPartial'!: Record<number, InferPartial<TElement>>;
   /** Type-token, not available at runtime */
   public readonly '~exotic'!: WgslArray<Exotic<TElement>>;
 

--- a/packages/typegpu/src/data/array.ts
+++ b/packages/typegpu/src/data/array.ts
@@ -47,7 +47,10 @@ class TgpuArrayImpl<TElement extends AnyWgslData>
   /** Type-token, not available at runtime */
   public readonly '~repr'!: Infer<TElement>[];
   /** Type-token, not available at runtime */
-  public readonly '~reprPartial'!: Record<number, InferPartial<TElement>>;
+  public readonly '~reprPartial'!: {
+    idx: number;
+    value: InferPartial<TElement>;
+  }[];
   /** Type-token, not available at runtime */
   public readonly '~exotic'!: WgslArray<Exotic<TElement>>;
 

--- a/packages/typegpu/src/data/dataTypes.ts
+++ b/packages/typegpu/src/data/dataTypes.ts
@@ -1,4 +1,9 @@
-import type { Infer, InferRecord } from '../shared/repr';
+import type {
+  Infer,
+  InferPartial,
+  InferPartialRecord,
+  InferRecord,
+} from '../shared/repr';
 import { vertexFormats } from '../shared/vertexFormat';
 import type { PackedData } from './vertexFormatData';
 import * as wgsl from './wgslTypes';
@@ -18,6 +23,7 @@ export interface Disarray<
   readonly elementCount: number;
   readonly elementType: TElement;
   readonly '~repr': Infer<TElement>[];
+  readonly '~reprPartial': Record<number, InferPartial<TElement>>;
 }
 
 /**
@@ -37,6 +43,7 @@ export interface Unstruct<
   readonly type: 'unstruct';
   readonly propTypes: TProps;
   readonly '~repr': InferRecord<TProps>;
+  readonly '~reprPartial': Partial<InferPartialRecord<TProps>>;
 }
 
 export interface LooseDecorated<

--- a/packages/typegpu/src/data/dataTypes.ts
+++ b/packages/typegpu/src/data/dataTypes.ts
@@ -23,7 +23,7 @@ export interface Disarray<
   readonly elementCount: number;
   readonly elementType: TElement;
   readonly '~repr': Infer<TElement>[];
-  readonly '~reprPartial': Record<number, InferPartial<TElement>>;
+  readonly '~reprPartial': { idx: number; value: InferPartial<TElement> }[];
 }
 
 /**

--- a/packages/typegpu/src/data/disarray.ts
+++ b/packages/typegpu/src/data/disarray.ts
@@ -1,4 +1,4 @@
-import type { Infer } from '../shared/repr';
+import type { Infer, InferPartial } from '../shared/repr';
 import type { AnyData, Disarray } from './dataTypes';
 import type { Exotic } from './exotic';
 
@@ -37,6 +37,8 @@ class DisarrayImpl<TElement extends AnyData> implements Disarray<TElement> {
   public readonly type = 'disarray';
   /** Type-token, not available at runtime */
   public readonly '~repr'!: Infer<TElement>[];
+  /** Type-token, not available at runtime */
+  public readonly '~reprPartial'!: Record<number, InferPartial<TElement>>;
 
   constructor(
     public readonly elementType: TElement,

--- a/packages/typegpu/src/data/disarray.ts
+++ b/packages/typegpu/src/data/disarray.ts
@@ -38,7 +38,10 @@ class DisarrayImpl<TElement extends AnyData> implements Disarray<TElement> {
   /** Type-token, not available at runtime */
   public readonly '~repr'!: Infer<TElement>[];
   /** Type-token, not available at runtime */
-  public readonly '~reprPartial'!: Record<number, InferPartial<TElement>>;
+  public readonly '~reprPartial'!: {
+    idx: number;
+    value: InferPartial<TElement>;
+  }[];
 
   constructor(
     public readonly elementType: TElement,

--- a/packages/typegpu/src/data/offests.ts
+++ b/packages/typegpu/src/data/offests.ts
@@ -1,0 +1,32 @@
+import { Measurer } from 'typed-binary';
+import alignIO from './alignIO';
+import { alignmentOf } from './alignmentOf';
+import { sizeOf } from './sizeOf';
+import type { BaseWgslData, WgslStruct } from './wgslTypes';
+
+const cachedOffsets = new WeakMap<WgslStruct, Record<string, number>>();
+
+export function offsetsForProps<T extends Record<string, BaseWgslData>>(
+  struct: WgslStruct<T>,
+): Record<keyof T, number> {
+  const cached = cachedOffsets.get(struct);
+  if (cached) {
+    return cached as Record<keyof T, number>;
+  }
+
+  const measurer = new Measurer();
+  const offsets: Record<keyof T, number> = {} as Record<keyof T, number>;
+  for (const key in struct.propTypes) {
+    const prop = struct.propTypes[key];
+    if (prop === undefined) {
+      throw new Error(`Property ${key} is undefined in struct`);
+    }
+
+    alignIO(measurer, alignmentOf(prop));
+    offsets[key] = measurer.size;
+    measurer.add(sizeOf(prop));
+  }
+
+  cachedOffsets.set(struct, offsets);
+  return offsets;
+}

--- a/packages/typegpu/src/data/partialIO.ts
+++ b/packages/typegpu/src/data/partialIO.ts
@@ -3,6 +3,7 @@ import { roundUp } from '../mathUtils';
 import type { Infer, InferPartial } from '../shared/repr';
 import { alignmentOf } from './alignmentOf';
 import { writeData } from './dataIO';
+import { isDisarray, isUnstruct } from './dataTypes';
 import { offsetsForProps } from './offests';
 import { sizeOf } from './sizeOf';
 import type * as wgsl from './wgslTypes';
@@ -20,7 +21,7 @@ export function getWriteInstructions<TData extends wgsl.BaseWgslData>(
   instructions: WriteInstruction[] = [],
   offset = 0,
 ): WriteInstruction[] {
-  if (isWgslStruct(schema)) {
+  if (isWgslStruct(schema) || isUnstruct(schema)) {
     for (const key in schema.propTypes) {
       const prop = schema.propTypes[key];
       if (prop === undefined) {
@@ -41,7 +42,7 @@ export function getWriteInstructions<TData extends wgsl.BaseWgslData>(
     return instructions;
   }
 
-  if (isWgslArray(schema)) {
+  if (isWgslArray(schema) || isDisarray(schema)) {
     const arraySchema = schema as wgsl.WgslArray<wgsl.AnyWgslData>;
     const elementSize = roundUp(
       sizeOf(arraySchema.elementType),

--- a/packages/typegpu/src/data/partialIO.ts
+++ b/packages/typegpu/src/data/partialIO.ts
@@ -1,0 +1,148 @@
+import { BufferWriter } from 'typed-binary';
+import { roundUp } from '../mathUtils';
+import type { Infer, InferPartial } from '../shared/repr';
+import { alignmentOf } from './alignmentOf';
+import { writeData } from './dataIO';
+import { offsetsForProps } from './offests';
+import { sizeOf } from './sizeOf';
+import type * as wgsl from './wgslTypes';
+import { isWgslArray, isWgslStruct } from './wgslTypes';
+
+export interface WriteInstruction {
+  start: number;
+  length: number;
+  data: ArrayBuffer;
+}
+
+export function getWriteInstructions<TData extends wgsl.BaseWgslData>(
+  schema: TData,
+  data: InferPartial<TData>,
+  instructions: WriteInstruction[] = [],
+  offset = 0,
+): WriteInstruction[] {
+  if (isWgslStruct(schema)) {
+    for (const key in schema.propTypes) {
+      const prop = schema.propTypes[key];
+      if (prop === undefined) {
+        throw new Error(`Property ${key} is undefined in struct`);
+      }
+      const typedData = data as Record<string, InferPartial<wgsl.AnyWgslData>>;
+      const propData = typedData[key];
+      if (propData !== undefined) {
+        const propOffset = offsetsForProps(schema)[key];
+        if (propOffset === undefined) {
+          throw new Error(`Offset for property ${key} is undefined`);
+        }
+        const newOffset = propOffset + offset;
+        getWriteInstructions(prop, propData, instructions, newOffset);
+      }
+    }
+
+    return instructions;
+  }
+
+  if (isWgslArray(schema)) {
+    const arraySchema = schema as wgsl.WgslArray<wgsl.AnyWgslData>;
+    const elementSize = roundUp(
+      sizeOf(arraySchema.elementType),
+      alignmentOf(arraySchema.elementType),
+    );
+
+    const selectedElements = data as Record<
+      number,
+      InferPartial<wgsl.AnyWgslData>
+    >;
+    for (const index in selectedElements) {
+      const elementData = selectedElements[index];
+      const newOffset = offset + elementSize * Number(index);
+      getWriteInstructions(
+        arraySchema.elementType,
+        elementData,
+        instructions,
+        newOffset,
+      );
+    }
+
+    return instructions;
+  }
+
+  if (data !== undefined) {
+    const dataLength = sizeOf(schema);
+    const dataBytes = new ArrayBuffer(dataLength);
+    writeData(new BufferWriter(dataBytes), schema, data as Infer<TData>);
+    instructions.push({
+      start: offset,
+      length: dataLength,
+      data: dataBytes,
+    });
+  }
+
+  return instructions;
+}
+
+export function combineContiguousInstructions(
+  instructions: WriteInstruction[],
+  sort = false,
+): WriteInstruction[] {
+  if (instructions.length === 0) return instructions;
+
+  // The instructions should always already be sorted (?) if coming from getWriteInstructions
+  if (sort) {
+    instructions.sort((a, b) => a.start - b.start);
+  }
+
+  const combinedInstructions: WriteInstruction[] = [];
+  let currentInstruction = instructions[0];
+
+  for (let i = 1; i < instructions.length; i++) {
+    const nextInstruction = instructions[i];
+
+    if (currentInstruction === undefined || nextInstruction === undefined) {
+      throw new Error('Instruction is undefined');
+    }
+
+    if (
+      currentInstruction.start + currentInstruction.length ===
+      nextInstruction.start
+    ) {
+      // They are contiguous, so combine them
+      const combinedLength = currentInstruction.length + nextInstruction.length;
+      const combinedData = new ArrayBuffer(combinedLength);
+      const combinedView = new Uint8Array(combinedData);
+
+      // Copy data from current instruction
+      combinedView.set(new Uint8Array(currentInstruction.data), 0);
+
+      // Copy data from next instruction
+      combinedView.set(
+        new Uint8Array(nextInstruction.data),
+        currentInstruction.length,
+      );
+
+      // Update the current instruction with the combined data
+      currentInstruction = {
+        start: currentInstruction.start,
+        length: combinedLength,
+        data: combinedData,
+      };
+    } else {
+      // Not contiguous, push the current instruction and move to the next
+      combinedInstructions.push(currentInstruction);
+      currentInstruction = nextInstruction;
+    }
+  }
+
+  if (currentInstruction !== undefined) {
+    combinedInstructions.push(currentInstruction);
+  }
+
+  return combinedInstructions;
+}
+
+export function partialWrite<TData extends wgsl.BaseWgslData>(
+  schema: TData,
+  data: InferPartial<TData>,
+): WriteInstruction[] {
+  const instructions = getWriteInstructions(schema, data);
+  return combineContiguousInstructions(instructions);
+}

--- a/packages/typegpu/src/data/partialIO.ts
+++ b/packages/typegpu/src/data/partialIO.ts
@@ -49,16 +49,19 @@ export function getWriteInstructions<TData extends wgsl.BaseWgslData>(
       alignmentOf(arraySchema.elementType),
     );
 
-    const selectedElements = data as Record<
-      number,
-      InferPartial<wgsl.AnyWgslData>
-    >;
-    for (const index in selectedElements) {
-      const elementData = selectedElements[index];
-      const newOffset = offset + elementSize * Number(index);
+    if (!Array.isArray(data)) {
+      throw new Error('Data is not an array');
+    }
+
+    for (const entry of data) {
+      const { idx, value } = entry as unknown as {
+        idx: number;
+        value: InferPartial<wgsl.AnyWgslData>;
+      };
+      const newOffset = offset + elementSize * idx;
       getWriteInstructions(
         arraySchema.elementType,
-        elementData,
+        value,
         instructions,
         newOffset,
       );

--- a/packages/typegpu/src/data/struct.ts
+++ b/packages/typegpu/src/data/struct.ts
@@ -1,5 +1,5 @@
 import type { TgpuNamable } from '../namable';
-import type { InferRecord } from '../shared/repr';
+import type { InferPartialRecord, InferRecord } from '../shared/repr';
 import type { Prettify } from '../shared/utilityTypes';
 import type { ExoticRecord } from './exotic';
 import type { AnyWgslData, BaseWgslData, WgslStruct } from './wgslTypes';
@@ -49,6 +49,8 @@ class TgpuStructImpl<TProps extends Record<string, AnyWgslData>>
   public readonly type = 'struct';
   /** Type-token, not available at runtime */
   public readonly '~repr'!: InferRecord<TProps>;
+  /** Type-token, not available at runtime */
+  public readonly '~reprPartial'!: Partial<InferPartialRecord<TProps>>;
   /** Type-token, not available at runtime */
   public readonly '~exotic'!: WgslStruct<ExoticRecord<TProps>>;
 

--- a/packages/typegpu/src/data/unstruct.ts
+++ b/packages/typegpu/src/data/unstruct.ts
@@ -1,4 +1,4 @@
-import type { InferRecord } from '../shared/repr';
+import type { InferPartialRecord, InferRecord } from '../shared/repr';
 import type { Unstruct } from './dataTypes';
 import type { ExoticRecord } from './exotic';
 import type { BaseWgslData } from './wgslTypes';
@@ -40,6 +40,8 @@ class UnstructImpl<TProps extends Record<string, BaseWgslData>>
   public readonly type = 'unstruct';
   /** Type-token, not available at runtime */
   public readonly '~repr'!: InferRecord<TProps>;
+  /** Type-token, not available at runtime */
+  public readonly '~reprPartial'!: Partial<InferPartialRecord<TProps>>;
 
   constructor(public readonly propTypes: TProps) {}
 }

--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -1,4 +1,9 @@
-import type { Infer, InferRecord } from '../shared/repr';
+import type {
+  Infer,
+  InferPartial,
+  InferPartialRecord,
+  InferRecord,
+} from '../shared/repr';
 
 export interface NumberArrayView {
   readonly length: number;
@@ -680,6 +685,7 @@ export interface WgslStruct<
   readonly propTypes: TProps;
   /** Type-token, not available at runtime */
   readonly '~repr': InferRecord<TProps>;
+  readonly '~reprPartial': Partial<InferPartialRecord<TProps>>;
 }
 
 export interface WgslArray<TElement = BaseWgslData> {
@@ -688,6 +694,7 @@ export interface WgslArray<TElement = BaseWgslData> {
   readonly elementType: TElement;
   /** Type-token, not available at runtime */
   readonly '~repr': Infer<TElement>[];
+  readonly '~reprPartial': Record<number, InferPartial<TElement>>;
 }
 
 /**

--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -698,7 +698,7 @@ export interface WgslArray<TElement = BaseWgslData> {
   readonly elementType: TElement;
   /** Type-token, not available at runtime */
   readonly '~repr': Infer<TElement>[];
-  readonly '~reprPartial': Record<number, InferPartial<TElement>>;
+  readonly '~reprPartial': { idx: number; value: InferPartial<TElement> }[];
 }
 
 /**

--- a/packages/typegpu/src/shared/repr.ts
+++ b/packages/typegpu/src/shared/repr.ts
@@ -5,7 +5,19 @@
  * type B = Infer<TgpuArray<F32>> // => number[]
  */
 export type Infer<T> = T extends { readonly '~repr': infer TRepr } ? TRepr : T;
+export type InferPartial<T> = T extends { readonly '~reprPartial': infer TRepr }
+  ? TRepr
+  : T extends { readonly '~repr': infer TRepr }
+    ? TRepr | undefined
+    : T extends Record<string | number | symbol, unknown>
+      ? InferPartialRecord<T>
+      : T;
 
 export type InferRecord<T extends Record<string | number | symbol, unknown>> = {
   [Key in keyof T]: Infer<T[Key]>;
+};
+export type InferPartialRecord<
+  T extends Record<string | number | symbol, unknown>,
+> = {
+  [Key in keyof T]: InferPartial<T[Key]>;
 };

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -181,4 +181,24 @@ describe('TgpuBuffer', () => {
         .$usage('storage');
     }).toThrow();
   });
+
+  it('should allow for partial writes', ({ root, device }) => {
+    const buffer = root.createBuffer(d.struct({ a: d.u32, b: d.u32 }));
+
+    buffer.writePartial({ a: 3 });
+
+    const rawBuffer = root.unwrap(buffer);
+    expect(rawBuffer).toBeDefined();
+
+    expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
+      [rawBuffer, 0, new Uint32Array([3]).buffer, 0, 4],
+    ]);
+
+    buffer.writePartial({ b: 4 });
+
+    expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
+      [rawBuffer, 0, new Uint32Array([3]).buffer, 0, 4],
+      [rawBuffer, 4, new Uint32Array([4]).buffer, 0, 4],
+    ]);
+  });
 });

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -230,7 +230,12 @@ describe('TgpuBuffer', () => {
       [rawBuffer, 8, new Float32Array([1, 2]).buffer, 0, 8],
     ]);
 
-    buffer.writePartial({ d: { 0: 1, 2: 3 } });
+    buffer.writePartial({
+      d: [
+        { idx: 0, value: 1 },
+        { idx: 2, value: 3 },
+      ],
+    });
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
       [rawBuffer, 0, new Uint32Array([3]).buffer, 0, 4],
@@ -249,7 +254,7 @@ describe('TgpuBuffer', () => {
       }),
     );
 
-    buffer.writePartial({ a: { 2: d.vec2f(0.5, 0.5) } });
+    buffer.writePartial({ a: [{ idx: 2, value: d.vec2f(0.5, 0.5) }] });
 
     const rawBuffer = root.unwrap(buffer);
     expect(rawBuffer).toBeDefined();

--- a/packages/typegpu/tests/partialIo.test.ts
+++ b/packages/typegpu/tests/partialIo.test.ts
@@ -66,12 +66,12 @@ describe('getWriteInstructions', () => {
 
     const data = {
       a: 3,
-      b: {
-        0: d.vec3f(1, 2, 3),
-        1: d.vec3f(4, 5, 6),
-        2: d.vec3f(7, 8, 9),
-        3: d.vec3f(10, 11, 12),
-      },
+      b: [
+        { idx: 0, value: d.vec3f(1, 2, 3) },
+        { idx: 1, value: d.vec3f(4, 5, 6) },
+        { idx: 2, value: d.vec3f(7, 8, 9) },
+        { idx: 3, value: d.vec3f(10, 11, 12) },
+      ],
       c: { d: 4 },
     };
 
@@ -95,11 +95,11 @@ describe('getWriteInstructions', () => {
     });
 
     const data = {
-      b: {
-        0: d.vec3f(1, 2, 3),
-        2: d.vec3f(7, 8, 9),
-        3: d.vec3f(10, 11, 12),
-      },
+      b: [
+        { idx: 0, value: d.vec3f(1, 2, 3) },
+        { idx: 2, value: d.vec3f(7, 8, 9) },
+        { idx: 3, value: d.vec3f(10, 11, 12) },
+      ],
       c: { d: 4 },
     };
 

--- a/packages/typegpu/tests/partialIo.test.ts
+++ b/packages/typegpu/tests/partialIo.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect } from 'vitest';
+import * as d from '../src/data';
+import { offsetsForProps } from '../src/data/offests';
+import {
+  type WriteInstruction,
+  combineContiguousInstructions,
+  getWriteInstructions,
+} from '../src/data/partialIO';
+import { it } from './utils/extendedIt';
+
+describe('offsetsForProps', () => {
+  it('should return correct offsets for props', () => {
+    const struct = d.struct({
+      a: d.u32,
+      b: d.vec3f,
+      c: d.struct({ d: d.u32 }),
+    });
+
+    const offsets = offsetsForProps(struct);
+
+    expect(offsets).toStrictEqual({ a: 0, b: 16, c: 28 });
+  });
+
+  it('should return correct offsets for props with arrays', () => {
+    const struct = d.struct({
+      a: d.u32,
+      b: d.arrayOf(d.vec3f, 4),
+      c: d.struct({ d: d.u32 }),
+    });
+
+    const offsets = offsetsForProps(struct);
+
+    expect(offsets).toStrictEqual({ a: 0, b: 16, c: 80 });
+  });
+});
+
+describe('getWriteInstructions', () => {
+  it('should return correct write instructions for props', () => {
+    const struct = d.struct({
+      a: d.u32,
+      b: d.vec3f,
+      c: d.struct({ d: d.u32 }),
+    });
+
+    const data = {
+      a: 3,
+      b: d.vec3f(1, 2, 3),
+      c: { d: 4 },
+    };
+
+    const instructions = getWriteInstructions(struct, data);
+
+    expect(instructions).toStrictEqual([
+      { start: 0, length: 4, data: new Uint32Array([3]).buffer },
+      { start: 16, length: 12, data: new Float32Array([1, 2, 3]).buffer },
+      { start: 28, length: 4, data: new Uint32Array([4]).buffer },
+    ]);
+  });
+
+  it('should return correct write instructions for props with arrays', () => {
+    const struct = d.struct({
+      a: d.u32,
+      b: d.arrayOf(d.vec3f, 4),
+      c: d.struct({ d: d.u32 }),
+    });
+
+    const data = {
+      a: 3,
+      b: {
+        0: d.vec3f(1, 2, 3),
+        1: d.vec3f(4, 5, 6),
+        2: d.vec3f(7, 8, 9),
+        3: d.vec3f(10, 11, 12),
+      },
+      c: { d: 4 },
+    };
+
+    const instructions = getWriteInstructions(struct, data);
+
+    expect(instructions).toStrictEqual([
+      { start: 0, length: 4, data: new Uint32Array([3]).buffer },
+      { start: 16, length: 12, data: new Float32Array([1, 2, 3]).buffer },
+      { start: 32, length: 12, data: new Float32Array([4, 5, 6]).buffer },
+      { start: 48, length: 12, data: new Float32Array([7, 8, 9]).buffer },
+      { start: 64, length: 12, data: new Float32Array([10, 11, 12]).buffer },
+      { start: 80, length: 4, data: new Uint32Array([4]).buffer },
+    ]);
+  });
+
+  it('should return correct write instructions for props with arrays and missing data', () => {
+    const struct = d.struct({
+      a: d.u32,
+      b: d.arrayOf(d.vec3f, 4),
+      c: d.struct({ d: d.u32 }),
+    });
+
+    const data = {
+      b: {
+        0: d.vec3f(1, 2, 3),
+        2: d.vec3f(7, 8, 9),
+        3: d.vec3f(10, 11, 12),
+      },
+      c: { d: 4 },
+    };
+
+    const instructions = getWriteInstructions(struct, data);
+
+    expect(instructions).toStrictEqual([
+      { start: 16, length: 12, data: new Float32Array([1, 2, 3]).buffer },
+      { start: 48, length: 12, data: new Float32Array([7, 8, 9]).buffer },
+      { start: 64, length: 12, data: new Float32Array([10, 11, 12]).buffer },
+      { start: 80, length: 4, data: new Uint32Array([4]).buffer },
+    ]);
+  });
+});
+
+describe('combineContiguousInstructions', () => {
+  it('should combine contiguous instructions', () => {
+    const instructions = [
+      { start: 0, length: 4, data: new Uint32Array([3]).buffer },
+      { start: 4, length: 4, data: new Uint32Array([4]).buffer },
+      { start: 8, length: 4, data: new Uint32Array([5]).buffer },
+      { start: 12, length: 4, data: new Uint32Array([6]).buffer },
+    ];
+
+    const combinedInstructions = combineContiguousInstructions(instructions);
+
+    expect(combinedInstructions).toStrictEqual([
+      { start: 0, length: 16, data: new Uint32Array([3, 4, 5, 6]).buffer },
+    ]);
+  });
+
+  it('should not combine non-contiguous instructions', () => {
+    const instructions = [
+      { start: 0, length: 4, data: new Uint32Array([3]).buffer },
+      { start: 8, length: 4, data: new Uint32Array([4]).buffer },
+      { start: 16, length: 4, data: new Uint32Array([5]).buffer },
+      { start: 24, length: 4, data: new Uint32Array([6]).buffer },
+    ];
+
+    const combinedInstructions = combineContiguousInstructions(instructions);
+
+    expect(combinedInstructions).toStrictEqual(instructions);
+  });
+
+  it('should handle empty instructions', () => {
+    const instructions = [] as WriteInstruction[];
+
+    const combinedInstructions = combineContiguousInstructions(instructions);
+
+    expect(combinedInstructions).toStrictEqual(instructions);
+  });
+
+  it('should handle partially contiguous instructions', () => {
+    const instructions = [
+      { start: 0, length: 4, data: new Uint32Array([3]).buffer },
+      { start: 4, length: 4, data: new Uint32Array([4]).buffer },
+      { start: 8, length: 4, data: new Uint32Array([5]).buffer },
+      { start: 12, length: 4, data: new Uint32Array([6]).buffer },
+      { start: 20, length: 4, data: new Uint32Array([7]).buffer },
+    ];
+
+    const combinedInstructions = combineContiguousInstructions(instructions);
+
+    expect(combinedInstructions).toStrictEqual([
+      { start: 0, length: 16, data: new Uint32Array([3, 4, 5, 6]).buffer },
+      { start: 20, length: 4, data: new Uint32Array([7]).buffer },
+    ]);
+  });
+});


### PR DESCRIPTION
closes #800 

- [x] Investigate if having one ArrayBuffer for all data is practical and faster
- [ ] Figure a way to cache calls to avoid creating instructions for the same accessed data (to speed up subsequent calls)
- [x] Support unstructs and disarrays 