### PR TITLE
chore: Linking from source directory in local dev

### DIFF
--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -18,6 +18,7 @@
   "exports": "./src/index.ts",
   "publishConfig": {
     "directory": "dist",
+    "linkDirectory": false,
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {

--- a/packages/tgpu-jit/package.json
+++ b/packages/tgpu-jit/package.json
@@ -8,6 +8,7 @@
   "exports": "./src/index.ts",
   "publishConfig": {
     "directory": "dist",
+    "linkDirectory": false,
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {

--- a/packages/tgpu-wgsl-parser/package.json
+++ b/packages/tgpu-wgsl-parser/package.json
@@ -11,6 +11,7 @@
   },
   "publishConfig": {
     "directory": "dist",
+    "linkDirectory": false,
     "main": "./dist/index.js",
     "types": "./index.d.ts",
     "exports": {

--- a/packages/tinyest-for-wgsl/package.json
+++ b/packages/tinyest-for-wgsl/package.json
@@ -8,6 +8,7 @@
   "exports": "./src/index.ts",
   "publishConfig": {
     "directory": "dist",
+    "linkDirectory": false,
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {

--- a/packages/tinyest/package.json
+++ b/packages/tinyest/package.json
@@ -8,6 +8,7 @@
   "exports": "./src/index.ts",
   "publishConfig": {
     "directory": "dist",
+    "linkDirectory": false,
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {

--- a/packages/typegpu/package.json
+++ b/packages/typegpu/package.json
@@ -12,6 +12,7 @@
   },
   "publishConfig": {
     "directory": "dist",
+    "linkDirectory": false,
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {

--- a/packages/unplugin-typegpu/package.json
+++ b/packages/unplugin-typegpu/package.json
@@ -29,6 +29,7 @@
   },
   "publishConfig": {
     "directory": "dist",
+    "linkDirectory": false,
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {


### PR DESCRIPTION
## Why?

`publishConfig.directory` was causing pnpm to link all libraries to that directory, something I had to fix manually each time a dependency changed. This change fixes that.