### PR TITLE
feat: layout.value

### DIFF
--- a/apps/typegpu-docs/src/content/examples/rendering/3d-fish/compute.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/3d-fish/compute.ts
@@ -2,11 +2,8 @@ import tgpu from 'typegpu';
 import * as d from 'typegpu/data';
 import * as std from 'typegpu/std';
 import * as p from './params';
-import { computeBindGroupLayout } from './schemas';
+import { computeBindGroupLayout as layout } from './schemas';
 import { distanceVectorFromLine } from './tgsl-helpers';
-
-const { currentFishData, nextFishData, mouseRay, timePassed } =
-  computeBindGroupLayout.bound;
 
 export const computeShader = tgpu['~unstable']
   .computeFn({
@@ -15,7 +12,7 @@ export const computeShader = tgpu['~unstable']
   })
   .does((input) => {
     const fishIndex = input.gid.x;
-    const fishData = currentFishData.value[fishIndex];
+    const fishData = layout.$.currentFishData[fishIndex];
     let separation = d.vec3f();
     let alignment = d.vec3f();
     let alignmentCount = 0;
@@ -29,7 +26,7 @@ export const computeShader = tgpu['~unstable']
         continue;
       }
 
-      const other = currentFishData.value[i];
+      const other = layout.$.currentFishData[i];
       const dist = std.length(std.sub(fishData.position, other.position));
       if (dist < p.fishSeparationDistance) {
         separation = std.add(
@@ -74,10 +71,10 @@ export const computeShader = tgpu['~unstable']
       }
     }
 
-    if (mouseRay.value.activated === 1) {
+    if (layout.$.mouseRay.activated === 1) {
       const distanceVector = distanceVectorFromLine(
-        mouseRay.value.pointX,
-        mouseRay.value.pointY,
+        layout.$.mouseRay.pointX,
+        layout.$.mouseRay.pointY,
         fishData.position,
       );
       const limit = p.fishMouseRayRepulsionDistance;
@@ -113,10 +110,10 @@ export const computeShader = tgpu['~unstable']
     );
 
     const translation = std.mul(
-      d.f32(std.min(999, timePassed.value)) / 8,
+      d.f32(std.min(999, layout.$.timePassed)) / 8,
       fishData.direction,
     );
     fishData.position = std.add(fishData.position, translation);
-    nextFishData.value[fishIndex] = fishData;
+    layout.$.nextFishData[fishIndex] = fishData;
   })
   .$name('compute shader');

--- a/apps/typegpu-docs/src/content/examples/rendering/box-raytracing/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/box-raytracing/index.ts
@@ -92,13 +92,13 @@ const boxSizeUniform = root['~unstable']
 
 // bind groups and layouts
 
-const renderBindGroupLayout = tgpu.bindGroupLayout({
+const renderLayout = tgpu.bindGroupLayout({
   boxMatrix: { storage: boxMatrixBuffer.dataType },
   cameraPosition: { storage: cameraPositionBuffer.dataType },
   cameraAxes: { storage: cameraAxesBuffer.dataType },
 });
 
-const renderBindGroup = root.createBindGroup(renderBindGroupLayout, {
+const renderBindGroup = root.createBindGroup(renderLayout, {
   boxMatrix: boxMatrixBuffer,
   cameraPosition: cameraPositionBuffer,
   cameraAxes: cameraAxesBuffer,
@@ -256,7 +256,7 @@ const fragmentFunction = tgpu['~unstable']
   return color;
 }`)
   .$uses({
-    ...renderBindGroupLayout.bound,
+    ...renderLayout.bound,
     RayStruct,
     getBoxIntersection,
     X,
@@ -283,7 +283,7 @@ const pipeline = root['~unstable']
   .withVertex(vertexFunction, {})
   .withFragment(fragmentFunction, { format: presentationFormat })
   .createPipeline()
-  .with(renderBindGroupLayout, renderBindGroup);
+  .with(renderLayout, renderBindGroup);
 
 // UI
 

--- a/packages/typegpu/src/core/resolve/externals.ts
+++ b/packages/typegpu/src/core/resolve/externals.ts
@@ -68,7 +68,7 @@ export function addReturnTypeToExternals(
 
 function identifierRegex(name: string) {
   return new RegExp(
-    `(?<![\\w_.])${name.replaceAll('.', '\\.')}(?![\\w_])`,
+    `(?<![\\w\\$_.])${name.replaceAll('.', '\\.').replaceAll('$', '\\$')}(?![\\w\\$_])`,
     'g',
   );
 }
@@ -100,7 +100,7 @@ export function replaceExternalsInWgsl(
         [
           ...wgsl.matchAll(
             new RegExp(
-              `${externalName.replaceAll('.', '\\.')}\\.(?<prop>.*?)(?![\\w_])`,
+              `${externalName.replaceAll('.', '\\.').replaceAll('$', '\\$')}\\.(?<prop>.*?)(?![\\w\\$_])`,
               'g',
             ),
           ),

--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -48,7 +48,7 @@ import {
   type Sampled,
   isUsableAsSampled,
 } from './core/texture/usageExtension';
-import type { AnyData } from './data';
+import type { AnyData } from './data/dataTypes.js';
 import type { AnyWgslData, BaseData } from './data/wgslTypes';
 import { NotUniformError } from './errors';
 import {
@@ -57,6 +57,7 @@ import {
   isUsableAsStorage,
 } from './extension';
 import type { TgpuNamable } from './namable';
+import type { Infer } from './shared/repr.js';
 import type { Default, OmitProps, Prettify } from './shared/utilityTypes';
 import type { TgpuShaderStage } from './types';
 import type { Unwrapper } from './unwrapper';
@@ -163,6 +164,12 @@ export interface TgpuBindGroupLayout<
   readonly entries: Entries;
   readonly bound: {
     [K in keyof Entries]: BindLayoutEntry<Entries[K]>;
+  };
+  readonly value: {
+    [K in keyof Entries]: InferLayoutEntry<Entries[K]>;
+  };
+  readonly $: {
+    [K in keyof Entries]: InferLayoutEntry<Entries[K]>;
   };
 
   /**
@@ -309,9 +316,27 @@ export type LayoutEntryToInput<T extends TgpuLayoutEntry | null> =
 
 export type BindLayoutEntry<T extends TgpuLayoutEntry | null> =
   T extends TgpuLayoutUniform
-    ? TgpuBufferUniform<UnwrapRuntimeConstructor<T['uniform']>>
+    ? TgpuBufferUniform<T['uniform']>
     : T extends TgpuLayoutStorage
       ? StorageUsageForEntry<T>
+      : T extends TgpuLayoutSampler
+        ? TgpuSampler
+        : T extends TgpuLayoutComparisonSampler
+          ? TgpuComparisonSampler
+          : T extends TgpuLayoutTexture
+            ? TgpuSampledTexture<
+                Default<GetDimension<T['viewDimension']>, '2d'>,
+                ChannelFormatToSchema[T['texture']]
+              >
+            : T extends TgpuLayoutStorageTexture
+              ? StorageTextureUsageForEntry<T>
+              : never;
+
+export type InferLayoutEntry<T extends TgpuLayoutEntry | null> =
+  T extends TgpuLayoutUniform
+    ? Infer<T['uniform']>
+    : T extends TgpuLayoutStorage
+      ? Infer<UnwrapRuntimeConstructor<T['storage']>>
       : T extends TgpuLayoutSampler
         ? TgpuSampler
         : T extends TgpuLayoutComparisonSampler
@@ -392,6 +417,14 @@ class TgpuBindGroupLayoutImpl<
     [K in keyof Entries]: BindLayoutEntry<Entries[K]>;
   };
 
+  public readonly value = {} as {
+    [K in keyof Entries]: InferLayoutEntry<Entries[K]>;
+  };
+
+  public readonly $ = this.value as {
+    [K in keyof Entries]: InferLayoutEntry<Entries[K]>;
+  };
+
   constructor(public readonly entries: Entries) {
     let idx = 0;
 
@@ -461,8 +494,29 @@ class TgpuBindGroupLayoutImpl<
         }
       }
 
+      if (
+        'texture' in entry ||
+        'storageTexture' in entry ||
+        'externalTexture' in entry ||
+        'sampler' in entry
+      ) {
+        // biome-ignore lint/suspicious/noExplicitAny: <no need for type magic>
+        (this.value as any)[key] = this.bound[key];
+      } else {
+        Object.defineProperty(this.value, key, {
+          get: () => {
+            // biome-ignore lint/suspicious/noExplicitAny: <no need for type magic>
+            return (this.bound[key] as any).value;
+          },
+        });
+      }
+
       idx++;
     }
+  }
+
+  toString(): string {
+    return `bindGroupLayout:${this._label ?? '<unnamed>'}`;
   }
 
   get label(): string | undefined {


### PR DESCRIPTION
## Why?
To avoid double "unwrapping" of the layout entries, e.g., `layout.bound.foo.value`.