### PR TITLE
🐎: Scaffolding for a benchmarking tool

### DIFF
--- a/apps/typegpu-docs/package.json
+++ b/apps/typegpu-docs/package.json
@@ -27,8 +27,10 @@
     "classnames": "^2.5.1",
     "jotai": "^2.8.4",
     "jotai-location": "^0.5.5",
+    "lucide-react": "^0.474.0",
     "lz-string": "^1.5.0",
     "monaco-editor": "^0.50.0",
+    "motion": "^12.0.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "remeda": "^2.3.0",
@@ -37,6 +39,7 @@
     "starlight-blog": "^0.12.0",
     "starlight-typedoc": "^0.17.0",
     "tailwindcss": "^3.4.6",
+    "tinybench": "^3.1.0",
     "typed-binary": "^4.0.0",
     "typedoc": "^0.27.1",
     "typedoc-plugin-markdown": "^4.3.0",
@@ -49,6 +52,7 @@
     "@types/babel__template": "^7.4.4",
     "@types/babel__traverse": "^7.20.6",
     "@webgpu/types": "^0.1.43",
-    "astro-vtbot": "^1.8.2"
+    "astro-vtbot": "^1.8.2",
+    "tailwindcss-motion": "^1.0.1"
   }
 }

--- a/apps/typegpu-docs/src/components/design/DeleteIcon.tsx
+++ b/apps/typegpu-docs/src/components/design/DeleteIcon.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import type { Variants } from 'motion/react';
+import { motion, useAnimation } from 'motion/react';
+
+const lidVariants: Variants = {
+  normal: { y: 0 },
+  animate: { y: -1.1 },
+};
+
+const springTransition = {
+  type: 'spring',
+  stiffness: 500,
+  damping: 30,
+};
+
+const DeleteIcon = () => {
+  const controls = useAnimation();
+
+  return (
+    <div
+      className="cursor-pointer select-none p-2 hover:bg-accent rounded-md transition-colors duration-200 flex items-center justify-center"
+      onMouseEnter={() => controls.start('animate')}
+      onMouseLeave={() => controls.start('normal')}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <title>Delete</title>
+        <motion.g
+          variants={lidVariants}
+          animate={controls}
+          transition={springTransition}
+        >
+          <path d="M3 6h18" />
+          <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+        </motion.g>
+        <motion.path
+          d="M19 8v12c0 1-1 2-2 2H7c-1 0-2-1-2-2V8"
+          variants={{
+            normal: { d: 'M19 8v12c0 1-1 2-2 2H7c-1 0-2-1-2-2V8' },
+            animate: { d: 'M19 9v12c0 1-1 2-2 2H7c-1 0-2-1-2-2V9' },
+          }}
+          animate={controls}
+          transition={springTransition}
+        />
+        <motion.line
+          x1="10"
+          x2="10"
+          y1="11"
+          y2="17"
+          variants={{
+            normal: { y1: 11, y2: 17 },
+            animate: { y1: 11.5, y2: 17.5 },
+          }}
+          animate={controls}
+          transition={springTransition}
+        />
+        <motion.line
+          x1="14"
+          x2="14"
+          y1="11"
+          y2="17"
+          variants={{
+            normal: { y1: 11, y2: 17 },
+            animate: { y1: 11.5, y2: 17.5 },
+          }}
+          animate={controls}
+          transition={springTransition}
+        />
+      </svg>
+    </div>
+  );
+};
+
+export { DeleteIcon };

--- a/apps/typegpu-docs/src/layouts/PageLayout.astro
+++ b/apps/typegpu-docs/src/layouts/PageLayout.astro
@@ -1,10 +1,10 @@
 ---
 import '../tailwind.css';
 import '../fonts/font-face.css';
-const { title } = Astro.props;
+const { title, theme = 'light' } = Astro.props;
 ---
 
-<html>
+<html data-theme={theme}>
   <head>
     <title>{title ? `${title} |` : ''} TypeGPU</title>
     <meta charset="UTF-8" />
@@ -49,6 +49,14 @@ const { title } = Astro.props;
         margin: 0;
       }
 
+      [data-theme='dark'] body {
+        background-color: #171724;
+        color: white;
+      }
+
+      [data-theme='light'] body {
+        background-color: white;
+      }
     </style>
   </head>
   <body>

--- a/apps/typegpu-docs/src/pages/benchmark/atom-with-url.ts
+++ b/apps/typegpu-docs/src/pages/benchmark/atom-with-url.ts
@@ -1,0 +1,68 @@
+import { atom } from 'jotai';
+import { atomWithLocation } from 'jotai-location';
+
+const locationAtom = atomWithLocation();
+
+export const stringParam = {
+  encode: (val: string) => val,
+  decode: (val: string) => val,
+};
+
+export const boolParam = {
+  encode: (val: boolean) => (val ? '1' : '0'),
+  decode: (val: string) => val === '1',
+};
+
+export const numberParam = {
+  encode: (val: number) => String(val),
+  decode: (val: string) => Number.parseFloat(val),
+};
+
+export const objParam = {
+  encode: JSON.stringify,
+  decode: JSON.parse,
+};
+
+export const typeToParam = {
+  string: stringParam,
+  boolean: boolParam,
+  number: numberParam,
+  object: objParam,
+};
+
+export const atomWithUrl = <T>(
+  key: string,
+  defaultValue: T,
+  options?: { encode: (val: T) => string; decode: (val: string) => unknown },
+) => {
+  const optionsOrInferred =
+    options ??
+    typeToParam[typeof defaultValue as keyof typeof typeToParam] ??
+    objParam;
+
+  const { encode, decode } = optionsOrInferred;
+
+  return atom(
+    (get) => {
+      const location = get(locationAtom);
+      return location.searchParams?.has(key)
+        ? (decode(location.searchParams.get(key) ?? '') as T)
+        : defaultValue;
+    },
+    (get, set, newValue: T) => {
+      const prev = get(locationAtom);
+      const searchParams = new URLSearchParams(prev.searchParams);
+      searchParams.set(key, encode(newValue));
+
+      set(
+        // biome-ignore lint/suspicious/noExplicitAny: <really annoying>
+        locationAtom as any,
+        {
+          ...prev,
+          searchParams: searchParams,
+        },
+        { replace: false },
+      );
+    },
+  );
+};

--- a/apps/typegpu-docs/src/pages/benchmark/atom-with-url.ts
+++ b/apps/typegpu-docs/src/pages/benchmark/atom-with-url.ts
@@ -55,13 +55,12 @@ export const atomWithUrl = <T>(
       searchParams.set(key, encode(newValue));
 
       set(
-        // biome-ignore lint/suspicious/noExplicitAny: <really annoying>
-        locationAtom as any,
+        locationAtom,
         {
           ...prev,
           searchParams: searchParams,
         },
-        { replace: false },
+        { replace: true },
       );
     },
   );

--- a/apps/typegpu-docs/src/pages/benchmark/benchmark-app.tsx
+++ b/apps/typegpu-docs/src/pages/benchmark/benchmark-app.tsx
@@ -1,0 +1,223 @@
+import { useAtomValue, useSetAtom } from 'jotai/react';
+import { atom } from 'jotai/vanilla';
+import { CirclePlus } from 'lucide-react';
+import { Suspense, useMemo } from 'react';
+import { Bench } from 'tinybench';
+import { importTypeGPU, importTypeGPUData } from './modules.js';
+import { ParameterSetRow } from './parameter-set-row.js';
+import {
+  type BenchParameterSet,
+  createParameterSetAtom,
+  parameterSetAtomsAtom,
+  parameterSetsAtom,
+  stringifyLocator,
+} from './parameter-set.js';
+
+interface BenchResults {
+  parameterSet: BenchParameterSet;
+  bench: Bench;
+}
+
+async function runBench(params: BenchParameterSet): Promise<BenchResults> {
+  const { tgpu } = await importTypeGPU(params.typegpu);
+  const d = await importTypeGPUData(params.typegpu);
+
+  const bench = new Bench({
+    name: stringifyLocator('typegpu', params.typegpu),
+    time: 1000,
+  });
+
+  const amountOfBoids = 10000;
+
+  bench
+    .add('mass boid transfer', async () => {
+      const root = await tgpu.init();
+
+      const Boid = d.struct({
+        pos: d.vec3f,
+        vel: d.vec3f,
+      });
+
+      const BoidArray = d.arrayOf(Boid, amountOfBoids);
+
+      const buffer = root.createBuffer(BoidArray);
+
+      buffer.write(
+        Array.from({ length: amountOfBoids }).map(() => ({
+          pos: d.vec3f(1, 2, 3),
+          vel: d.vec3f(4, 5, 6),
+        })),
+      );
+
+      root.destroy();
+    })
+    .add('mass boid transfer (manual reference)', async () => {
+      const root = await tgpu.init();
+
+      const Boid = d.struct({
+        pos: d.vec3f,
+        vel: d.vec3f,
+      });
+
+      const BoidArray = d.arrayOf(Boid, amountOfBoids);
+
+      const buffer = root.createBuffer(BoidArray);
+
+      const data = new ArrayBuffer(d.sizeOf(BoidArray));
+      const fView = new Float32Array(data);
+
+      for (let i = 0; i < amountOfBoids; ++i) {
+        fView[i * 8 + 0] = 1;
+        fView[i * 8 + 1] = 2;
+        fView[i * 8 + 2] = 3;
+
+        fView[i * 8 + 4] = 4;
+        fView[i * 8 + 5] = 5;
+        fView[i * 8 + 6] = 6;
+      }
+
+      root.device.queue.writeBuffer(root.unwrap(buffer), 0, data);
+
+      root.destroy();
+    });
+
+  await bench.run();
+
+  return { parameterSet: params, bench };
+}
+
+const benchResultsAtom = atom<Promise<BenchResults[]> | null>(null);
+
+const runBenchmarksAtom = atom(null, async (get, set) => {
+  const parameterSets = get(parameterSetsAtom);
+
+  set(
+    benchResultsAtom,
+    (async () => {
+      const results: BenchResults[] = [];
+
+      // Running each benchmark in sequence
+      for (const params of parameterSets) {
+        results.push(await runBench(params));
+      }
+
+      return results;
+    })(),
+  );
+});
+
+function SingleBenchResults(props: { results: BenchResults }) {
+  const { bench } = props.results;
+  const results = useMemo(() => bench.table(), [bench]);
+  const columns = Object.keys(results?.[0] ?? {});
+
+  return (
+    <table className="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400 mb-4">
+      <caption>{bench.name}</caption>
+      <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+        <tr>
+          {columns.map((columnKey) => (
+            <th scope="col" key={columnKey} className="px-6 py-3">
+              {columnKey}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {results.map((task) => (
+          <tr
+            key={task?.['Task name']}
+            className="bg-white border-b dark:bg-gray-800 dark:border-gray-700 border-gray-200"
+          >
+            {columns.map((columnKey) => (
+              <td key={columnKey} className="px-6 py-4">
+                {task?.[columnKey]}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function BenchmarkResults() {
+  const benchResults = useAtomValue(benchResultsAtom);
+
+  return benchResults?.map((results) => (
+    <SingleBenchResults key={results.bench.name ?? ''} results={results} />
+  ));
+}
+
+function BenchmarkFallback() {
+  return (
+    <div className="flex items-center justify-center font-sans benchmark-fallback h-32">
+      <div
+        role="status"
+        className="flex items-center gap-2 motion-preset-focus"
+      >
+        <svg
+          aria-hidden="true"
+          className="w-8 h-8 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600"
+          viewBox="0 0 100 101"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+            fill="currentColor"
+          />
+          <path
+            d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+            fill="currentFill"
+          />
+        </svg>
+        <p>Running...</p>
+      </div>
+    </div>
+  );
+}
+
+export default function BenchmarkApp() {
+  const parameterSetAtoms = useAtomValue(parameterSetAtomsAtom);
+  const runBenchmarks = useSetAtom(runBenchmarksAtom);
+  const createParameterSet = useSetAtom(createParameterSetAtom);
+
+  return (
+    <div className="px-4">
+      <div className="mx-auto p-4 my-10 flex flex-col items-center justify-between w-96 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        <p className="w-full mt-1 mb-3 text-lg">Versions to compare:</p>
+        <ul className="w-full flex flex-col items-start gap-1 my-1 list-none p-0 m-0">
+          {parameterSetAtoms.map((paramsAtom, index) => (
+            <li
+              // biome-ignore lint/suspicious/noArrayIndexKey: <it's fine React>
+              key={`${index}`}
+              className="w-full"
+            >
+              <ParameterSetRow parameterSetAtom={paramsAtom} />
+            </li>
+          ))}
+        </ul>
+        <div className="w-full">
+          <button
+            type="button"
+            className="cursor-pointer select-none p-2 flex justify-center items-center w-10 h-10 bg-transparent text-white transition-colors hover:bg-gray-700 rounded-md text-sm text-center me-2"
+            onClick={createParameterSet}
+          >
+            <CirclePlus />
+          </button>
+        </div>
+        <button
+          type="button"
+          className="mt-5 text-white bg-gradient-to-r from-purple-500 via-purple-600 to-purple-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-purple-300 dark:focus:ring-purple-800 shadow-lg shadow-purple-500/50 dark:shadow-lg dark:shadow-purple-800/80 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2"
+          onClick={runBenchmarks}
+        >
+          Run Benchmarks
+        </button>
+      </div>
+      <Suspense fallback={<BenchmarkFallback />}>
+        <BenchmarkResults />
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/typegpu-docs/src/pages/benchmark/index.astro
+++ b/apps/typegpu-docs/src/pages/benchmark/index.astro
@@ -1,0 +1,19 @@
+---
+import { Image } from 'astro:assets';
+import PageLayout from '../../layouts/PageLayout.astro';
+import BenchmarkApp from './benchmark-app.tsx';
+import TypeGPULogoDark from '../../assets/typegpu-logo-dark.svg';
+---
+
+<PageLayout title="Benchmark" theme="dark">
+  <h1 class="w-full flex items-center justify-center">
+    <Image
+      src={TypeGPULogoDark}
+      alt="TypeGPU Logo"
+      class="w-[10rem] relative"
+    />
+    <p class="text-lg font-sans">— benchmark</p>
+  </h1>
+
+  <BenchmarkApp client:only="react" />
+</PageLayout>

--- a/apps/typegpu-docs/src/pages/benchmark/modules.ts
+++ b/apps/typegpu-docs/src/pages/benchmark/modules.ts
@@ -1,0 +1,35 @@
+import type { PackageLocator } from './parameter-set.js';
+
+export type TypeGPUModule = typeof import('typegpu');
+export type TypeGPUDataModule = typeof import('typegpu/data');
+export type TypeGPUStdModule = typeof import('typegpu/std');
+
+export function importTypeGPU(locator: PackageLocator): Promise<TypeGPUModule> {
+  if (locator.type === 'local') {
+    return import('typegpu');
+  }
+
+  if (locator.type === 'npm') {
+    return import(
+      /* @vite-ignore */ `https://esm.sh/typegpu@${locator.version}/`
+    );
+  }
+
+  throw new Error('Unsupported import of `typegpu`');
+}
+
+export function importTypeGPUData(
+  locator: PackageLocator,
+): Promise<TypeGPUDataModule> {
+  if (locator.type === 'local') {
+    return import('typegpu/data');
+  }
+
+  if (locator.type === 'npm') {
+    return import(
+      /* @vite-ignore */ `https://esm.sh/typegpu@${locator.version}/data`
+    );
+  }
+
+  throw new Error('Unsupported import of `typegpu/data`');
+}

--- a/apps/typegpu-docs/src/pages/benchmark/parameter-set-row.tsx
+++ b/apps/typegpu-docs/src/pages/benchmark/parameter-set-row.tsx
@@ -1,0 +1,84 @@
+import { type PrimitiveAtom, useAtom, useSetAtom } from 'jotai';
+import { useCallback } from 'react';
+import { DeleteIcon } from '../../components/design/DeleteIcon.js';
+import {
+  type BenchParameterSet,
+  deleteParameterSetAtom,
+} from './parameter-set.js';
+
+function NpmParameters(props: {
+  parameterSetAtom: PrimitiveAtom<BenchParameterSet>;
+}) {
+  const [parameterSet, setParameterSet] = useAtom(props.parameterSetAtom);
+
+  const version =
+    parameterSet.typegpu.type === 'npm' ? parameterSet.typegpu.version : '';
+
+  const setVersion = useCallback(
+    (version: string) => {
+      setParameterSet((prev) => ({
+        ...prev,
+        typegpu: { ...prev.typegpu, version },
+      }));
+    },
+    [setParameterSet],
+  );
+
+  return (
+    <>
+      <p className="text-sm">typegpu@</p>
+      <input
+        type="text"
+        className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-1 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+        value={version}
+        onChange={(e) => setVersion(e.target.value)}
+        placeholder="0.0.0"
+      />
+    </>
+  );
+}
+
+export function ParameterSetRow(props: {
+  parameterSetAtom: PrimitiveAtom<BenchParameterSet>;
+}) {
+  const [parameterSet, setParameterSet] = useAtom(props.parameterSetAtom);
+  const deleteParameterSet = useSetAtom(deleteParameterSetAtom);
+
+  const typeValue = parameterSet.typegpu.type;
+
+  const setType = useCallback(
+    (type: 'local' | 'npm') => {
+      setParameterSet((prev) => ({
+        ...prev,
+        typegpu: { type },
+      }));
+    },
+    [setParameterSet],
+  );
+
+  return (
+    <div className="w-full flex gap-4 justify-between items-center relative">
+      <button
+        type="button"
+        className="p-0 bg-transparent text-white transition-colors hover:bg-gray-700 rounded-md"
+        onClick={() => deleteParameterSet(parameterSet.key)}
+      >
+        <DeleteIcon />
+      </button>
+      <select
+        className="w-20 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+        value={typeValue}
+        onChange={(event) => setType(event.target.value as 'local' | 'npm')}
+      >
+        <option value="local">local</option>
+        <option value="npm">npm</option>
+      </select>
+      <div className="flex-1 flex justify-start items-center">
+        {typeValue === 'local' && <p className="text-sm">typegpu</p>}
+        {typeValue === 'npm' && (
+          <NpmParameters parameterSetAtom={props.parameterSetAtom} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/typegpu-docs/src/pages/benchmark/parameter-set-row.tsx
+++ b/apps/typegpu-docs/src/pages/benchmark/parameter-set-row.tsx
@@ -66,12 +66,13 @@ export function ParameterSetRow(props: {
         <DeleteIcon />
       </button>
       <select
-        className="w-20 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+        className="w-22 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
         value={typeValue}
+        data-value={typeValue}
         onChange={(event) => setType(event.target.value as 'local' | 'npm')}
       >
-        <option value="local">local</option>
-        <option value="npm">npm</option>
+        <option value="local">📌 local</option>
+        <option value="npm">⬇️ npm</option>
       </select>
       <div className="flex-1 flex justify-start items-center">
         {typeValue === 'local' && <p className="text-sm">typegpu</p>}

--- a/apps/typegpu-docs/src/pages/benchmark/parameter-set.ts
+++ b/apps/typegpu-docs/src/pages/benchmark/parameter-set.ts
@@ -1,0 +1,64 @@
+import { type Getter, atom } from 'jotai';
+import { splitAtom } from 'jotai/utils';
+import { atomWithUrl } from './atom-with-url.js';
+
+export type PackageLocator =
+  | {
+      type: 'npm';
+      version?: string;
+    }
+  | {
+      type: 'local';
+    };
+
+export interface BenchParameterSet {
+  key: number;
+  typegpu: PackageLocator;
+}
+
+export function stringifyLocator(
+  name: string,
+  locator: PackageLocator,
+): string {
+  if (locator.type === 'npm') {
+    return `${name}@${locator.version}`;
+  }
+
+  if (locator.type === 'local') {
+    return `${name}:local`;
+  }
+
+  return name;
+}
+
+function getFreeKey(get: Getter): number {
+  return Math.max(...get(parameterSetsAtom).map((params) => params.key)) + 1;
+}
+
+export const parameterSetsAtom = atomWithUrl<BenchParameterSet[]>('p', [
+  { key: 1, typegpu: { type: 'local' } },
+  { key: 2, typegpu: { type: 'npm', version: 'latest' } },
+]);
+
+export const parameterSetAtomsAtom = splitAtom(
+  parameterSetsAtom,
+  (params) => params.key,
+);
+
+export const createParameterSetAtom = atom(null, (get, set) => {
+  const prev = get(parameterSetsAtom);
+  const key = getFreeKey(get);
+
+  set(parameterSetsAtom, [
+    ...prev,
+    { key, typegpu: { type: 'npm', version: '' } },
+  ]);
+});
+
+export const deleteParameterSetAtom = atom(null, (get, set, key: number) => {
+  const prev = get(parameterSetsAtom);
+  set(
+    parameterSetsAtom,
+    prev.filter((params) => params.key !== key),
+  );
+});

--- a/apps/typegpu-docs/tailwind.config.mjs
+++ b/apps/typegpu-docs/tailwind.config.mjs
@@ -1,4 +1,7 @@
 import starlightPlugin from '@astrojs/starlight-tailwind';
+import tailwindcssMotion from 'tailwindcss-motion';
+// @ts-check
+import plugin from 'tailwindcss/plugin';
 
 const accent = {
   200: '#c3c4f1',
@@ -17,6 +20,7 @@ const gray = {
   900: '#171724',
 };
 
+/** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   theme: {
@@ -70,5 +74,11 @@ export default {
       lg: '1441px',
     },
   },
-  plugins: [starlightPlugin()],
+  plugins: [
+    starlightPlugin(),
+    tailwindcssMotion,
+    plugin(({ addVariant }) => {
+      addVariant('starting', '@starting-style');
+    }),
+  ],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,12 +83,18 @@ importers:
       jotai-location:
         specifier: ^0.5.5
         version: 0.5.5(jotai@2.8.4)
+      lucide-react:
+        specifier: ^0.474.0
+        version: 0.474.0(react@18.3.1)
       lz-string:
         specifier: ^1.5.0
         version: 1.5.0
       monaco-editor:
         specifier: ^0.50.0
         version: 0.50.0
+      motion:
+        specifier: ^12.0.5
+        version: 12.0.5(react-dom@18.3.1)(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -113,6 +119,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.6
         version: 3.4.6
+      tinybench:
+        specifier: ^3.1.0
+        version: 3.1.0
       typed-binary:
         specifier: ^4.0.0
         version: 4.0.0
@@ -147,6 +156,9 @@ importers:
       astro-vtbot:
         specifier: ^1.8.2
         version: 1.10.7
+      tailwindcss-motion:
+        specifier: ^1.0.1
+        version: 1.0.1(tailwindcss@3.4.6)
 
   packages/rollup-plugin:
     dependencies:
@@ -336,7 +348,6 @@ packages:
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-    dev: false
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -2856,7 +2867,6 @@ packages:
 
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
-    dev: false
 
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -3174,7 +3184,6 @@ packages:
   /camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
-    dev: false
 
   /camelcase@7.0.1:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
@@ -3397,7 +3406,6 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: false
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -3487,7 +3495,6 @@ packages:
 
   /didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
-    dev: false
 
   /diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
@@ -3512,7 +3519,6 @@ packages:
 
   /dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
-    dev: false
 
   /dpdm@3.14.0:
     resolution: {integrity: sha512-YJzsFSyEtj88q5eTELg3UWU7TVZkG1dpbF4JDQ3t1b07xuzXmdoGeSz9TKOke1mUuOpWlk4q+pBh+aHzD6GBTg==}
@@ -3826,6 +3832,27 @@ packages:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
     dev: false
 
+  /framer-motion@12.0.5(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-OgfUHfL+u80uCf6VzkV7j3+H2W9zPMdV+40bug4ftB0C2+0FpfNca2rbH2Fouq2R7//bjw6tJhOwXsrsM4+LKw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      motion-dom: 12.0.0
+      motion-utils: 12.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.6.3
+    dev: false
+
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     dev: false
@@ -3848,7 +3875,6 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: false
 
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -3904,7 +3930,6 @@ packages:
     engines: {node: '>=10.13.0'}
     dependencies:
       is-glob: 4.0.3
-    dev: false
 
   /glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
@@ -3975,7 +4000,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: false
 
   /hast-util-embedded@3.0.0:
     resolution: {integrity: sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==}
@@ -4280,7 +4304,6 @@ packages:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
     dependencies:
       hasown: 2.0.1
-    dev: false
 
   /is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
@@ -4401,7 +4424,6 @@ packages:
   /jiti@1.21.6:
     resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
     hasBin: true
-    dev: false
 
   /jotai-location@0.5.5(jotai@2.8.4):
     resolution: {integrity: sha512-6QW/7W9IJHjhbn7gRgAw4sC30k0/G6JiC4uPlKi8ZPZGYk7R7r9PyMD2eVhL4XSxxag89JxS1iSyr6BIXsB4Sw==}
@@ -4493,7 +4515,6 @@ packages:
   /lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
-    dev: false
 
   /lilconfig@3.1.0:
     resolution: {integrity: sha512-p3cz0JV5vw/XeouBU3Ldnp+ZkBjE+n8ydJ4mcwBrOiXXPqNlrzGBqWs9X4MWF7f+iKUBu794Y8Hh8yawiJbCjw==}
@@ -4579,6 +4600,14 @@ packages:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
       yallist: 3.1.1
+    dev: false
+
+  /lucide-react@0.474.0(react@18.3.1):
+    resolution: {integrity: sha512-CmghgHkh0OJNmxGKWc0qfPJCYHASPMVSyGY8fj3xgk4v84ItqDg64JNKFZn5hC6E0vHi6gxnbCgwhyVB09wQtA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    dependencies:
+      react: 18.3.1
     dev: false
 
   /lunr@2.3.9:
@@ -5300,6 +5329,36 @@ packages:
   /moo@0.5.2:
     resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
 
+  /motion-dom@12.0.0:
+    resolution: {integrity: sha512-CvYd15OeIR6kHgMdonCc1ihsaUG4MYh/wrkz8gZ3hBX/uamyZCXN9S9qJoYF03GqfTt7thTV/dxnHYX4+55vDg==}
+    dependencies:
+      motion-utils: 12.0.0
+    dev: false
+
+  /motion-utils@12.0.0:
+    resolution: {integrity: sha512-MNFiBKbbqnmvOjkPyOKgHUp3Q6oiokLkI1bEwm5QA28cxMZrv0CbbBGDNmhF6DIXsi1pCQBSs0dX8xjeER1tmA==}
+    dev: false
+
+  /motion@12.0.5(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-AFCMJWX7xtd2V4PEuL+FnVscw++SaMZuFXrm3kjN1sIqrNDJdJrFbZ2B+pfq6CKlcTor/vVJcmrc2pJqF3EByw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      framer-motion: 12.0.5(react-dom@18.3.1)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.6.3
+    dev: false
+
   /mrmime@2.0.0:
     resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
     engines: {node: '>=10'}
@@ -5402,7 +5461,6 @@ packages:
   /object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
-    dev: false
 
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -5557,7 +5615,6 @@ packages:
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: false
 
   /path-scurry@1.10.1:
     resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
@@ -5614,7 +5671,6 @@ packages:
   /pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -5642,7 +5698,6 @@ packages:
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.8
-    dev: false
 
   /postcss-js@4.0.1(postcss@8.4.39):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
@@ -5652,7 +5707,6 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.39
-    dev: false
 
   /postcss-load-config@4.0.2(postcss@8.4.39):
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
@@ -5678,7 +5732,6 @@ packages:
     dependencies:
       postcss: 8.4.39
       postcss-selector-parser: 6.1.0
-    dev: false
 
   /postcss-selector-parser@6.1.0:
     resolution: {integrity: sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==}
@@ -5686,11 +5739,9 @@ packages:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-    dev: false
 
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-    dev: false
 
   /postcss@8.4.39:
     resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
@@ -5869,7 +5920,6 @@ packages:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
     dependencies:
       pify: 2.3.0
-    dev: false
 
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -6054,7 +6104,6 @@ packages:
       is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: false
 
   /restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -6522,7 +6571,14 @@ packages:
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: false
+
+  /tailwindcss-motion@1.0.1(tailwindcss@3.4.6):
+    resolution: {integrity: sha512-ZqarvI3XSclT46Dq1wOo9qG9Yx0TIyEtkMfTo8l0JuVKvO1WiSbvAECuTqdYHpC9Ml7abuJIk7u907SBHYprwQ==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
+    dependencies:
+      tailwindcss: 3.4.6
+    dev: true
 
   /tailwindcss@3.4.6:
     resolution: {integrity: sha512-1uRHzPB+Vzu57ocybfZ4jh5Q3SdlH7XW23J5sQoM9LhE9eIOlzxer/3XPSsycvih3rboRsvt0QCmzSrqyOYUIA==}
@@ -6553,7 +6609,6 @@ packages:
       sucrase: 3.35.0
     transitivePeerDependencies:
       - ts-node
-    dev: false
 
   /tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
@@ -6613,6 +6668,11 @@ packages:
   /tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
     dev: true
+
+  /tinybench@3.1.0:
+    resolution: {integrity: sha512-Km+oMh2xqNCxuyoUsqbRmHgFSd8sATh7v7xreP+kHN6x67w28Pawr83WmBxcaORvxkc0Ex6zgqK951yBnTFaaQ==}
+    engines: {node: '>=18.0.0'}
+    dev: false
 
   /tinyexec@0.3.1:
     resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}


### PR DESCRIPTION

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/afb642c9-1229-45bb-8a36-b2d66ef087fd" />


## Motivation
As we're focusing more and more on performance, I thought a tool for comparing different versions of TypeGPU in the same benchmarks would be a nice tool to have.

Leveraging [esm.sh](https://esm.sh), we can download and run any version of TypeGPU that exists on npm. They also promise that installing packages from PRs should work fine as well, which we could use to:
- Allow a "PR" type of version, synced to the URL like the rest of the state.
- Create a GitHub bot that comments on new PRs with a link to the benchmark, with the id of that PR.

This would allow us to see the performance impact of a PR's changes without having to checkout that code locally 🚀

## This PR
- Creates a new route in the docs site: `docs.swmansion.com/TypeGPU/benchmark`
- Adds two benchmarks that measure the speed of writing to buffers (one with our APIs, the other by manually writing values to the buffer).
