### PR TITLE
feat: Automatic tgpu objects naming in `unplugin-typegpu`

### DIFF
--- a/packages/typegpu/src/core/function/astUtils.ts
+++ b/packages/typegpu/src/core/function/astUtils.ts
@@ -1,4 +1,5 @@
 import type { ArgNames, Block } from 'tinyest';
+import { isNamable } from '../../namable';
 
 export type Ast = {
   argNames: ArgNames;
@@ -37,4 +38,10 @@ export function removedJsImpl(name?: string) {
       `The function "${name ?? '<unnamed>'}" is invokable only on the GPU. If you want to use it on the CPU, mark it with the "kernel & js" directive.`,
     );
   };
+}
+
+export function autoName(object: unknown, label: string) {
+  if (isNamable(object)) {
+    object.$name(label);
+  }
 }

--- a/packages/typegpu/src/core/function/astUtils.ts
+++ b/packages/typegpu/src/core/function/astUtils.ts
@@ -40,8 +40,8 @@ export function removedJsImpl(name?: string) {
   };
 }
 
-export function autoName(object: unknown, label: string) {
-  if (isNamable(object)) {
-    object.$name(label);
-  }
+export function autoName<T>(object: T, label: string): T {
+  return isNamable(object) && 'label' in object && object.label !== undefined
+    ? object.$name(label)
+    : object;
 }

--- a/packages/typegpu/src/index.ts
+++ b/packages/typegpu/src/index.ts
@@ -4,7 +4,7 @@
 
 import { constant } from './core/constant/tgpuConstant';
 import { declare } from './core/declare/tgpuDeclare';
-import { assignAst, removedJsImpl, autoName } from './core/function/astUtils';
+import { assignAst, autoName, removedJsImpl } from './core/function/astUtils';
 import { computeFn } from './core/function/tgpuComputeFn';
 import { fn } from './core/function/tgpuFn';
 import { fragmentFn } from './core/function/tgpuFragmentFn';

--- a/packages/typegpu/src/index.ts
+++ b/packages/typegpu/src/index.ts
@@ -4,7 +4,7 @@
 
 import { constant } from './core/constant/tgpuConstant';
 import { declare } from './core/declare/tgpuDeclare';
-import { assignAst, removedJsImpl } from './core/function/astUtils';
+import { assignAst, removedJsImpl, autoName } from './core/function/astUtils';
 import { computeFn } from './core/function/tgpuComputeFn';
 import { fn } from './core/function/tgpuFn';
 import { fragmentFn } from './core/function/tgpuFragmentFn';
@@ -54,6 +54,7 @@ export default tgpu;
 Object.assign(tgpu, {
   __assignAst: assignAst,
   __removedJsImpl: removedJsImpl,
+  __autoName: autoName,
 });
 
 export {

--- a/packages/unplugin-typegpu/src/common.ts
+++ b/packages/unplugin-typegpu/src/common.ts
@@ -8,11 +8,13 @@ export type Context = {
    */
   tgpuAliases: Set<string>;
   fileId?: string | undefined;
+  autoNamingEnabled?: boolean | undefined;
 };
 
 export interface TypegpuPluginOptions {
   include?: 'all' | RegExp[];
   forceTgpuAlias?: string;
+  autoNamingEnabled?: boolean;
 }
 
 export function embedJSON(jsValue: unknown) {
@@ -25,7 +27,10 @@ export function embedJSON(jsValue: unknown) {
  * Checks if `node` is an alias for the 'tgpu' object, traditionally
  * available via `import tgpu from 'typegpu'`.
  */
-function isTgpu(ctx: Context, node: babel.Node | acorn.AnyNode): boolean {
+export function isTgpu(
+  ctx: Context,
+  node: babel.Node | acorn.AnyNode,
+): boolean {
   let path = '';
 
   let tail = node;

--- a/packages/unplugin-typegpu/test/auto-naming.test.ts
+++ b/packages/unplugin-typegpu/test/auto-naming.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { babelTransform } from './transform';
+
+describe('[BABEL] automatic naming', () => {
+  it('works for vertex layouts', () => {
+    const code = `\
+      import tgpu from 'typegpu';
+
+      const vertexLayout = tgpu.vertexLayout((n) =>
+        d.arrayOf(d.location(0, d.vec2f), n),
+      );
+
+      const vertexLayoutWithName = tgpu.vertexLayout((n) =>
+        d.arrayOf(d.location(0, d.vec2f), n),
+      ).$name('customName');
+
+      const vertexLayoutUnstable = tgpu['unstable'].vertexLayout((n) =>
+        d.arrayOf(d.location(0, d.vec2f), n),
+      );
+    `;
+
+    expect(
+      babelTransform(code, { autoNamingEnabled: true }),
+    ).toMatchInlineSnapshot(`
+      "import tgpu from 'typegpu';
+      const vertexLayout = tgpu.__autoName(tgpu.vertexLayout(n => d.arrayOf(d.location(0, d.vec2f), n)), "vertexLayout");
+      const vertexLayoutWithName = tgpu.__autoName(tgpu.vertexLayout(n => d.arrayOf(d.location(0, d.vec2f), n)), "vertexLayoutWithName").$name('customName');
+      const vertexLayoutUnstable = tgpu.__autoName(tgpu['unstable'].vertexLayout(n => d.arrayOf(d.location(0, d.vec2f), n)), "vertexLayoutUnstable");"
+    `);
+  });
+
+  it('works for functions', () => {
+    // TODO: need to name functions with implementations, not shells
+  });
+});
+
+// TODO:
+
+// describe('[ROLLUP] tgpu alias gathering', async () => {
+//   it('works for vertex layouts', async () => {
+//     const code = `\
+//       import tgpu from 'typegpu';
+
+//       const vertexLayout = tgpu.vertexLayout((n) =>
+//         d.arrayOf(d.location(0, d.vec2f), n),
+//       );
+
+//       const vertexLayoutWithName = tgpu.vertexLayout((n) =>
+//         d.arrayOf(d.location(0, d.vec2f), n),
+//       ).$name('customName');
+
+//       const vertexLayoutUnstable = tgpu['unstable'].vertexLayout((n) =>
+//         d.arrayOf(d.location(0, d.vec2f), n),
+//       );
+//     `;
+
+//     expect(
+//       await rollupTransform(code, { autoNamingEnabled: true }),
+//     ).toMatchInlineSnapshot(`
+//       "import tgpu from 'typegpu';
+//       const vertexLayout = tgpu.__autoName(tgpu.vertexLayout((n) => d.arrayOf(d.location(0, d.vec2f), n)), "vertexLayout");
+//       const vertexLayoutWithName = tgpu.__autoName(tgpu.vertexLayout((n) => d.arrayOf(d.location(0, d.vec2f), n)), "vertexLayoutWithName").$name('customName');
+//       const vertexLayoutUnstable = tgpu.__autoName(tgpu['unstable'].vertexLayout((n) => d.arrayOf(d.location(0, d.vec2f), n)), "vertexLayoutUnstable");"
+//     `);
+//   });
+// });

--- a/packages/unplugin-typegpu/test/transform.ts
+++ b/packages/unplugin-typegpu/test/transform.ts
@@ -5,7 +5,10 @@ import type { TypegpuPluginOptions } from '../src';
 import babelPlugin from '../src/babel';
 import rollupPlugin from '../src/rollup';
 
-const defaultPluginOptions: TypegpuPluginOptions = { include: 'all' };
+const defaultPluginOptions: TypegpuPluginOptions = {
+  include: 'all',
+  autoNamingEnabled: false,
+};
 
 export const babelTransform = (
   code: string,


### PR DESCRIPTION
closes #710 

left to do:

- [ ] Rollup
- [ ] objects created through root