### PR TITLE
fix: Stackblitz canvas resize observers

### DIFF
--- a/apps/typegpu-docs/src/components/stackblitz/openInStackBlitz.ts
+++ b/apps/typegpu-docs/src/components/stackblitz/openInStackBlitz.ts
@@ -33,7 +33,7 @@ export const openInStackBlitz = (example: Example) => {
       template: 'node',
       title: example.metadata.title,
       files: {
-        'index.ts': index.slice('// @ts-ignore\n'.length),
+        'index.ts': index.replaceAll(/\/\/\s*@ts-ignore\s*\n/g, ''),
         ...tsFiles,
         'index.html': `\
 <!DOCTYPE html>

--- a/apps/typegpu-docs/src/components/stackblitz/stackBlitzIndex.ts
+++ b/apps/typegpu-docs/src/components/stackblitz/stackBlitzIndex.ts
@@ -1,6 +1,3 @@
-// @ts-ignore
-import * as example from './src/index.ts';
-
 const body = document.querySelector('body') as HTMLBodyElement;
 body.style.display = 'flex';
 body.style.flexDirection = 'column';
@@ -66,6 +63,10 @@ if (body.firstChild) {
 } else {
   body.appendChild(controlsPanel);
 }
+
+// Execute example
+// @ts-ignore
+const example = import('./src/index.ts');
 
 // Create example controls
 for (const controls of Object.values(example)) {


### PR DESCRIPTION
closes #1025 

the order of resize observers caused bugs in "two boxes" example. now this example (on stackblitz) doesn't break on resize and isn't squished at the start