### PR TITLE
docs: Better meta title

### DIFF
--- a/apps/typegpu-docs/src/layouts/PageLayout.astro
+++ b/apps/typegpu-docs/src/layouts/PageLayout.astro
@@ -6,7 +6,7 @@ const { title, theme = 'light' } = Astro.props;
 
 <html data-theme={theme}>
   <head>
-    <title>{title ? `${title} |` : ''} TypeGPU</title>
+    <title>{title ?? 'TypeGPU'}</title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/TypeGPU/favicon.svg" />

--- a/apps/typegpu-docs/src/pages/benchmark/index.astro
+++ b/apps/typegpu-docs/src/pages/benchmark/index.astro
@@ -5,7 +5,7 @@ import BenchmarkApp from './benchmark-app.tsx';
 import TypeGPULogoDark from '../../assets/typegpu-logo-dark.svg';
 ---
 
-<PageLayout title="Benchmark" theme="dark">
+<PageLayout title="Benchmark | TypeGPU" theme="dark">
   <h1 class="w-full flex items-center justify-center">
     <Image
       src={TypeGPULogoDark}

--- a/apps/typegpu-docs/src/pages/examples/index.astro
+++ b/apps/typegpu-docs/src/pages/examples/index.astro
@@ -3,6 +3,6 @@ import { ExampleLayout } from '../../components/ExampleLayout';
 import PageLayout from '../../layouts/PageLayout.astro';
 ---
 
-<PageLayout title="Live Examples">
+<PageLayout title="Live Examples | TypeGPU">
   <ExampleLayout client:only="react" />
 </PageLayout>

--- a/apps/typegpu-docs/src/pages/index.astro
+++ b/apps/typegpu-docs/src/pages/index.astro
@@ -23,7 +23,7 @@ import PageLayout from '../layouts/PageLayout.astro';
 const showcaseVideoResolution = [2048, 1200];
 ---
 
-<PageLayout>
+<PageLayout title="TypeGPU – Type-safe WebGPU toolkit">
   <main
     class="flex flex-col items-center bg-tameplum-50 lg:gap-[7.5rem] gap-10 md:gap-20">
     <section


### PR DESCRIPTION
This is to improve the look of typegpu.com in searches

**Before:**
<img width="693" alt="image" src="https://github.com/user-attachments/assets/4e673bac-81da-462a-82f6-b196bc9a567a" />

**After:**
<img width="702" alt="image" src="https://github.com/user-attachments/assets/97293731-93a4-4575-b57a-df8c9c34c8ae" />
