### PR TITLE
Add multisampling to function visualizer

### DIFF
--- a/apps/typegpu-docs/src/content/examples/rendering/function-visualizer/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/function-visualizer/index.ts
@@ -181,13 +181,29 @@ const renderBackgroundPipeline = device.createRenderPipeline({
   primitive: {
     topology: 'triangle-strip',
   },
+  multisample: {
+    count: 4,
+  },
 });
+
+const msTexture = device.createTexture({
+  size: [
+    canvas.clientWidth * window.devicePixelRatio,
+    canvas.clientHeight * window.devicePixelRatio,
+  ],
+  sampleCount: 4,
+  format: presentationFormat,
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+
+const msView = msTexture.createView();
 
 const renderBackgroundPassDescriptor = {
   label: 'Render pass',
   colorAttachments: [
     {
-      view: undefined as unknown as GPUTextureView,
+      view: msView,
+      resolveTarget: context.getCurrentTexture().createView(),
       clearValue: [1.0, 1.0, 1.0, 1] as const,
       loadOp: 'clear' as const,
       storeOp: 'store' as const,
@@ -265,13 +281,17 @@ const renderPipeline = device.createRenderPipeline({
   primitive: {
     topology: 'triangle-strip',
   },
+  multisample: {
+    count: 4,
+  },
 });
 
 const renderPassDescriptor = {
   label: 'Render pass',
   colorAttachments: [
     {
-      view: undefined as unknown as GPUTextureView,
+      view: msView,
+      resolveTarget: context.getCurrentTexture().createView(),
       clearValue: [0.3, 0.3, 0.3, 1] as const,
       loadOp: 'load' as const,
       storeOp: 'store' as const,
@@ -327,7 +347,7 @@ function runRenderBackgroundPass() {
     properties: propertiesBuffer,
   });
 
-  renderBackgroundPassDescriptor.colorAttachments[0].view = context
+  renderBackgroundPassDescriptor.colorAttachments[0].resolveTarget = context
     .getCurrentTexture()
     .createView();
 
@@ -344,7 +364,7 @@ function runRenderBackgroundPass() {
 }
 
 function runRenderPass() {
-  renderPassDescriptor.colorAttachments[0].view = context
+  renderPassDescriptor.colorAttachments[0].resolveTarget = context
     .getCurrentTexture()
     .createView();
 


### PR DESCRIPTION
I think this example will benefit much from it as smooth lines are prone to aliasing

Before:
<img width="651" alt="Screenshot 2025-02-19 at 10 55 50" src="https://github.com/user-attachments/assets/0129a0c9-980c-4b50-9e42-7dc6e5b2886d" />
After:
<img width="651" alt="Screenshot 2025-02-19 at 10 55 55" src="https://github.com/user-attachments/assets/4ead90d0-b354-4b0d-92aa-86acab98512a" />

