### PR TITLE
chore: Investigate casts in `createVertexFn` and `createComputeFn`

### DIFF
--- a/packages/typegpu/src/core/function/tgpuComputeFn.ts
+++ b/packages/typegpu/src/core/function/tgpuComputeFn.ts
@@ -154,7 +154,7 @@ function createComputeFn<ComputeIn extends IORecord<AnyComputeBuiltin>>(
   const core = createFnCore(shell, implementation);
   const inputType = shell.argTypes[0];
 
-  return {
+  const result: This = {
     shell,
 
     $uses(newExternals) {
@@ -181,5 +181,6 @@ function createComputeFn<ComputeIn extends IORecord<AnyComputeBuiltin>>(
     toString() {
       return `computeFn:${getName(core) ?? '<unnamed>'}`;
     },
-  } as This;
+  };
+  return result;
 }

--- a/packages/typegpu/src/core/function/tgpuVertexFn.ts
+++ b/packages/typegpu/src/core/function/tgpuVertexFn.ts
@@ -3,12 +3,7 @@ import type {
   AnyVertexOutputBuiltin,
   OmitBuiltins,
 } from '../../builtin.ts';
-import type {
-  Decorated,
-  Interpolate,
-  Location,
-  WgslStruct,
-} from '../../data/wgslTypes.ts';
+import type { Decorated, Interpolate, Location } from '../../data/wgslTypes.ts';
 import {
   getName,
   isNamable,
@@ -26,11 +21,7 @@ import type {
   InferIO,
   IORecord,
 } from './fnTypes.ts';
-import {
-  createIoSchema,
-  type IOLayoutToSchema,
-  type WithLocations,
-} from './ioOutputType.ts';
+import { createIoSchema, type IOLayoutToSchema } from './ioOutputType.ts';
 import { stripTemplate } from './templateUtils.ts';
 
 // ----------
@@ -101,8 +92,7 @@ export interface TgpuVertexFn<
 > extends TgpuNamable {
   readonly shell: TgpuVertexFnShellHeader<VertexIn, VertexOut>;
   readonly outputType: IOLayoutToSchema<VertexOut>;
-  readonly inputType: IOLayoutToSchema<VertexIn>;
-
+  readonly inputType: IOLayoutToSchema<VertexIn> | undefined;
   $uses(dependencyMap: Record<string, unknown>): this;
 }
 
@@ -194,7 +184,7 @@ function createVertexFn(
   const result: This = {
     shell,
     outputType,
-    inputType: inputType as WgslStruct<WithLocations<VertexInConstrained>>,
+    inputType,
 
     $uses(newExternals) {
       core.applyExternals(newExternals);

--- a/packages/typegpu/tests/renderPipeline.test.ts
+++ b/packages/typegpu/tests/renderPipeline.test.ts
@@ -96,7 +96,9 @@ describe('Inter-Stage Variables', () => {
       .$name('example-layout');
 
     const vertexFn = utgpu
-      .vertexFn({ out: {} })('() { layout.bound.alpha; }')
+      .vertexFn({ out: { pos: d.builtin.position } })(
+        '() { layout.bound.alpha; }',
+      )
       .$uses({ layout });
 
     const fragmentFn = utgpu.fragmentFn({ out: { out: d.vec4f } })('() {}');
@@ -119,14 +121,14 @@ describe('Inter-Stage Variables', () => {
 
   it('allows to omit input in entry function shell', () => {
     expectTypeOf(
-      tgpu['~unstable'].vertexFn({ in: {}, out: {} }),
+      tgpu['~unstable'].vertexFn({ in: {}, out: { pos: d.builtin.position } }),
       // biome-ignore lint/complexity/noBannedTypes: it's fine
-    ).toEqualTypeOf<TgpuVertexFnShell<{}, {}>>();
+    ).toEqualTypeOf<TgpuVertexFnShell<{}, { pos: d.BuiltinPosition }>>();
 
     expectTypeOf(
-      tgpu['~unstable'].vertexFn({ out: {} }),
+      tgpu['~unstable'].vertexFn({ out: { pos: d.builtin.position } }),
       // biome-ignore lint/complexity/noBannedTypes: it's fine
-    ).toEqualTypeOf<TgpuVertexFnShell<{}, {}>>();
+    ).toEqualTypeOf<TgpuVertexFnShell<{}, { pos: d.BuiltinPosition }>>();
 
     expectTypeOf(
       tgpu['~unstable'].fragmentFn({ in: {}, out: {} }),

--- a/packages/typegpu/tests/renderPipeline.test.ts
+++ b/packages/typegpu/tests/renderPipeline.test.ts
@@ -8,66 +8,6 @@ import tgpu, {
 import { it } from './utils/extendedIt.ts';
 
 describe('Inter-Stage Variables', () => {
-  describe('Empty vertex output', () => {
-    const emptyVert = tgpu['~unstable'].vertexFn({ out: {} })('');
-    const emptyVertWithBuiltin = tgpu['~unstable'].vertexFn({
-      out: { pos: d.builtin.position },
-    })('');
-
-    it('allows fragment functions to use a subset of the vertex output', ({ root }) => {
-      const emptyFragment = tgpu['~unstable'].fragmentFn({ in: {}, out: {} })(
-        '',
-      );
-      const emptyFragmentWithBuiltin = tgpu['~unstable'].fragmentFn({
-        in: { pos: d.builtin.position },
-        out: {},
-      })('');
-
-      // Using none of none
-      const pipeline = root
-        .withVertex(emptyVert, {})
-        .withFragment(emptyFragment, {})
-        .createPipeline();
-
-      // Using none of none (builtins are erased from the vertex output)
-      const pipeline2 = root
-        .withVertex(emptyVertWithBuiltin, {})
-        .withFragment(emptyFragment, {})
-        .createPipeline();
-
-      // Using none of none (builtins are ignored in the fragment input)
-      const pipeline3 = root
-        .withVertex(emptyVert, {})
-        .withFragment(emptyFragmentWithBuiltin, {})
-        .createPipeline();
-
-      // Using none of none (builtins are ignored in both input and output,
-      // so their conflict of the `pos` key is fine)
-      const pipeline4 = root
-        .withVertex(emptyVertWithBuiltin, {})
-        .withFragment(emptyFragmentWithBuiltin, {})
-        .createPipeline();
-
-      expect(pipeline).toBeDefined();
-      expect(pipeline2).toBeDefined();
-      expect(pipeline3).toBeDefined();
-      expect(pipeline4).toBeDefined();
-    });
-
-    it('rejects fragment functions that use non-existent vertex output', ({ root }) => {
-      const fragment = tgpu['~unstable'].fragmentFn({
-        in: { a: d.vec3f, c: d.f32 },
-        out: {},
-      })('');
-
-      root
-        .withVertex(emptyVert, {})
-        // @ts-expect-error: Missing from vertex output
-        .withFragment(fragment, {})
-        .createPipeline();
-    });
-  });
-
   describe('Non-empty vertex output', () => {
     const vert = tgpu['~unstable'].vertexFn({
       out: { a: d.vec3f, b: d.vec2f },

--- a/packages/typegpu/tests/tgslFn.test.ts
+++ b/packages/typegpu/tests/tgslFn.test.ts
@@ -212,6 +212,18 @@ describe('TGSL tgpu.fn function', () => {
     expect(actual).toBe(expected);
   });
 
+  it('throws when empty object is passed to vertexFn', () => {
+    expect(() =>
+      tgpu['~unstable']
+        .vertexFn({
+          in: { vi: builtin.vertexIndex },
+          out: {},
+        })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: A vertexFn's shell output cannot be empty since must include the 'position' builtin.]`,
+    );
+  });
+
   it('allows destructuring the input argument in vertexFn', () => {
     const vertexFn = tgpu['~unstable']
       .vertexFn({

--- a/packages/typegpu/tests/tgslFn.test.ts
+++ b/packages/typegpu/tests/tgslFn.test.ts
@@ -212,7 +212,27 @@ describe('TGSL tgpu.fn function', () => {
     expect(actual).toBe(expected);
   });
 
-  it('throws when empty object is passed to vertexFn', () => {
+  it('resolves vertexFn with empty in', () => {
+    const vertexFn = tgpu['~unstable'].vertexFn({
+      out: { pos: d.builtin.position },
+    })(() => ({ pos: d.vec4f() }));
+
+    const actual = parseResolved({ vertexFn });
+
+    const expected = parse(`
+      struct vertexFn_Output {
+        @builtin(position) pos: vec4f,
+      }
+
+      @vertex fn vertexFn() -> vertexFn_Output{
+        return vertexFn_Output(vec4f());
+      }
+    `);
+
+    expect(actual).toBe(expected);
+  });
+
+  it('throws when vertexFn with empty out', () => {
     expect(() =>
       tgpu['~unstable']
         .vertexFn({
@@ -220,7 +240,7 @@ describe('TGSL tgpu.fn function', () => {
           out: {},
         })
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: A vertexFn's shell output cannot be empty since must include the 'position' builtin.]`,
+      `[Error: A vertexFn output cannot be empty since must include the 'position' builtin.]`,
     );
   });
 


### PR DESCRIPTION
The cast in `createComputeFn` was unnecessary.
In `createVertexFn`, `inputType` can be undefined, we even have a signature with only `out` parameter. I added it to the type.
In `createVertexFn`, `outputType` cannot be undefined, since the output needs to include at least the `@builtin(position)`, otherwise WGSL throws. 
