### PR TITLE
fix: Make babel plugin target only calls to does with a function expression inside

### DIFF
--- a/packages/unplugin-typegpu/src/babel.ts
+++ b/packages/unplugin-typegpu/src/babel.ts
@@ -34,8 +34,8 @@ function functionVisitor(ctx: Context): TraverseOptions {
 
         if (
           implementation &&
-          !(implementation.type === 'TemplateLiteral') &&
-          !(implementation.type === 'StringLiteral')
+          (implementation.type === 'FunctionExpression' ||
+            implementation.type === 'ArrowFunctionExpression')
         ) {
           const { argNames, body, externalNames } = transpileFn(implementation);
 


### PR DESCRIPTION
This makes it work for cases where `.does()` was already transformed, e.g., for libraries using TypeGPU. This also works with `.does` method calls that don't originate from TypeGPU.