### PR TITLE
chore: Deprecate and rename extension types to avoid ambiguity

### DIFF
--- a/apps/typegpu-docs/src/content/docs/fundamentals/bind-groups.mdx
+++ b/apps/typegpu-docs/src/content/docs/fundamentals/bind-groups.mdx
@@ -230,7 +230,7 @@ If you accidentally pass the wrong type of resource, the TypeScript compiler wil
   - `TgpuBuffer<TData> & Uniform` - buffers of type `TData` with `'uniform'` usage,
   - `GPUBuffer` - raw WebGPU buffers.
 - **Storage** bindings with schema `TData` accept:
-  - `TgpuBuffer<TData> & Storage` - buffers of type `TData` with `'storage'` usage,
+  - `TgpuBuffer<TData> & StorageFlag` - buffers of type `TData` with `'storage'` usage,
   - `GPUBuffer` - raw WebGPU buffers.
 - **Texture** bindings:
   - `GPUTextureView` - views of raw WebGPU textures.

--- a/apps/typegpu-docs/src/content/docs/fundamentals/bind-groups.mdx
+++ b/apps/typegpu-docs/src/content/docs/fundamentals/bind-groups.mdx
@@ -227,7 +227,7 @@ const fooBindGroup1 = root.createBindGroup(fooLayout, {
 If you accidentally pass the wrong type of resource, the TypeScript compiler will catch the error at compile time.
 
 - **Uniform** bindings with schema `TData` accept:
-  - `TgpuBuffer<TData> & Uniform` - buffers of type `TData` with `'uniform'` usage,
+  - `TgpuBuffer<TData> & UniformFlag` - buffers of type `TData` with `'uniform'` usage,
   - `GPUBuffer` - raw WebGPU buffers.
 - **Storage** bindings with schema `TData` accept:
   - `TgpuBuffer<TData> & StorageFlag` - buffers of type `TData` with `'storage'` usage,

--- a/apps/typegpu-docs/src/content/docs/fundamentals/buffers.mdx
+++ b/apps/typegpu-docs/src/content/docs/fundamentals/buffers.mdx
@@ -105,7 +105,7 @@ const buffer = root.createBuffer(d.u32)
 :::note
 Along with passing the appropriate flags to WebGPU, the methods will also embed type information into the buffer.
 ```ts
-// TgpuBuffer<d.U32> & Uniform & StorageFlag
+// TgpuBuffer<d.U32> & UniformFlag & StorageFlag
 const buffer = root.createBuffer(d.u32)
   .$usage('uniform', 'storage');
 ```

--- a/apps/typegpu-docs/src/content/docs/fundamentals/buffers.mdx
+++ b/apps/typegpu-docs/src/content/docs/fundamentals/buffers.mdx
@@ -105,7 +105,7 @@ const buffer = root.createBuffer(d.u32)
 :::note
 Along with passing the appropriate flags to WebGPU, the methods will also embed type information into the buffer.
 ```ts
-// TgpuBuffer<d.U32> & Uniform & Storage
+// TgpuBuffer<d.U32> & Uniform & StorageFlag
 const buffer = root.createBuffer(d.u32)
   .$usage('uniform', 'storage');
 ```

--- a/apps/typegpu-docs/src/content/docs/integration/webgpu-interoperability.mdx
+++ b/apps/typegpu-docs/src/content/docs/integration/webgpu-interoperability.mdx
@@ -37,7 +37,7 @@ const rawLayout = root.unwrap(layout); // => GPUBindGroupLayout
 
 ```ts
 const numbersBuffer = root.createBuffer(d.f32).$usage('uniform');
-//    ^? TgpuBuffer<d.F32> & Uniform
+//    ^? TgpuBuffer<d.F32> & UniformFlag
 
 const rawNumbersBuffer = root.unwrap(numbersBuffer); // => GPUBuffer
 

--- a/apps/typegpu-docs/src/content/docs/integration/webgpu-interoperability.mdx
+++ b/apps/typegpu-docs/src/content/docs/integration/webgpu-interoperability.mdx
@@ -95,7 +95,7 @@ const layout = tgpu.bindGroupLayout({
 });
 
 const aBuffer = root.createBuffer(d.f32, 0.5).$usage('uniform');
-//    ^? TgpuBuffer<d.F32> & Uniform
+//    ^? TgpuBuffer<d.F32> & UniformFlag
 
 const bBuffer = root.device.createBuffer({
   size: Uint32Array.BYTES_PER_ELEMENT,

--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { type TgpuBuffer, type Storage } from 'typegpu';
+import tgpu, { type TgpuBuffer, type StorageFlag } from 'typegpu';
 import * as d from 'typegpu/data';
 
 const SIZE = 28;
@@ -73,19 +73,19 @@ const pipeline = device.createComputePipeline({
 
 interface LayerData {
   shape: readonly [number] | readonly [number, number];
-  buffer: TgpuBuffer<d.WgslArray<d.F32>> & Storage;
+  buffer: TgpuBuffer<d.WgslArray<d.F32>> & StorageFlag;
 }
 
 interface Layer {
-  weights: TgpuBuffer<d.WgslArray<d.F32>> & Storage;
-  biases: TgpuBuffer<d.WgslArray<d.F32>> & Storage;
-  state: TgpuBuffer<d.WgslArray<d.F32>> & Storage;
+  weights: TgpuBuffer<d.WgslArray<d.F32>> & StorageFlag;
+  biases: TgpuBuffer<d.WgslArray<d.F32>> & StorageFlag;
+  state: TgpuBuffer<d.WgslArray<d.F32>> & StorageFlag;
 }
 
 interface Network {
   layers: Layer[];
-  input: TgpuBuffer<d.WgslArray<d.F32>> & Storage;
-  output: TgpuBuffer<d.WgslArray<d.F32>> & Storage;
+  input: TgpuBuffer<d.WgslArray<d.F32>> & StorageFlag;
+  output: TgpuBuffer<d.WgslArray<d.F32>> & StorageFlag;
 
   inference(data: number[]): Promise<number[]>;
 }

--- a/packages/typegpu/src/core/buffer/buffer.ts
+++ b/packages/typegpu/src/core/buffer/buffer.ts
@@ -5,7 +5,7 @@ import type { AnyData } from '../../data/dataTypes';
 import { getWriteInstructions } from '../../data/partialIO';
 import { sizeOf } from '../../data/sizeOf';
 import type { BaseData, WgslTypeLiteral } from '../../data/wgslTypes';
-import type { Storage } from '../../extension';
+import type { StorageFlag } from '../../extension';
 import type { TgpuNamable } from '../../namable';
 import type { Infer, InferPartial } from '../../shared/repr';
 import type { MemIdentity } from '../../shared/repr';
@@ -38,7 +38,7 @@ type LiteralToUsageType<T extends 'uniform' | 'storage' | 'vertex'> =
   T extends 'uniform'
     ? Uniform
     : T extends 'storage'
-      ? Storage
+      ? StorageFlag
       : T extends 'vertex'
         ? Vertex
         : never;

--- a/packages/typegpu/src/core/buffer/buffer.ts
+++ b/packages/typegpu/src/core/buffer/buffer.ts
@@ -35,9 +35,14 @@ export interface UniformFlag {
  */
 export type Uniform = UniformFlag;
 
-export interface Vertex {
+export interface VertexFlag {
   usableAsVertex: true;
 }
+
+/**
+ * @deprecated Use VertexFlag instead.
+ */
+export type Vertex = VertexFlag;
 
 type LiteralToUsageType<T extends 'uniform' | 'storage' | 'vertex'> =
   T extends 'uniform'
@@ -45,7 +50,7 @@ type LiteralToUsageType<T extends 'uniform' | 'storage' | 'vertex'> =
     : T extends 'storage'
       ? StorageFlag
       : T extends 'vertex'
-        ? Vertex
+        ? VertexFlag
         : never;
 
 type ViewUsages<TBuffer extends TgpuBuffer<BaseData>> =
@@ -115,8 +120,8 @@ export function isBuffer<T extends TgpuBuffer<AnyData>>(
 
 export function isUsableAsVertex<T extends TgpuBuffer<AnyData>>(
   buffer: T,
-): buffer is T & Vertex {
-  return !!(buffer as unknown as Vertex).usableAsVertex;
+): buffer is T & VertexFlag {
+  return !!(buffer as unknown as VertexFlag).usableAsVertex;
 }
 
 // --------------

--- a/packages/typegpu/src/core/buffer/buffer.ts
+++ b/packages/typegpu/src/core/buffer/buffer.ts
@@ -26,9 +26,14 @@ import {
 // Public API
 // ----------
 
-export interface Uniform {
+export interface UniformFlag {
   usableAsUniform: true;
 }
+
+/**
+ * @deprecated Use UniformFlag instead.
+ */
+export type Uniform = UniformFlag;
 
 export interface Vertex {
   usableAsVertex: true;
@@ -36,7 +41,7 @@ export interface Vertex {
 
 type LiteralToUsageType<T extends 'uniform' | 'storage' | 'vertex'> =
   T extends 'uniform'
-    ? Uniform
+    ? UniformFlag
     : T extends 'storage'
       ? StorageFlag
       : T extends 'vertex'

--- a/packages/typegpu/src/core/buffer/bufferUsage.ts
+++ b/packages/typegpu/src/core/buffer/bufferUsage.ts
@@ -11,7 +11,7 @@ import type {
   SelfResolvable,
 } from '../../types';
 import { valueProxyHandler } from '../valueProxyUtils';
-import type { TgpuBuffer, Uniform } from './buffer';
+import type { TgpuBuffer, UniformFlag } from './buffer';
 
 // ----------
 // Public API
@@ -48,8 +48,8 @@ export interface TgpuBufferMutable<TData extends BaseData>
 
 export function isUsableAsUniform<T extends TgpuBuffer<AnyData>>(
   buffer: T,
-): buffer is T & Uniform {
-  return !!(buffer as unknown as Uniform).usableAsUniform;
+): buffer is T & UniformFlag {
+  return !!(buffer as unknown as UniformFlag).usableAsUniform;
 }
 
 // --------------
@@ -242,7 +242,7 @@ const uniformUsageMap = new WeakMap<
  * @deprecated Use buffer.as('uniform') instead.
  */
 export function asUniform<TData extends AnyWgslData>(
-  buffer: TgpuBuffer<TData> & Uniform,
+  buffer: TgpuBuffer<TData> & UniformFlag,
 ): TgpuBufferUniform<TData> & TgpuFixedBufferUsage<TData> {
   if (!isUsableAsUniform(buffer)) {
     throw new Error(

--- a/packages/typegpu/src/core/buffer/bufferUsage.ts
+++ b/packages/typegpu/src/core/buffer/bufferUsage.ts
@@ -1,6 +1,6 @@
 import type { AnyData } from '../../data/dataTypes';
 import type { AnyWgslData, BaseData } from '../../data/wgslTypes';
-import { type Storage, isUsableAsStorage } from '../../extension';
+import { type StorageFlag, isUsableAsStorage } from '../../extension';
 import { inGPUMode } from '../../gpuMode';
 import type { TgpuNamable } from '../../namable';
 import type { Infer } from '../../shared/repr';
@@ -190,7 +190,7 @@ const mutableUsageMap = new WeakMap<
  * @deprecated Use buffer.as('mutable') instead.
  */
 export function asMutable<TData extends AnyWgslData>(
-  buffer: TgpuBuffer<TData> & Storage,
+  buffer: TgpuBuffer<TData> & StorageFlag,
 ): TgpuBufferMutable<TData> & TgpuFixedBufferUsage<TData> {
   if (!isUsableAsStorage(buffer)) {
     throw new Error(
@@ -216,7 +216,7 @@ const readonlyUsageMap = new WeakMap<
  * @deprecated Use buffer.as('readonly') instead.
  */
 export function asReadonly<TData extends AnyWgslData>(
-  buffer: TgpuBuffer<TData> & Storage,
+  buffer: TgpuBuffer<TData> & StorageFlag,
 ): TgpuBufferReadonly<TData> & TgpuFixedBufferUsage<TData> {
   if (!isUsableAsStorage(buffer)) {
     throw new Error(

--- a/packages/typegpu/src/core/pipeline/renderPipeline.ts
+++ b/packages/typegpu/src/core/pipeline/renderPipeline.ts
@@ -1,4 +1,4 @@
-import type { TgpuBuffer, Vertex } from '../../core/buffer/buffer';
+import type { TgpuBuffer, VertexFlag } from '../../core/buffer/buffer';
 import type { Disarray } from '../../data/dataTypes';
 import type { AnyWgslData, WgslArray } from '../../data/wgslTypes';
 import {
@@ -40,7 +40,7 @@ export interface TgpuRenderPipeline<Output extends IOLayout = IOLayout>
 
   with<TData extends WgslArray | Disarray>(
     vertexLayout: TgpuVertexLayout<TData>,
-    buffer: TgpuBuffer<TData> & Vertex,
+    buffer: TgpuBuffer<TData> & VertexFlag,
   ): TgpuRenderPipeline<IOLayout>;
   with<Entries extends Record<string, TgpuLayoutEntry | null>>(
     bindGroupLayout: TgpuBindGroupLayout<Entries>,
@@ -208,7 +208,7 @@ export function isRenderPipeline(value: unknown): value is TgpuRenderPipeline {
 
 type TgpuRenderPipelinePriors = {
   readonly vertexLayoutMap?:
-    | Map<TgpuVertexLayout, TgpuBuffer<AnyWgslData> & Vertex>
+    | Map<TgpuVertexLayout, TgpuBuffer<AnyWgslData> & VertexFlag>
     | undefined;
   readonly bindGroupLayoutMap?:
     | Map<TgpuBindGroupLayout, TgpuBindGroup>
@@ -244,7 +244,7 @@ class TgpuRenderPipelineImpl
 
   with<TData extends WgslArray<AnyWgslData>>(
     vertexLayout: TgpuVertexLayout<TData>,
-    buffer: TgpuBuffer<TData> & Vertex,
+    buffer: TgpuBuffer<TData> & VertexFlag,
   ): TgpuRenderPipeline;
   with(
     bindGroupLayout: TgpuBindGroupLayout,
@@ -252,7 +252,7 @@ class TgpuRenderPipelineImpl
   ): TgpuRenderPipeline;
   with(
     definition: TgpuVertexLayout | TgpuBindGroupLayout,
-    resource: (TgpuBuffer<AnyWgslData> & Vertex) | TgpuBindGroup,
+    resource: (TgpuBuffer<AnyWgslData> & VertexFlag) | TgpuBindGroup,
   ): TgpuRenderPipeline {
     if (isBindGroupLayout(definition)) {
       return new TgpuRenderPipelineImpl(this.core, {
@@ -269,7 +269,7 @@ class TgpuRenderPipelineImpl
         ...this.priors,
         vertexLayoutMap: new Map([
           ...(this.priors.vertexLayoutMap ?? []),
-          [definition, resource as TgpuBuffer<AnyWgslData> & Vertex],
+          [definition, resource as TgpuBuffer<AnyWgslData> & VertexFlag],
         ]),
       });
     }

--- a/packages/typegpu/src/core/root/init.ts
+++ b/packages/typegpu/src/core/root/init.ts
@@ -29,7 +29,7 @@ import {
 import {
   INTERNAL_createBuffer,
   type TgpuBuffer,
-  type Vertex,
+  type VertexFlag,
   isBuffer,
 } from '../buffer/buffer';
 import type {
@@ -424,7 +424,7 @@ class TgpuRootImpl
       TgpuVertexLayout,
       {
         buffer:
-          | (TgpuBuffer<WgslArray<BaseData> | Disarray<BaseData>> & Vertex)
+          | (TgpuBuffer<WgslArray<BaseData> | Disarray<BaseData>> & VertexFlag)
           | GPUBuffer;
         offset?: number | undefined;
         size?: number | undefined;

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -12,7 +12,7 @@ import type {
   TgpuLayoutEntry,
 } from '../../tgpuBindGroupLayout';
 import type { Unwrapper } from '../../unwrapper';
-import type { TgpuBuffer, Vertex } from '../buffer/buffer';
+import type { TgpuBuffer, VertexFlag } from '../buffer/buffer';
 import type {
   TgpuBufferMutable,
   TgpuBufferReadonly,
@@ -283,7 +283,7 @@ export interface RenderPass {
 
   setVertexBuffer<TData extends WgslArray | Disarray>(
     vertexLayout: TgpuVertexLayout<TData>,
-    buffer: (TgpuBuffer<TData> & Vertex) | GPUBuffer,
+    buffer: (TgpuBuffer<TData> & VertexFlag) | GPUBuffer,
     offset?: GPUSize64,
     size?: GPUSize64,
   ): void;

--- a/packages/typegpu/src/core/texture/usageExtension.ts
+++ b/packages/typegpu/src/core/texture/usageExtension.ts
@@ -1,4 +1,4 @@
-import type { Storage } from '../../extension';
+import type { StorageFlag } from '../../extension';
 import type { StorageTextureTexelFormat } from './textureFormats';
 import type { TextureProps } from './textureProps';
 
@@ -11,7 +11,7 @@ export interface Render {
 }
 
 export type LiteralToExtensionMap = {
-  storage: Storage; // <- shared between buffers and textures
+  storage: StorageFlag; // <- shared between buffers and textures
   sampled: Sampled;
   render: Render;
 };

--- a/packages/typegpu/src/extension.ts
+++ b/packages/typegpu/src/extension.ts
@@ -8,14 +8,17 @@ export type ExtensionGuard<TFlag, TMsg, TAllowed> = boolean extends TFlag
 
 // #region Shared usage extensions
 
-export interface Storage {
+export interface StorageFlag {
   usableAsStorage: true;
 }
 
-export const Storage = { usableAsStorage: true } as Storage;
+/**
+ * @deprecated Use StorageFlag instead.
+ */
+export type Storage = StorageFlag;
 
-export function isUsableAsStorage<T>(value: T): value is T & Storage {
-  return !!(value as unknown as Storage)?.usableAsStorage;
+export function isUsableAsStorage<T>(value: T): value is T & StorageFlag {
+  return !!(value as unknown as StorageFlag)?.usableAsStorage;
 }
 
 /**

--- a/packages/typegpu/src/index.ts
+++ b/packages/typegpu/src/index.ts
@@ -106,6 +106,7 @@ export type { TgpuRenderPipeline } from './core/pipeline/renderPipeline';
 export type { TgpuComputePipeline } from './core/pipeline/computePipeline';
 export type {
   TgpuBuffer,
+  UniformFlag,
   Uniform,
   Vertex,
 } from './core/buffer/buffer';

--- a/packages/typegpu/src/index.ts
+++ b/packages/typegpu/src/index.ts
@@ -108,6 +108,7 @@ export type {
   TgpuBuffer,
   UniformFlag,
   Uniform,
+  VertexFlag,
   Vertex,
 } from './core/buffer/buffer';
 export type {

--- a/packages/typegpu/src/index.ts
+++ b/packages/typegpu/src/index.ts
@@ -100,7 +100,7 @@ export type {
   WithFragment,
   WithVertex,
 } from './core/root/rootTypes';
-export type { Storage } from './extension';
+export type { StorageFlag, Storage } from './extension';
 export type { TgpuVertexLayout } from './core/vertexLayout/vertexLayout';
 export type { TgpuRenderPipeline } from './core/pipeline/renderPipeline';
 export type { TgpuComputePipeline } from './core/pipeline/computePipeline';

--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -1,4 +1,8 @@
-import { type TgpuBuffer, type Uniform, isBuffer } from './core/buffer/buffer';
+import {
+  type TgpuBuffer,
+  type UniformFlag,
+  isBuffer,
+} from './core/buffer/buffer';
 import {
   type TgpuBufferMutable,
   type TgpuBufferReadonly,
@@ -265,7 +269,9 @@ type GetStorageTextureRestriction<T extends TgpuLayoutStorageTexture> = Default<
 
 export type LayoutEntryToInput<T extends TgpuLayoutEntry | null> =
   T extends TgpuLayoutUniform
-    ? (TgpuBuffer<UnwrapRuntimeConstructor<T['uniform']>> & Uniform) | GPUBuffer
+    ?
+        | (TgpuBuffer<UnwrapRuntimeConstructor<T['uniform']>> & UniformFlag)
+        | GPUBuffer
     : T extends TgpuLayoutStorage
       ?
           | (TgpuBuffer<UnwrapRuntimeConstructor<T['storage']>> & StorageFlag)

--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -43,7 +43,11 @@ import {
 import type { AnyData } from './data';
 import type { AnyWgslData, BaseData } from './data/wgslTypes';
 import { NotUniformError } from './errors';
-import { NotStorageError, type Storage, isUsableAsStorage } from './extension';
+import {
+  NotStorageError,
+  type StorageFlag,
+  isUsableAsStorage,
+} from './extension';
 import type { TgpuNamable } from './namable';
 import type { Default, OmitProps, Prettify } from './shared/utilityTypes';
 import type { TgpuShaderStage } from './types';
@@ -264,7 +268,7 @@ export type LayoutEntryToInput<T extends TgpuLayoutEntry | null> =
     ? (TgpuBuffer<UnwrapRuntimeConstructor<T['uniform']>> & Uniform) | GPUBuffer
     : T extends TgpuLayoutStorage
       ?
-          | (TgpuBuffer<UnwrapRuntimeConstructor<T['storage']>> & Storage)
+          | (TgpuBuffer<UnwrapRuntimeConstructor<T['storage']>> & StorageFlag)
           | GPUBuffer
       : T extends TgpuLayoutSampler
         ? TgpuSampler | GPUSampler
@@ -280,7 +284,7 @@ export type LayoutEntryToInput<T extends TgpuLayoutEntry | null> =
             : T extends TgpuLayoutStorageTexture
               ?
                   | GPUTextureView
-                  | (Storage &
+                  | (StorageFlag &
                       TgpuTexture<
                         Prettify<TextureProps & GetStorageTextureRestriction<T>>
                       >)
@@ -669,15 +673,15 @@ export class TgpuBindGroupImpl<
 
               if (entry.access === 'readonly') {
                 resource = unwrapper.unwrap(
-                  (value as TgpuTexture & Storage).createView('readonly'),
+                  (value as TgpuTexture & StorageFlag).createView('readonly'),
                 );
               } else if (entry.access === 'mutable') {
                 resource = unwrapper.unwrap(
-                  (value as TgpuTexture & Storage).createView('mutable'),
+                  (value as TgpuTexture & StorageFlag).createView('mutable'),
                 );
               } else {
                 resource = unwrapper.unwrap(
-                  (value as TgpuTexture & Storage).createView('writeonly'),
+                  (value as TgpuTexture & StorageFlag).createView('writeonly'),
                 );
               }
             } else {


### PR DESCRIPTION
Closes #899 

- Add UniformFlag, StorageFlag and VertexFlag interfaces.
- Deprecate Uniform, Storage and Vertex interfaces.


<details>
  <summary>Example code for testing:</summary>

  ```javascript
  import * as d from 'typegpu/data';
  import tgpu, {
    type TgpuBuffer,
    type Storage,
    type StorageFlag,
    type Uniform,
    type UniformFlag,
    type Vertex,
    type VertexFlag,
  } from 'typegpu';
  
  const root = await tgpu.init();
  
  const storageBuffer1: TgpuBuffer<d.Vec2f> & Storage = root
    .createBuffer(d.vec2f)
    .$usage('storage');
  const storageBuffer2: TgpuBuffer<d.Vec2f> & StorageFlag = root
    .createBuffer(d.vec2f)
    .$usage('storage');
  
  const uniformBuffer1: TgpuBuffer<d.Vec2f> & Uniform = root
    .createBuffer(d.vec2f)
    .$usage('uniform');
  const uniformBuffer2: TgpuBuffer<d.Vec2f> & UniformFlag = root
    .createBuffer(d.vec2f)
    .$usage('uniform');
  
  const vertexBuffer1: TgpuBuffer<d.Vec2f> & Vertex = root
    .createBuffer(d.vec2f)
    .$usage('vertex');
  const vertexBuffer2: TgpuBuffer<d.Vec2f> & VertexFlag = root
    .createBuffer(d.vec2f)
    .$usage('vertex');

  ```
</details>
