### PR TITLE
docs: Script for detecting changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:unit": "ATTEST_skipTypes=1 vitest run",
     "test:unit:watch": "ATTEST_skipTypes=1 vitest",
     "test:coverage": "vitest --coverage run",
-    "nightly-build": "pnpm --filter typegpu prepublishOnly --skip-publish-tag-check"
+    "nightly-build": "pnpm --filter typegpu prepublishOnly --skip-publish-tag-check",
+    "changes": "tgpu-dev-cli changes"
   },
   "engines": {
     "node": ">=12.20.0"
@@ -24,17 +25,14 @@
     "type": "git",
     "url": "git+https://github.com/software-mansion/TypeGPU.git"
   },
-  "keywords": [
-    "webgpu",
-    "wgpu",
-    "wgsl"
-  ],
+  "keywords": ["webgpu", "wgpu", "wgsl"],
   "bugs": {
     "url": "https://github.com/software-mansion/TypeGPU/issues"
   },
   "homepage": "https://docs.swmansion.com/TypeGPU",
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@typegpu/tgpu-dev-cli": "workspace:*",
     "@types/node": "^22.13.14",
     "@vitest/coverage-v8": "3.1.2",
     "@webgpu/types": "catalog:",
@@ -46,11 +44,7 @@
   },
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af",
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "@biomejs/biome",
-      "esbuild",
-      "sharp"
-    ],
+    "onlyBuiltDependencies": ["@biomejs/biome", "esbuild", "sharp"],
     "overrides": {
       "rollup": "4.34.8"
     }

--- a/packages/tgpu-dev-cli/changes.mjs
+++ b/packages/tgpu-dev-cli/changes.mjs
@@ -1,0 +1,40 @@
+// @ts-check
+
+import { consola } from 'consola';
+import { execa } from 'execa';
+import { filter, map, pipe, unique } from 'remeda';
+import colors from './colors.mjs';
+
+const packageNameRegex = /^packages\/([@\w\-]+)\//g;
+
+async function main() {
+  const $ = execa({ all: true });
+
+  consola.start('Estimating change between release and main branches...');
+  consola.log('');
+
+  const diffMsg =
+    (await $`git diff --name-only release..main`.pipe('sort')).stdout;
+  const filesChanged = diffMsg.split('\n');
+
+  consola.info(`${colors.Bold}Files changed:${colors.Reset}`);
+  for (const file of filesChanged) {
+    consola.log(`⋅ ${file}`);
+  }
+  consola.log('');
+
+  const packagesChanged = pipe(
+    filesChanged,
+    map((file) => packageNameRegex.exec(file)?.[1]),
+    filter(Boolean),
+    unique(),
+  );
+  // consola.log(diffMsg.split('\n'));
+  consola.info(`${colors.Bold}Packages changed:${colors.Reset}`);
+  for (const pkg of packagesChanged) {
+    consola.log(`⋅ ${pkg}`);
+  }
+  consola.log('');
+}
+
+export default main;

--- a/packages/tgpu-dev-cli/tgpu-dev-cli.mjs
+++ b/packages/tgpu-dev-cli/tgpu-dev-cli.mjs
@@ -5,6 +5,7 @@ import arg from 'arg';
 import color from './colors.mjs';
 import { Frog } from './log.mjs';
 import prepack from './prepack.mjs';
+import changes from './changes.mjs';
 
 if (!process.env.npm_config_user_agent.startsWith('pnpm')) {
   console.error(
@@ -19,6 +20,9 @@ const COMMANDS = {
   prepack: {
     execute: prepack,
   },
+  changes: {
+    execute: changes,
+  },
 };
 
 function printHelp() {
@@ -32,6 +36,7 @@ ${color.Reset}
 
 ${color.Bold}Commands:${color.Reset}
   tgpu-dev-cli prepack   Builds and prepares a package for publishing.
+  tgpu-dev-cli changes   Prints files (and packages) changed between 'release' and 'main'.
 `);
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      '@typegpu/tgpu-dev-cli':
+        specifier: workspace:*
+        version: link:packages/tgpu-dev-cli
       '@types/node':
         specifier: ^22.13.14
         version: 22.13.14
@@ -7690,14 +7693,6 @@ snapshots:
     optionalDependencies:
       vite: 6.3.3(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
 
-  '@vitest/mocker@3.1.2(vite@6.3.3(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))':
-    dependencies:
-      '@vitest/spy': 3.1.2
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.3.3(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
-
   '@vitest/pretty-format@3.1.2':
     dependencies:
       tinyrainbow: 2.0.0
@@ -11271,7 +11266,7 @@ snapshots:
   vitest@3.1.2(@types/debug@4.1.12)(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.1.2
-      '@vitest/mocker': 3.1.2(vite@6.3.3(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.1.2(vite@6.3.3(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.1.2
       '@vitest/runner': 3.1.2
       '@vitest/snapshot': 3.1.2


### PR DESCRIPTION
Added a new script to be ran from the monorepo root: `nr changes`
It prints files and packages changed between `release` and `main` branches

<img width="939" alt="Screenshot 2025-06-18 at 12 25 38" src="https://github.com/user-attachments/assets/d28acde2-6d3b-42ca-af33-2fc4894ded35" />
