### PR TITLE
feat: Better TgpuFn type (0.6.0)

### DIFF
--- a/apps/typegpu-docs/src/content/examples/rendering/perlin-noise/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/perlin-noise/index.ts
@@ -30,7 +30,9 @@ const tanhSharpen = tgpu['~unstable'].fn([d.f32, d.f32], d.f32)(
   (n, sharpness) => tanh(n * (1 + sharpness * 10)),
 );
 
-const sharpenFnSlot = tgpu['~unstable'].slot<TgpuFn<[d.F32, d.F32], d.F32>>(
+const sharpenFnSlot = tgpu['~unstable'].slot<
+  TgpuFn<(n: d.F32, sharpness: d.F32) => d.F32>
+>(
   exponentialSharpen,
 );
 

--- a/apps/typegpu-docs/src/content/examples/simulation/stable-fluid/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/stable-fluid/index.ts
@@ -147,7 +147,7 @@ function createRenderPipeline(
   fragmentFn: TgpuFragmentFn<{ uv: d.Vec2f }, d.Vec4f>,
 ) {
   return root['~unstable']
-    .withVertex(renderFn, renderFn.shell.attributes)
+    .withVertex(renderFn, {})
     .withFragment(fragmentFn, { format })
     .withPrimitive({
       topology: 'triangle-strip',

--- a/packages/typegpu-noise/src/generator.ts
+++ b/packages/typegpu-noise/src/generator.ts
@@ -3,11 +3,11 @@ import * as d from 'typegpu/data';
 import { add, cos, dot, fract } from 'typegpu/std';
 
 export interface StatefulGenerator {
-  seed: TgpuFn<[d.F32], d.Void>;
-  seed2: TgpuFn<[d.Vec2f], d.Void>;
-  seed3: TgpuFn<[d.Vec3f], d.Void>;
-  seed4: TgpuFn<[d.Vec4f], d.Void>;
-  sample: TgpuFn<[], d.F32>;
+  seed: TgpuFn<(seed: d.F32) => d.Void>;
+  seed2: TgpuFn<(seed: d.Vec2f) => d.Void>;
+  seed3: TgpuFn<(seed: d.Vec3f) => d.Void>;
+  seed4: TgpuFn<(seed: d.Vec4f) => d.Void>;
+  sample: TgpuFn<() => d.F32>;
 }
 
 export const randomGeneratorShell: TgpuFnShell<[], d.F32> = tgpu[

--- a/packages/typegpu-noise/src/perlin-3d/dynamic-cache.ts
+++ b/packages/typegpu-noise/src/perlin-3d/dynamic-cache.ts
@@ -40,7 +40,7 @@ type Bindings<Prefix extends string> = Prettify<
 export interface DynamicPerlin3DCacheConfig<Prefix extends string> {
   readonly layout: Layout<Prefix>;
   readonly valuesSlot: TgpuSlot<LayoutValue<Prefix>>;
-  readonly getJunctionGradient: TgpuFn<[pos: d.Vec3i], d.Vec3f>;
+  readonly getJunctionGradient: TgpuFn<(pos: d.Vec3i) => d.Vec3f>;
 
   instance(
     root: TgpuRoot,

--- a/packages/typegpu-noise/src/perlin-3d/static-cache.ts
+++ b/packages/typegpu-noise/src/perlin-3d/static-cache.ts
@@ -5,7 +5,7 @@ import { computeJunctionGradient } from './algorithm.ts';
 const MemorySchema = (n: number) => d.arrayOf(d.vec3f, n);
 
 export interface StaticPerlin3DCache {
-  readonly getJunctionGradient: TgpuFn<[pos: d.Vec3i], d.Vec3f>;
+  readonly getJunctionGradient: TgpuFn<(pos: d.Vec3i) => d.Vec3f>;
   readonly size: d.v3u;
   destroy(): void;
 }

--- a/packages/typegpu-noise/src/random.ts
+++ b/packages/typegpu-noise/src/random.ts
@@ -5,81 +5,69 @@ import { randomGeneratorSlot } from './generator.ts';
 
 const TWO_PI = Math.PI * 2;
 
-export const randSeed: TgpuFn<[d.F32], d.Void> = tgpu['~unstable'].fn([d.f32])(
-  (seed) => {
+export const randSeed: TgpuFn<(seed: d.F32) => d.Void> = tgpu['~unstable']
+  .fn([d.f32])((seed) => {
     randomGeneratorSlot.value.seed(seed);
-  },
-);
+  });
 
-export const randSeed2: TgpuFn<[d.Vec2f], d.Void> = tgpu['~unstable'].fn([
-  d.vec2f,
-])((seed) => {
-  randomGeneratorSlot.value.seed2(seed);
-});
+export const randSeed2: TgpuFn<(seed: d.Vec2f) => d.Void> = tgpu['~unstable']
+  .fn([d.vec2f])((seed) => {
+    randomGeneratorSlot.value.seed2(seed);
+  });
 
-export const randSeed3: TgpuFn<[d.Vec3f], d.Void> = tgpu['~unstable'].fn([
-  d.vec3f,
-])((seed) => {
-  randomGeneratorSlot.value.seed3(seed);
-});
+export const randSeed3: TgpuFn<(seed: d.Vec3f) => d.Void> = tgpu['~unstable']
+  .fn([d.vec3f])((seed) => {
+    randomGeneratorSlot.value.seed3(seed);
+  });
 
-export const randSeed4: TgpuFn<[d.Vec4f], d.Void> = tgpu['~unstable'].fn([
-  d.vec4f,
-])((seed) => {
-  randomGeneratorSlot.value.seed4(seed);
-});
+export const randSeed4: TgpuFn<(seed: d.Vec4f) => d.Void> = tgpu['~unstable']
+  .fn([d.vec4f])((seed) => {
+    randomGeneratorSlot.value.seed4(seed);
+  });
 
-export const randFloat01: TgpuFn<[], d.F32> = tgpu['~unstable'].fn([], d.f32)(
+export const randFloat01: TgpuFn<() => d.F32> = tgpu['~unstable'].fn([], d.f32)(
   () => randomGeneratorSlot.value.sample(),
 );
 
-export const randInUnitCube: TgpuFn<[], d.Vec3f> = tgpu['~unstable'].fn(
-  [],
-  d.vec3f,
-)(() =>
-  d.vec3f(
-    randomGeneratorSlot.value.sample() * 2 - 1,
-    randomGeneratorSlot.value.sample() * 2 - 1,
-    randomGeneratorSlot.value.sample() * 2 - 1,
-  )
-);
+export const randInUnitCube: TgpuFn<() => d.Vec3f> = tgpu['~unstable']
+  .fn([], d.vec3f)(() =>
+    d.vec3f(
+      randomGeneratorSlot.value.sample() * 2 - 1,
+      randomGeneratorSlot.value.sample() * 2 - 1,
+      randomGeneratorSlot.value.sample() * 2 - 1,
+    )
+  );
 
-export const randInUnitCircle: TgpuFn<[], d.Vec2f> = tgpu['~unstable'].fn(
-  [],
-  d.vec2f,
-)(() => {
-  const radius = sqrt(randomGeneratorSlot.value.sample());
-  const angle = randomGeneratorSlot.value.sample() * TWO_PI;
+export const randInUnitCircle: TgpuFn<() => d.Vec2f> = tgpu['~unstable']
+  .fn([], d.vec2f)(() => {
+    const radius = sqrt(randomGeneratorSlot.value.sample());
+    const angle = randomGeneratorSlot.value.sample() * TWO_PI;
 
-  return d.vec2f(cos(angle) * radius, sin(angle) * radius);
-});
+    return d.vec2f(cos(angle) * radius, sin(angle) * radius);
+  });
 
-export const randOnUnitCircle: TgpuFn<[], d.Vec2f> = tgpu['~unstable'].fn(
-  [],
-  d.vec2f,
-)(() => {
-  const angle = randomGeneratorSlot.value.sample() * TWO_PI;
-  return d.vec2f(cos(angle), sin(angle));
-});
+export const randOnUnitCircle: TgpuFn<() => d.Vec2f> = tgpu['~unstable']
+  .fn([], d.vec2f)(() => {
+    const angle = randomGeneratorSlot.value.sample() * TWO_PI;
+    return d.vec2f(cos(angle), sin(angle));
+  });
 
-export const randOnUnitSphere: TgpuFn<[], d.Vec3f> = tgpu['~unstable'].fn(
-  [],
-  d.vec3f,
-)(() => {
-  const z = 2 * randomGeneratorSlot.value.sample() - 1;
-  const oneMinusZSq = sqrt(1 - z * z);
-  // TODO: Work out if the -Math.PI offset is necessary
-  const theta = TWO_PI * randomGeneratorSlot.value.sample() - Math.PI;
-  const x = sin(theta) * oneMinusZSq;
-  const y = cos(theta) * oneMinusZSq;
-  return d.vec3f(x, y, z);
-});
+export const randOnUnitSphere: TgpuFn<() => d.Vec3f> = tgpu['~unstable']
+  .fn([], d.vec3f)(() => {
+    const z = 2 * randomGeneratorSlot.value.sample() - 1;
+    const oneMinusZSq = sqrt(1 - z * z);
+    // TODO: Work out if the -Math.PI offset is necessary
+    const theta = TWO_PI * randomGeneratorSlot.value.sample() - Math.PI;
+    const x = sin(theta) * oneMinusZSq;
+    const y = cos(theta) * oneMinusZSq;
+    return d.vec3f(x, y, z);
+  });
 
-export const randOnUnitHemisphere: TgpuFn<[normal: d.Vec3f], d.Vec3f> = tgpu[
-  '~unstable'
-].fn([d.vec3f], d.vec3f)((normal) => {
-  const value = randOnUnitSphere();
-  const alignment = dot(normal, value);
+export const randOnUnitHemisphere: TgpuFn<(normal: d.Vec3f) => d.Vec3f> =
+  tgpu['~unstable']
+    .fn([d.vec3f], d.vec3f)((normal) => {
+      const value = randOnUnitSphere();
+      const alignment = dot(normal, value);
 
-  return mul(sign(alignment), value);
-});
+      return mul(sign(alignment), value);
+    });

--- a/packages/typegpu/setupVitest.ts
+++ b/packages/typegpu/setupVitest.ts
@@ -2,5 +2,5 @@ import { setup } from '@ark/attest';
 
 export default () =>
   setup({
-    formatCmd: 'pnpm check',
+    formatCmd: 'pnpm fix',
   });

--- a/packages/typegpu/src/core/function/fnTypes.ts
+++ b/packages/typegpu/src/core/function/fnTypes.ts
@@ -23,6 +23,8 @@ import type {
 } from '../../data/wgslTypes.ts';
 import type { Infer } from '../../shared/repr.ts';
 
+export type AnyFn = (...args: never[]) => unknown;
+
 /**
  * Information extracted from transpiling a JS function.
  */
@@ -40,14 +42,11 @@ export type InferArgs<T extends unknown[]> = {
   [Idx in keyof T]: Infer<T[Idx]>;
 };
 
-export type InferImplSchema<ImplSchema extends (...args: never[]) => unknown> =
-  (...args: InferArgs<Parameters<ImplSchema>>) => Infer<ReturnType<ImplSchema>>;
+export type InferImplSchema<ImplSchema extends AnyFn> = (
+  ...args: InferArgs<Parameters<ImplSchema>>
+) => Infer<ReturnType<ImplSchema>>;
 
-export type Implementation<
-  ImplSchema extends (...args: never[]) => unknown = (
-    ...args: never[]
-  ) => unknown,
-> =
+export type Implementation<ImplSchema extends AnyFn = AnyFn> =
   | string
   | InferImplSchema<ImplSchema>;
 

--- a/packages/typegpu/src/core/function/fnTypes.ts
+++ b/packages/typegpu/src/core/function/fnTypes.ts
@@ -43,7 +43,11 @@ export type InferArgs<T extends unknown[]> = {
 export type InferImplSchema<ImplSchema extends (...args: never[]) => unknown> =
   (...args: InferArgs<Parameters<ImplSchema>>) => Infer<ReturnType<ImplSchema>>;
 
-export type Implementation<ImplSchema extends (...args: never[]) => unknown> =
+export type Implementation<
+  ImplSchema extends (...args: never[]) => unknown = (
+    ...args: never[]
+  ) => unknown,
+> =
   | string
   | InferImplSchema<ImplSchema>;
 

--- a/packages/typegpu/src/core/function/fnTypes.ts
+++ b/packages/typegpu/src/core/function/fnTypes.ts
@@ -42,6 +42,28 @@ export type InferArgs<T extends unknown[]> = {
   [Idx in keyof T]: Infer<T[Idx]>;
 };
 
+type InheritTupleValues<T, From> = {
+  [K in keyof T]: K extends keyof From ? From[K] : never;
+};
+
+/**
+ * Returns a type that has arg and return types of `T`, but argument
+ * names of `From`
+ *
+ * Wrapped in an object type with `result` prop just so that it's easier
+ * to remove InheritArgNames<...> from Intellisense with Prettify<T>['result']
+ */
+export type InheritArgNames<T extends AnyFn, From extends AnyFn> = {
+  result: (
+    ...args: Parameters<
+      & ((
+        ...args: InheritTupleValues<Parameters<From>, Parameters<T>>
+      ) => ReturnType<T>)
+      & T
+    >
+  ) => ReturnType<T>;
+};
+
 export type InferImplSchema<ImplSchema extends AnyFn> = (
   ...args: InferArgs<Parameters<ImplSchema>>
 ) => Infer<ReturnType<ImplSchema>>;

--- a/packages/typegpu/src/core/function/fnTypes.ts
+++ b/packages/typegpu/src/core/function/fnTypes.ts
@@ -40,15 +40,12 @@ export type InferArgs<T extends unknown[]> = {
   [Idx in keyof T]: Infer<T[Idx]>;
 };
 
-export type JsImplementation<
-  Args extends unknown[] | [] = unknown[] | [],
-  Return = unknown,
-> = (...args: InferArgs<Args>) => Infer<Return>;
+export type InferImplSchema<ImplSchema extends (...args: never[]) => unknown> =
+  (...args: InferArgs<Parameters<ImplSchema>>) => Infer<ReturnType<ImplSchema>>;
 
-export type Implementation<
-  Args extends unknown[] | [] = unknown[] | [],
-  Return = unknown,
-> = string | JsImplementation<Args, Return>;
+export type Implementation<ImplSchema extends (...args: never[]) => unknown> =
+  | string
+  | InferImplSchema<ImplSchema>;
 
 export type BaseIOData =
   | F32

--- a/packages/typegpu/src/core/function/tgpuFn.ts
+++ b/packages/typegpu/src/core/function/tgpuFn.ts
@@ -27,8 +27,10 @@ import type {
   Implementation,
   InferArgs,
   InferImplSchema,
+  InheritArgNames,
 } from './fnTypes.ts';
 import { stripTemplate } from './templateUtils.ts';
+import type { Prettify } from '../../shared/utilityTypes.ts';
 
 // ----------
 // Public API
@@ -57,9 +59,11 @@ export type TgpuFnShell<
   Return extends AnyData,
 > =
   & TgpuFnShellHeader<Args, Return>
-  & ((
-    implementation: (...args: InferArgs<Args>) => Infer<Return>,
-  ) => TgpuFn<(...args: Args) => Return>)
+  & (<T extends (...args: InferArgs<Args>) => Infer<Return>>(
+    implementation: T,
+  ) => TgpuFn<
+    Prettify<InheritArgNames<(...args: Args) => Return, T>>['result']
+  >)
   & ((implementation: string) => TgpuFn<(...args: Args) => Return>)
   & ((
     strings: TemplateStringsArray,

--- a/packages/typegpu/src/core/function/tgpuFn.ts
+++ b/packages/typegpu/src/core/function/tgpuFn.ts
@@ -22,14 +22,17 @@ import {
   type TgpuSlot,
 } from '../slot/slotTypes.ts';
 import { createFnCore, type FnCore } from './fnCore.ts';
-import type { Implementation, InferArgs, InferImplSchema } from './fnTypes.ts';
+import type {
+  AnyFn,
+  Implementation,
+  InferArgs,
+  InferImplSchema,
+} from './fnTypes.ts';
 import { stripTemplate } from './templateUtils.ts';
 
 // ----------
 // Public API
 // ----------
-
-type AnyFn = (...args: never[]) => unknown;
 
 /**
  * Describes a function signature (its arguments and return type)

--- a/packages/typegpu/src/core/function/tgpuFn.ts
+++ b/packages/typegpu/src/core/function/tgpuFn.ts
@@ -98,10 +98,8 @@ interface TgpuFnBase<ImplSchema extends AnyFn> extends TgpuNamable {
   ): TgpuFn<ImplSchema>;
 }
 
-export type TgpuFn<
-  // biome-ignore lint/suspicious/noExplicitAny: the widest type requires `any`
-  ImplSchema extends AnyFn = (...args: any[]) => any,
-> =
+// biome-ignore lint/suspicious/noExplicitAny: the widest type requires `any`
+export type TgpuFn<ImplSchema extends AnyFn = (...args: any[]) => any> =
   & TgpuFnBase<ImplSchema>
   & InferImplSchema<ImplSchema>;
 
@@ -126,7 +124,7 @@ export function fn<
   };
 
   const call = (
-    arg: InferImplSchema<(...args: Args) => Return> | TemplateStringsArray,
+    arg: Implementation | TemplateStringsArray,
     ...values: unknown[]
   ) =>
     createFn(
@@ -156,7 +154,7 @@ function stringifyPair([slot, value]: SlotValuePair): string {
 
 function createFn<ImplSchema extends AnyFn>(
   shell: TgpuFnShellHeader<
-    Extract<Parameters<ImplSchema>, AnyData[]>,
+    Parameters<ImplSchema>,
     Extract<ReturnType<ImplSchema>, AnyData>
   >,
   implementation: Implementation<ImplSchema>,

--- a/packages/typegpu/src/core/root/init.ts
+++ b/packages/typegpu/src/core/root/init.ts
@@ -112,7 +112,7 @@ class WithBindingImpl implements WithBinding {
 
   with<T extends AnyWgslData>(
     slot: TgpuSlot<T> | TgpuAccessor<T>,
-    value: T | TgpuFn<[], T> | TgpuBufferUsage<T> | Infer<T>,
+    value: T | TgpuFn<() => T> | TgpuBufferUsage<T> | Infer<T>,
   ): WithBinding {
     return new WithBindingImpl(this._getRoot, [
       ...this._slotBindings,

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -115,7 +115,7 @@ export interface WithBinding {
   with<T>(slot: TgpuSlot<T>, value: Eventual<T>): WithBinding;
   with<T extends AnyWgslData>(
     accessor: TgpuAccessor<T>,
-    value: TgpuFn<[], T> | TgpuBufferUsage<T> | Infer<T>,
+    value: TgpuFn<() => T> | TgpuBufferUsage<T> | Infer<T>,
   ): WithBinding;
 
   withCompute<ComputeIn extends IORecord<AnyComputeBuiltin>>(

--- a/packages/typegpu/src/core/slot/accessor.ts
+++ b/packages/typegpu/src/core/slot/accessor.ts
@@ -24,7 +24,7 @@ import type { TgpuAccessor, TgpuSlot } from './slotTypes.ts';
 
 export function accessor<T extends AnyWgslData>(
   schema: T,
-  defaultValue?: TgpuFn<[], T> | TgpuBufferUsage<T> | Infer<T>,
+  defaultValue?: TgpuFn<() => T> | TgpuBufferUsage<T> | Infer<T>,
 ): TgpuAccessor<T> {
   return new TgpuAccessorImpl(schema, defaultValue);
 }
@@ -36,7 +36,9 @@ export function accessor<T extends AnyWgslData>(
 export class TgpuAccessorImpl<T extends AnyWgslData>
   implements TgpuAccessor<T>, SelfResolvable {
   public readonly resourceType = 'accessor';
-  public readonly slot: TgpuSlot<TgpuFn<[], T> | TgpuBufferUsage<T> | Infer<T>>;
+  public readonly slot: TgpuSlot<
+    TgpuFn<() => T> | TgpuBufferUsage<T> | Infer<T>
+  >;
 
   declare public readonly [$repr]: Infer<T>;
   declare public readonly '~gpuRepr': InferGPU<T>;
@@ -45,7 +47,7 @@ export class TgpuAccessorImpl<T extends AnyWgslData>
   constructor(
     public readonly schema: T,
     public readonly defaultValue:
-      | TgpuFn<[], T>
+      | TgpuFn<() => T>
       | TgpuBufferUsage<T>
       | Infer<T>
       | undefined = undefined,

--- a/packages/typegpu/src/core/slot/slotTypes.ts
+++ b/packages/typegpu/src/core/slot/slotTypes.ts
@@ -42,11 +42,11 @@ export interface TgpuAccessor<T extends AnyData = AnyData> extends TgpuNamable {
 
   readonly schema: T;
   readonly defaultValue:
-    | TgpuFn<[], T>
+    | TgpuFn<() => T>
     | TgpuBufferUsage<T>
     | Infer<T>
     | undefined;
-  readonly slot: TgpuSlot<TgpuFn<[], T> | TgpuBufferUsage<T> | Infer<T>>;
+  readonly slot: TgpuSlot<TgpuFn<() => T> | TgpuBufferUsage<T> | Infer<T>>;
 
   readonly value: InferGPU<T>;
 }

--- a/packages/typegpu/src/types.ts
+++ b/packages/typegpu/src/types.ts
@@ -65,8 +65,7 @@ export type ResolvableObject =
   | AnyVecInstance
   | AnyMatInstance
   | AnyData
-  // biome-ignore lint/suspicious/noExplicitAny: <has to be more permissive than unknown>
-  | TgpuFn<any, any>;
+  | TgpuFn;
 
 export type Wgsl = Eventual<string | number | boolean | ResolvableObject>;
 

--- a/packages/typegpu/tests/function.test.ts
+++ b/packages/typegpu/tests/function.test.ts
@@ -107,16 +107,18 @@ describe('tgpu.fn', () => {
     const two = tgpu['~unstable'].fn([d.f32, d.u32]);
 
     expectTypeOf(proc).toEqualTypeOf<TgpuFnShell<[], d.Void>>();
-    expectTypeOf<ReturnType<typeof proc>>().toEqualTypeOf<TgpuFn<[], d.Void>>();
+    expectTypeOf<ReturnType<typeof proc>>().toEqualTypeOf<
+      TgpuFn<() => d.Void>
+    >();
 
     expectTypeOf(one).toEqualTypeOf<TgpuFnShell<[d.F32], d.Void>>();
     expectTypeOf<ReturnType<typeof one>>().toEqualTypeOf<
-      TgpuFn<[d.F32], d.Void>
+      TgpuFn<(arg_0: d.F32) => d.Void>
     >();
 
     expectTypeOf(two).toEqualTypeOf<TgpuFnShell<[d.F32, d.U32], d.Void>>();
     expectTypeOf<ReturnType<typeof two>>().toEqualTypeOf<
-      TgpuFn<[d.F32, d.U32], d.Void>
+      TgpuFn<(arg_0: d.F32, arg_1: d.U32) => d.Void>
     >();
   });
 
@@ -126,16 +128,18 @@ describe('tgpu.fn', () => {
     const two = tgpu['~unstable'].fn([d.f32, d.u32], d.bool);
 
     expectTypeOf(proc).toEqualTypeOf<TgpuFnShell<[], d.Bool>>();
-    expectTypeOf<ReturnType<typeof proc>>().toEqualTypeOf<TgpuFn<[], d.Bool>>();
+    expectTypeOf<ReturnType<typeof proc>>().toEqualTypeOf<
+      TgpuFn<() => d.Bool>
+    >();
 
     expectTypeOf(one).toEqualTypeOf<TgpuFnShell<[d.F32], d.Bool>>();
     expectTypeOf<ReturnType<typeof one>>().toEqualTypeOf<
-      TgpuFn<[d.F32], d.Bool>
+      TgpuFn<(arg_0: d.F32) => d.Bool>
     >();
 
     expectTypeOf(two).toEqualTypeOf<TgpuFnShell<[d.F32, d.U32], d.Bool>>();
     expectTypeOf<ReturnType<typeof two>>().toEqualTypeOf<
-      TgpuFn<[d.F32, d.U32], d.Bool>
+      TgpuFn<(arg_0: d.F32, arg_1: d.U32) => d.Bool>
     >();
   });
 });

--- a/packages/typegpu/tests/tgslFn.test.ts
+++ b/packages/typegpu/tests/tgslFn.test.ts
@@ -4,6 +4,7 @@ import * as d from '../src/data/index.ts';
 import tgpu from '../src/index.ts';
 import { getName } from '../src/shared/meta.ts';
 import { parse, parseResolved } from './utils/parseResolved.ts';
+import { attest } from '@ark/attest';
 
 describe('TGSL tgpu.fn function', () => {
   it('is namable', () => {
@@ -835,5 +836,21 @@ describe('TGSL tgpu.fn function', () => {
     `);
 
     expect(actual).toBe(expected);
+  });
+
+  it('maintains argument names in the type', () => {
+    const fun = tgpu['~unstable'].fn([d.f32, d.f32], d.f32)((x, y) => {
+      return x + y;
+    });
+
+    attest(fun).type.toString.snap('TgpuFn<(x: F32, y: F32) => F32>');
+  });
+
+  it('falls back to args_N naming when not every argument is used in the implementation', () => {
+    const fun = tgpu['~unstable'].fn([d.f32, d.f32], d.f32)((x) => {
+      return x * 2;
+    });
+
+    attest(fun).type.toString.snap('TgpuFn<(args_0: F32, args_1: F32) => F32>');
   });
 });


### PR DESCRIPTION
Changes:
- Argument names are maintained by the type system (if implemented using TGSL)
- `TgpuFn` without generic instantiation is wide-enough that it represents any function created using `tgpu.fn`

https://github.com/user-attachments/assets/3f79bf10-9d03-4564-8d05-35dd6f5e7248

