### PR TITLE
fix: "Cannot determine size" error in Benchmarks

### DIFF
--- a/apps/typegpu-docs/src/pages/benchmark/modules.ts
+++ b/apps/typegpu-docs/src/pages/benchmark/modules.ts
@@ -11,13 +11,13 @@ export function importTypeGPU(locator: PackageLocator): Promise<TypeGPUModule> {
 
   if (locator.type === 'npm') {
     return import(
-      /* @vite-ignore */ `https://esm.sh/typegpu@${locator.version}/`
+      /* @vite-ignore */ `https://esm.sh/typegpu@${locator.version}/?bundle=false`
     );
   }
 
   if (locator.type === 'pr') {
     return import(
-      /* @vite-ignore */ `https://esm.sh/pr/software-mansion/TypeGPU/typegpu@${locator.commit}/`
+      /* @vite-ignore */ `https://esm.sh/pr/software-mansion/TypeGPU/typegpu@${locator.commit}/?bundle=false`
     );
   }
 
@@ -33,13 +33,13 @@ export function importTypeGPUData(
 
   if (locator.type === 'npm') {
     return import(
-      /* @vite-ignore */ `https://esm.sh/typegpu@${locator.version}/data`
+      /* @vite-ignore */ `https://esm.sh/typegpu@${locator.version}/data/?bundle=false`
     );
   }
 
   if (locator.type === 'pr') {
     return import(
-      /* @vite-ignore */ `https://esm.sh/pr/typegpu@${locator.commit}/data`
+      /* @vite-ignore */ `https://esm.sh/pr/typegpu@${locator.commit}/data/?bundle=false`
     );
   }
 


### PR DESCRIPTION
The symbol tag for structs was bundled into two different files and therefore some checks on equality with that symbol were failing.