### PR TITLE
fix: Add explicit type annotation to constant declarations

### DIFF
--- a/packages/typegpu/src/core/constant/tgpuConstant.ts
+++ b/packages/typegpu/src/core/constant/tgpuConstant.ts
@@ -55,8 +55,9 @@ class TgpuConstImpl<TDataType extends AnyWgslData>
   '~resolve'(ctx: ResolutionCtx): string {
     const id = ctx.names.makeUnique(getName(this));
     const resolvedValue = ctx.resolveValue(this._value, this.dataType);
+    const resolvedDataType = ctx.resolve(this.dataType);
 
-    ctx.addDeclaration(`const ${id} = ${resolvedValue};`);
+    ctx.addDeclaration(`const ${id}: ${resolvedDataType} = ${resolvedValue};`);
 
     return id;
   }


### PR DESCRIPTION
For example if we did:
```ts
const nums = tgpu['~unstable'].const(d.arrayOf(d.u32, 4), [1,2,3,4]);
```
It will get resolved to:
```
const nums = array(1, 2, 3, 4);
```
So we get an array of `i32` instead. This PR makes the types explicit so we don't have to deal with that.