### PR TITLE
bump: typegpu v0.5.4, unplugin-typegpu v0.1.0-alpha.8, tinyest, tinyest-for-wgsl

### DIFF
--- a/packages/tgpu-jit/package.json
+++ b/packages/tgpu-jit/package.json
@@ -56,7 +56,7 @@
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af",
   "dependencies": {
     "acorn": "^8.14.1",
-    "tinyest": "workspace:~0.1.0-alpha.6",
-    "tinyest-for-wgsl": "workspace:~0.1.0-alpha.7"
+    "tinyest": "workspace:~0.1.0-alpha.7",
+    "tinyest-for-wgsl": "workspace:~0.1.0-alpha.8"
   }
 }

--- a/packages/tinyest-for-wgsl/package.json
+++ b/packages/tinyest-for-wgsl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyest-for-wgsl",
   "private": true,
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Transforms JavaScript into its 'tinyest' form, to be used in generating equivalent (or close to) WGSL code.",
   "license": "MIT",
   "type": "module",
@@ -60,6 +60,6 @@
   },
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af",
   "dependencies": {
-    "tinyest": "workspace:~0.1.0-alpha.6"
+    "tinyest": "workspace:~0.1.0-alpha.7"
   }
 }

--- a/packages/tinyest/jsr.json
+++ b/packages/tinyest/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@typegpu/tinyest",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "license": "MIT",
   "exports": "./src/index.ts",
   "publish": {

--- a/packages/tinyest/package.json
+++ b/packages/tinyest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyest",
   "private": true,
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "A compact, fast, and embeddable JavaScript AST for transpilation.",
   "license": "MIT",
   "type": "module",

--- a/packages/typegpu/package.json
+++ b/packages/typegpu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typegpu",
   "private": true,
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A thin layer between JS and WebGPU/WGSL that improves development experience and allows for faster iteration.",
   "license": "MIT",
   "type": "module",

--- a/packages/typegpu/package.json
+++ b/packages/typegpu/package.json
@@ -78,7 +78,7 @@
   },
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af",
   "dependencies": {
-    "tinyest": "workspace:~0.1.0-alpha.6",
+    "tinyest": "workspace:~0.1.0-alpha.7",
     "typed-binary": "^4.3.1"
   }
 }

--- a/packages/unplugin-typegpu/package.json
+++ b/packages/unplugin-typegpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unplugin-typegpu",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Build plugins for TypeGPU, enabling seamless JavaScript -> WGSL transpilation and improved debugging.",
   "keywords": [
     "rollup-plugin",
@@ -108,7 +108,7 @@
     "@babel/standalone": "^7.26.6",
     "estree-walker": "^3.0.3",
     "magic-string": "^0.30.11",
-    "tinyest-for-wgsl": "workspace:~0.1.0-alpha.7",
+    "tinyest-for-wgsl": "workspace:~0.1.0-alpha.8",
     "unplugin": "^2.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,10 +266,10 @@ importers:
         specifier: ^8.14.1
         version: 8.14.1
       tinyest:
-        specifier: workspace:~0.1.0-alpha.6
+        specifier: workspace:~0.1.0-alpha.7
         version: link:../tinyest
       tinyest-for-wgsl:
-        specifier: workspace:~0.1.0-alpha.7
+        specifier: workspace:~0.1.0-alpha.8
         version: link:../tinyest-for-wgsl
     devDependencies:
       '@typegpu/tgpu-dev-cli':
@@ -337,7 +337,7 @@ importers:
   packages/tinyest-for-wgsl:
     dependencies:
       tinyest:
-        specifier: workspace:~0.1.0-alpha.6
+        specifier: workspace:~0.1.0-alpha.7
         version: link:../tinyest
     devDependencies:
       '@babel/parser':
@@ -363,7 +363,7 @@ importers:
   packages/typegpu:
     dependencies:
       tinyest:
-        specifier: workspace:~0.1.0-alpha.6
+        specifier: workspace:~0.1.0-alpha.7
         version: link:../tinyest
       typed-binary:
         specifier: ^4.3.1
@@ -463,7 +463,7 @@ importers:
         specifier: ^0.30.11
         version: 0.30.17
       tinyest-for-wgsl:
-        specifier: workspace:~0.1.0-alpha.7
+        specifier: workspace:~0.1.0-alpha.8
         version: link:../tinyest-for-wgsl
       unplugin:
         specifier: ^2.2.0


### PR DESCRIPTION
> [!CAUTION]  
> This version of the plugin requires the newest version of typegpu, which is not yet released.