### PR TITLE
refactor: Remove name method calls from examples and tests

### DIFF
--- a/apps/typegpu-docs/src/content/examples/image-processing/camera-thresholding/index.ts
+++ b/apps/typegpu-docs/src/content/examples/image-processing/camera-thresholding/index.ts
@@ -86,10 +86,7 @@ const sampler = root.device.createSampler({
   minFilter: 'linear',
 });
 
-const thresholdBuffer = root
-  .createBuffer(d.f32)
-  .$name('threshold')
-  .$usage('uniform');
+const thresholdBuffer = root.createBuffer(d.f32).$usage('uniform');
 
 const rareBindGroup = root.createBindGroup(rareLayout, {
   sampling: sampler,

--- a/apps/typegpu-docs/src/content/examples/image-processing/chroma-keying-next/index.ts
+++ b/apps/typegpu-docs/src/content/examples/image-processing/chroma-keying-next/index.ts
@@ -127,14 +127,10 @@ const mediaProcessor = new MediaStreamTrackProcessor({
 });
 const reader = mediaProcessor.readable.getReader();
 
-const thresholdBuffer = root
-  .createBuffer(d.f32, 0.5)
-  .$name('threshold')
-  .$usage('uniform');
+const thresholdBuffer = root.createBuffer(d.f32, 0.5).$usage('uniform');
 
 const colorBuffer = root
   .createBuffer(d.vec3f, d.vec3f(0, 1.0, 0))
-  .$name('color')
   .$usage('uniform');
 
 const sampler = device.createSampler({

--- a/apps/typegpu-docs/src/content/examples/image-processing/chroma-keying/index.ts
+++ b/apps/typegpu-docs/src/content/examples/image-processing/chroma-keying/index.ts
@@ -131,14 +131,10 @@ const mediaProcessor = new MediaStreamTrackProcessor({
 });
 const reader = mediaProcessor.readable.getReader();
 
-const thresholdBuffer = root
-  .createBuffer(d.f32, 0.5)
-  .$name('threshold')
-  .$usage('uniform');
+const thresholdBuffer = root.createBuffer(d.f32, 0.5).$usage('uniform');
 
 const colorBuffer = root
   .createBuffer(d.vec3f, d.vec3f(0, 1.0, 0))
-  .$name('color')
   .$usage('uniform');
 
 const sampler = device.createSampler({

--- a/apps/typegpu-docs/src/content/examples/rendering/3d-fish/compute.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/3d-fish/compute.ts
@@ -132,5 +132,4 @@ export const computeShader = tgpu['~unstable']
     );
     fishData.position = std.add(fishData.position, translation);
     layout.$.nextFishData[fishIndex] = fishData;
-  })
-  .$name('compute shader');
+  });

--- a/apps/typegpu-docs/src/content/examples/rendering/3d-fish/compute.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/3d-fish/compute.ts
@@ -5,131 +5,130 @@ import * as p from './params.ts';
 import { computeBindGroupLayout as layout, ModelData } from './schemas.ts';
 import { projectPointOnLine } from './tgsl-helpers.ts';
 
-export const computeShader = tgpu['~unstable']
-  .computeFn({
-    in: { gid: d.builtin.globalInvocationId },
-    workgroupSize: [p.workGroupSize],
-  })((input) => {
-    const fishIndex = input.gid.x;
-    // TODO: replace it with struct copy when Chromium is fixed
-    const fishData = ModelData({
-      position: layout.$.currentFishData[fishIndex].position,
-      direction: layout.$.currentFishData[fishIndex].direction,
-      scale: layout.$.currentFishData[fishIndex].scale,
-      variant: layout.$.currentFishData[fishIndex].variant,
-      applySeaDesaturation:
-        layout.$.currentFishData[fishIndex].applySeaDesaturation,
-      applySeaFog: layout.$.currentFishData[fishIndex].applySeaFog,
-      applySinWave: layout.$.currentFishData[fishIndex].applySinWave,
-    });
-    let separation = d.vec3f();
-    let alignment = d.vec3f();
-    let alignmentCount = 0;
-    let cohesion = d.vec3f();
-    let cohesionCount = 0;
-    let wallRepulsion = d.vec3f();
-    let rayRepulsion = d.vec3f();
-
-    for (let i = 0; i < p.fishAmount; i += 1) {
-      if (d.u32(i) === fishIndex) {
-        continue;
-      }
-
-      // TODO: replace it with struct copy when Chromium is fixed
-      const other = ModelData({
-        position: layout.$.currentFishData[i].position,
-        direction: layout.$.currentFishData[i].direction,
-        scale: layout.$.currentFishData[i].scale,
-        variant: layout.$.currentFishData[i].variant,
-        applySeaDesaturation: layout.$.currentFishData[i].applySeaDesaturation,
-        applySeaFog: layout.$.currentFishData[i].applySeaFog,
-        applySinWave: layout.$.currentFishData[i].applySinWave,
-      });
-      const dist = std.length(std.sub(fishData.position, other.position));
-      if (dist < layout.$.fishBehavior.separationDist) {
-        separation = std.add(
-          separation,
-          std.sub(fishData.position, other.position),
-        );
-      }
-      if (dist < layout.$.fishBehavior.alignmentDist) {
-        alignment = std.add(alignment, other.direction);
-        alignmentCount = alignmentCount + 1;
-      }
-      if (dist < layout.$.fishBehavior.cohesionDist) {
-        cohesion = std.add(cohesion, other.position);
-        cohesionCount = cohesionCount + 1;
-      }
-    }
-    if (alignmentCount > 0) {
-      alignment = std.mul(1 / d.f32(alignmentCount), alignment);
-    }
-    if (cohesionCount > 0) {
-      cohesion = std.sub(
-        std.mul(1 / d.f32(cohesionCount), cohesion),
-        fishData.position,
-      );
-    }
-    for (let i = 0; i < 3; i += 1) {
-      const repulsion = d.vec3f();
-      repulsion[i] = 1.0;
-
-      const axisAquariumSize = p.aquariumSize[i] / 2;
-      const axisPosition = fishData.position[i];
-      const distance = p.fishWallRepulsionDistance;
-
-      if (axisPosition > axisAquariumSize - distance) {
-        const str = axisPosition - (axisAquariumSize - distance);
-        wallRepulsion = std.sub(wallRepulsion, std.mul(str, repulsion));
-      }
-
-      if (axisPosition < -axisAquariumSize + distance) {
-        const str = -axisAquariumSize + distance - axisPosition;
-        wallRepulsion = std.add(wallRepulsion, std.mul(str, repulsion));
-      }
-    }
-
-    if (layout.$.mouseRay.activated === 1) {
-      const proj = projectPointOnLine(
-        fishData.position,
-        layout.$.mouseRay.line,
-      );
-      const diff = std.sub(fishData.position, proj);
-      const limit = p.fishMouseRayRepulsionDistance;
-      const str = std.pow(2, std.clamp(limit - std.length(diff), 0, limit)) - 1;
-      rayRepulsion = std.mul(str, std.normalize(diff));
-    }
-
-    fishData.direction = std.add(
-      fishData.direction,
-      std.mul(layout.$.fishBehavior.separationStr, separation),
-    );
-    fishData.direction = std.add(
-      fishData.direction,
-      std.mul(layout.$.fishBehavior.alignmentStr, alignment),
-    );
-    fishData.direction = std.add(
-      fishData.direction,
-      std.mul(layout.$.fishBehavior.cohesionStr, cohesion),
-    );
-    fishData.direction = std.add(
-      fishData.direction,
-      std.mul(p.fishWallRepulsionStrength, wallRepulsion),
-    );
-    fishData.direction = std.add(
-      fishData.direction,
-      std.mul(p.fishMouseRayRepulsionStrength, rayRepulsion),
-    );
-
-    fishData.direction = std.mul(
-      std.clamp(std.length(fishData.direction), 0.0, 0.01),
-      std.normalize(fishData.direction),
-    );
-
-    const translation = std.mul(
-      d.f32(std.min(999, layout.$.timePassed)) / 8,
-      fishData.direction,
-    );
-    fishData.position = std.add(fishData.position, translation);
-    layout.$.nextFishData[fishIndex] = fishData;
+export const computeShader = tgpu['~unstable'].computeFn({
+  in: { gid: d.builtin.globalInvocationId },
+  workgroupSize: [p.workGroupSize],
+})((input) => {
+  const fishIndex = input.gid.x;
+  // TODO: replace it with struct copy when Chromium is fixed
+  const fishData = ModelData({
+    position: layout.$.currentFishData[fishIndex].position,
+    direction: layout.$.currentFishData[fishIndex].direction,
+    scale: layout.$.currentFishData[fishIndex].scale,
+    variant: layout.$.currentFishData[fishIndex].variant,
+    applySeaDesaturation:
+      layout.$.currentFishData[fishIndex].applySeaDesaturation,
+    applySeaFog: layout.$.currentFishData[fishIndex].applySeaFog,
+    applySinWave: layout.$.currentFishData[fishIndex].applySinWave,
   });
+  let separation = d.vec3f();
+  let alignment = d.vec3f();
+  let alignmentCount = 0;
+  let cohesion = d.vec3f();
+  let cohesionCount = 0;
+  let wallRepulsion = d.vec3f();
+  let rayRepulsion = d.vec3f();
+
+  for (let i = 0; i < p.fishAmount; i += 1) {
+    if (d.u32(i) === fishIndex) {
+      continue;
+    }
+
+    // TODO: replace it with struct copy when Chromium is fixed
+    const other = ModelData({
+      position: layout.$.currentFishData[i].position,
+      direction: layout.$.currentFishData[i].direction,
+      scale: layout.$.currentFishData[i].scale,
+      variant: layout.$.currentFishData[i].variant,
+      applySeaDesaturation: layout.$.currentFishData[i].applySeaDesaturation,
+      applySeaFog: layout.$.currentFishData[i].applySeaFog,
+      applySinWave: layout.$.currentFishData[i].applySinWave,
+    });
+    const dist = std.length(std.sub(fishData.position, other.position));
+    if (dist < layout.$.fishBehavior.separationDist) {
+      separation = std.add(
+        separation,
+        std.sub(fishData.position, other.position),
+      );
+    }
+    if (dist < layout.$.fishBehavior.alignmentDist) {
+      alignment = std.add(alignment, other.direction);
+      alignmentCount = alignmentCount + 1;
+    }
+    if (dist < layout.$.fishBehavior.cohesionDist) {
+      cohesion = std.add(cohesion, other.position);
+      cohesionCount = cohesionCount + 1;
+    }
+  }
+  if (alignmentCount > 0) {
+    alignment = std.mul(1 / d.f32(alignmentCount), alignment);
+  }
+  if (cohesionCount > 0) {
+    cohesion = std.sub(
+      std.mul(1 / d.f32(cohesionCount), cohesion),
+      fishData.position,
+    );
+  }
+  for (let i = 0; i < 3; i += 1) {
+    const repulsion = d.vec3f();
+    repulsion[i] = 1.0;
+
+    const axisAquariumSize = p.aquariumSize[i] / 2;
+    const axisPosition = fishData.position[i];
+    const distance = p.fishWallRepulsionDistance;
+
+    if (axisPosition > axisAquariumSize - distance) {
+      const str = axisPosition - (axisAquariumSize - distance);
+      wallRepulsion = std.sub(wallRepulsion, std.mul(str, repulsion));
+    }
+
+    if (axisPosition < -axisAquariumSize + distance) {
+      const str = -axisAquariumSize + distance - axisPosition;
+      wallRepulsion = std.add(wallRepulsion, std.mul(str, repulsion));
+    }
+  }
+
+  if (layout.$.mouseRay.activated === 1) {
+    const proj = projectPointOnLine(
+      fishData.position,
+      layout.$.mouseRay.line,
+    );
+    const diff = std.sub(fishData.position, proj);
+    const limit = p.fishMouseRayRepulsionDistance;
+    const str = std.pow(2, std.clamp(limit - std.length(diff), 0, limit)) - 1;
+    rayRepulsion = std.mul(str, std.normalize(diff));
+  }
+
+  fishData.direction = std.add(
+    fishData.direction,
+    std.mul(layout.$.fishBehavior.separationStr, separation),
+  );
+  fishData.direction = std.add(
+    fishData.direction,
+    std.mul(layout.$.fishBehavior.alignmentStr, alignment),
+  );
+  fishData.direction = std.add(
+    fishData.direction,
+    std.mul(layout.$.fishBehavior.cohesionStr, cohesion),
+  );
+  fishData.direction = std.add(
+    fishData.direction,
+    std.mul(p.fishWallRepulsionStrength, wallRepulsion),
+  );
+  fishData.direction = std.add(
+    fishData.direction,
+    std.mul(p.fishMouseRayRepulsionStrength, rayRepulsion),
+  );
+
+  fishData.direction = std.mul(
+    std.clamp(std.length(fishData.direction), 0.0, 0.01),
+    std.normalize(fishData.direction),
+  );
+
+  const translation = std.mul(
+    d.f32(std.min(999, layout.$.timePassed)) / 8,
+    fishData.direction,
+  );
+  fishData.position = std.add(fishData.position, translation);
+  layout.$.nextFishData[fishIndex] = fishData;
+});

--- a/apps/typegpu-docs/src/content/examples/rendering/3d-fish/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/3d-fish/index.ts
@@ -137,33 +137,22 @@ const camera = {
   ),
 };
 
-const cameraBuffer = root
-  .createBuffer(Camera, camera)
-  .$usage('uniform')
-  .$name('camera');
+const cameraBuffer = root.createBuffer(Camera, camera).$usage('uniform');
 
 const mouseRayBuffer = root
   .createBuffer(MouseRay, {
     activated: 0,
     line: Line3({ origin: d.vec3f(), dir: d.vec3f() }),
   })
-  .$usage('uniform')
-  .$name('mouse');
+  .$usage('uniform');
 
-const timePassedBuffer = root
-  .createBuffer(d.f32)
-  .$usage('uniform')
-  .$name('time passed');
+const timePassedBuffer = root.createBuffer(d.f32).$usage('uniform');
 
-const currentTimeBuffer = root
-  .createBuffer(d.f32)
-  .$usage('uniform')
-  .$name('current time');
+const currentTimeBuffer = root.createBuffer(d.f32).$usage('uniform');
 
 const fishBehaviorBuffer = root
   .createBuffer(FishBehaviorParams, presets.default)
-  .$usage('uniform')
-  .$name('fish behavior');
+  .$usage('uniform');
 
 const oceanFloorDataBuffer = root
   .createBuffer(ModelDataArray(1), [
@@ -177,8 +166,7 @@ const oceanFloorDataBuffer = root
       applySeaDesaturation: 0,
     },
   ])
-  .$usage('storage', 'vertex')
-  .$name('ocean floor');
+  .$usage('storage', 'vertex');
 
 randomizeFishPositions();
 
@@ -193,8 +181,7 @@ const renderPipeline = root['~unstable']
     depthCompare: 'less',
   })
   .withPrimitive({ topology: 'triangle-list' })
-  .createPipeline()
-  .$name('render');
+  .createPipeline();
 
 let depthTexture = root.device.createTexture({
   size: [canvas.width, canvas.height, 1],
@@ -204,8 +191,7 @@ let depthTexture = root.device.createTexture({
 
 const computePipeline = root['~unstable']
   .withCompute(computeShader)
-  .createPipeline()
-  .$name('compute');
+  .createPipeline();
 
 // bind groups
 

--- a/apps/typegpu-docs/src/content/examples/rendering/3d-fish/render.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/3d-fish/render.ts
@@ -92,8 +92,7 @@ export const vertexShader = tgpu['~unstable']
       applySeaDesaturation: currentModelData.applySeaDesaturation,
       variant: currentModelData.variant,
     };
-  })
-  .$name('vertexShader');
+  });
 
 const sampleTexture = tgpu['~unstable'].fn(
   [d.vec2f],
@@ -162,5 +161,4 @@ export const fragmentShader = tgpu['~unstable']
     }
 
     return d.vec4f(foggedColor.xyz, 1);
-  })
-  .$name('fragmentShader');
+  });

--- a/apps/typegpu-docs/src/content/examples/rendering/3d-fish/render.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/3d-fish/render.ts
@@ -11,88 +11,87 @@ import {
 } from './schemas.ts';
 import { applySinWave, PosAndNormal } from './tgsl-helpers.ts';
 
-export const vertexShader = tgpu['~unstable']
-  .vertexFn({
-    in: { ...ModelVertexInput, instanceIndex: d.builtin.instanceIndex },
-    out: ModelVertexOutput,
-  })((input) => {
-    // rotate the model so that it aligns with model's direction of movement
-    // https://simple.wikipedia.org/wiki/Pitch,_yaw,_and_roll
-    // TODO: replace it with struct copy when Chromium is fixed
-    const currentModelData = ModelData({
-      position: layout.$.modelData[input.instanceIndex].position,
-      direction: layout.$.modelData[input.instanceIndex].direction,
-      scale: layout.$.modelData[input.instanceIndex].scale,
-      variant: layout.$.modelData[input.instanceIndex].variant,
-      applySeaDesaturation:
-        layout.$.modelData[input.instanceIndex].applySeaDesaturation,
-      applySeaFog: layout.$.modelData[input.instanceIndex].applySeaFog,
-      applySinWave: layout.$.modelData[input.instanceIndex].applySinWave,
-    });
+export const vertexShader = tgpu['~unstable'].vertexFn({
+  in: { ...ModelVertexInput, instanceIndex: d.builtin.instanceIndex },
+  out: ModelVertexOutput,
+})((input) => {
+  // rotate the model so that it aligns with model's direction of movement
+  // https://simple.wikipedia.org/wiki/Pitch,_yaw,_and_roll
+  // TODO: replace it with struct copy when Chromium is fixed
+  const currentModelData = ModelData({
+    position: layout.$.modelData[input.instanceIndex].position,
+    direction: layout.$.modelData[input.instanceIndex].direction,
+    scale: layout.$.modelData[input.instanceIndex].scale,
+    variant: layout.$.modelData[input.instanceIndex].variant,
+    applySeaDesaturation:
+      layout.$.modelData[input.instanceIndex].applySeaDesaturation,
+    applySeaFog: layout.$.modelData[input.instanceIndex].applySeaFog,
+    applySinWave: layout.$.modelData[input.instanceIndex].applySinWave,
+  });
 
-    // apply sin wave to imitate swimming motion
-    let wavedVertex = PosAndNormal({
-      position: input.modelPosition,
-      normal: input.modelNormal,
-    });
-    if (currentModelData.applySinWave === 1) {
-      wavedVertex = applySinWave(
-        input.instanceIndex,
-        PosAndNormal({
-          position: input.modelPosition,
-          normal: input.modelNormal,
-        }),
-        layout.$.currentTime,
-      );
-    }
+  // apply sin wave to imitate swimming motion
+  let wavedVertex = PosAndNormal({
+    position: input.modelPosition,
+    normal: input.modelNormal,
+  });
+  if (currentModelData.applySinWave === 1) {
+    wavedVertex = applySinWave(
+      input.instanceIndex,
+      PosAndNormal({
+        position: input.modelPosition,
+        normal: input.modelNormal,
+      }),
+      layout.$.currentTime,
+    );
+  }
 
-    // rotate model
-    const direction = std.normalize(currentModelData.direction);
-    const yaw = -std.atan2(direction.z, direction.x) + Math.PI;
-    const pitch = std.asin(-direction.y);
+  // rotate model
+  const direction = std.normalize(currentModelData.direction);
+  const yaw = -std.atan2(direction.z, direction.x) + Math.PI;
+  const pitch = std.asin(-direction.y);
 
-    const scaleMatrix = d.mat4x4f.scaling(d.vec3f(currentModelData.scale));
-    const pitchMatrix = d.mat4x4f.rotationZ(pitch);
-    const yawMatrix = d.mat4x4f.rotationY(yaw);
-    const translationMatrix = d.mat4x4f.translation(currentModelData.position);
+  const scaleMatrix = d.mat4x4f.scaling(d.vec3f(currentModelData.scale));
+  const pitchMatrix = d.mat4x4f.rotationZ(pitch);
+  const yawMatrix = d.mat4x4f.rotationY(yaw);
+  const translationMatrix = d.mat4x4f.translation(currentModelData.position);
 
-    const worldPosition = std.mul(
-      translationMatrix,
+  const worldPosition = std.mul(
+    translationMatrix,
+    std.mul(
+      yawMatrix,
       std.mul(
-        yawMatrix,
+        pitchMatrix,
         std.mul(
-          pitchMatrix,
-          std.mul(
-            scaleMatrix,
-            d.vec4f(wavedVertex.position, 1),
-          ),
+          scaleMatrix,
+          d.vec4f(wavedVertex.position, 1),
         ),
       ),
-    );
+    ),
+  );
 
-    // calculate where the normal vector points to
-    const worldNormal = std.normalize(
-      std.mul(yawMatrix, std.mul(pitchMatrix, d.vec4f(wavedVertex.normal, 1)))
-        .xyz,
-    );
+  // calculate where the normal vector points to
+  const worldNormal = std.normalize(
+    std.mul(yawMatrix, std.mul(pitchMatrix, d.vec4f(wavedVertex.normal, 1)))
+      .xyz,
+  );
 
-    // project the world position into the camera
-    const worldPositionUniform = worldPosition;
-    const canvasPosition = std.mul(
-      layout.$.camera.projection,
-      std.mul(layout.$.camera.view, worldPositionUniform),
-    );
+  // project the world position into the camera
+  const worldPositionUniform = worldPosition;
+  const canvasPosition = std.mul(
+    layout.$.camera.projection,
+    std.mul(layout.$.camera.view, worldPositionUniform),
+  );
 
-    return {
-      canvasPosition: canvasPosition,
-      textureUV: input.textureUV,
-      worldNormal: worldNormal,
-      worldPosition: worldPosition.xyz,
-      applySeaFog: currentModelData.applySeaFog,
-      applySeaDesaturation: currentModelData.applySeaDesaturation,
-      variant: currentModelData.variant,
-    };
-  });
+  return {
+    canvasPosition: canvasPosition,
+    textureUV: input.textureUV,
+    worldNormal: worldNormal,
+    worldPosition: worldPosition.xyz,
+    applySeaFog: currentModelData.applySeaFog,
+    applySeaDesaturation: currentModelData.applySeaDesaturation,
+    variant: currentModelData.variant,
+  };
+});
 
 const sampleTexture = tgpu['~unstable'].fn(
   [d.vec2f],
@@ -102,63 +101,62 @@ const sampleTexture = tgpu['~unstable'].fn(
 }
 `.$uses({ layout });
 
-export const fragmentShader = tgpu['~unstable']
-  .fragmentFn({
-    in: ModelVertexOutput,
-    out: d.vec4f,
-  })((input) => {
-    // shade the fragment in Phong reflection model
-    // https://en.wikipedia.org/wiki/Phong_reflection_model
-    // then apply sea fog and sea desaturation
+export const fragmentShader = tgpu['~unstable'].fragmentFn({
+  in: ModelVertexOutput,
+  out: d.vec4f,
+})((input) => {
+  // shade the fragment in Phong reflection model
+  // https://en.wikipedia.org/wiki/Phong_reflection_model
+  // then apply sea fog and sea desaturation
 
-    const textureColorWithAlpha = sampleTexture(input.textureUV); // base color
-    const textureColor = textureColorWithAlpha.xyz;
+  const textureColorWithAlpha = sampleTexture(input.textureUV); // base color
+  const textureColor = textureColorWithAlpha.xyz;
 
-    const ambient = std.mul(0.5, std.mul(textureColor, p.lightColor));
+  const ambient = std.mul(0.5, std.mul(textureColor, p.lightColor));
 
-    const cosTheta = std.dot(input.worldNormal, p.lightDirection);
-    const diffuse = std.mul(
-      std.max(0, cosTheta),
-      std.mul(textureColor, p.lightColor),
-    );
+  const cosTheta = std.dot(input.worldNormal, p.lightDirection);
+  const diffuse = std.mul(
+    std.max(0, cosTheta),
+    std.mul(textureColor, p.lightColor),
+  );
 
-    const viewSource = std.normalize(
-      std.sub(layout.$.camera.position.xyz, input.worldPosition),
-    );
-    const reflectSource = std.normalize(
-      std.reflect(std.mul(-1, p.lightDirection), input.worldNormal),
-    );
-    const specularStrength = std.pow(
-      std.max(0, std.dot(viewSource, reflectSource)),
-      16,
-    );
-    const specular = std.mul(specularStrength, p.lightColor);
+  const viewSource = std.normalize(
+    std.sub(layout.$.camera.position.xyz, input.worldPosition),
+  );
+  const reflectSource = std.normalize(
+    std.reflect(std.mul(-1, p.lightDirection), input.worldNormal),
+  );
+  const specularStrength = std.pow(
+    std.max(0, std.dot(viewSource, reflectSource)),
+    16,
+  );
+  const specular = std.mul(specularStrength, p.lightColor);
 
-    const lightedColor = std.add(ambient, std.add(diffuse, specular));
+  const lightedColor = std.add(ambient, std.add(diffuse, specular));
 
-    // apply desaturation
-    const distanceFromCamera = std.length(
-      std.sub(layout.$.camera.position.xyz, input.worldPosition),
-    );
+  // apply desaturation
+  const distanceFromCamera = std.length(
+    std.sub(layout.$.camera.position.xyz, input.worldPosition),
+  );
 
-    let desaturatedColor = lightedColor;
-    if (input.applySeaDesaturation === 1) {
-      const desaturationFactor = -std.atan2((distanceFromCamera - 5) / 10, 1) /
-        3;
-      const hsv = rgbToHsv(desaturatedColor);
-      hsv.y += desaturationFactor / 2;
-      hsv.z += desaturationFactor;
-      // Hue shift
-      hsv.x += (input.variant - 0.5) * 0.2;
-      desaturatedColor = hsvToRgb(hsv);
-    }
+  let desaturatedColor = lightedColor;
+  if (input.applySeaDesaturation === 1) {
+    const desaturationFactor = -std.atan2((distanceFromCamera - 5) / 10, 1) /
+      3;
+    const hsv = rgbToHsv(desaturatedColor);
+    hsv.y += desaturationFactor / 2;
+    hsv.z += desaturationFactor;
+    // Hue shift
+    hsv.x += (input.variant - 0.5) * 0.2;
+    desaturatedColor = hsvToRgb(hsv);
+  }
 
-    let foggedColor = desaturatedColor;
-    if (input.applySeaFog === 1) {
-      const fogParameter = std.max(0, (distanceFromCamera - 1.5) * 0.2);
-      const fogFactor = fogParameter / (1 + fogParameter);
-      foggedColor = std.mix(foggedColor, p.backgroundColor, fogFactor);
-    }
+  let foggedColor = desaturatedColor;
+  if (input.applySeaFog === 1) {
+    const fogParameter = std.max(0, (distanceFromCamera - 1.5) * 0.2);
+    const fogFactor = fogParameter / (1 + fogParameter);
+    foggedColor = std.mix(foggedColor, p.backgroundColor, fogFactor);
+  }
 
-    return d.vec4f(foggedColor.xyz, 1);
-  });
+  return d.vec4f(foggedColor.xyz, 1);
+});

--- a/apps/typegpu-docs/src/content/examples/rendering/3d-fish/schemas.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/3d-fish/schemas.ts
@@ -14,26 +14,22 @@ export const Line3 = d.struct({
   dir: d.vec3f,
 });
 
-export const Camera = d
-  .struct({
-    position: d.vec4f,
-    targetPos: d.vec4f,
-    view: d.mat4x4f,
-    projection: d.mat4x4f,
-  })
-  .$name('camera');
+export const Camera = d.struct({
+  position: d.vec4f,
+  targetPos: d.vec4f,
+  view: d.mat4x4f,
+  projection: d.mat4x4f,
+});
 
-export const ModelData = d
-  .struct({
-    position: d.vec3f,
-    direction: d.vec3f, // in case of the fish, this is also the velocity
-    scale: d.f32,
-    variant: d.f32, // (0-1)
-    applySinWave: d.u32, // bool
-    applySeaFog: d.u32, // bool
-    applySeaDesaturation: d.u32, // bool
-  })
-  .$name('model data');
+export const ModelData = d.struct({
+  position: d.vec3f,
+  direction: d.vec3f, // in case of the fish, this is also the velocity
+  scale: d.f32,
+  variant: d.f32, // (0-1)
+  applySinWave: d.u32, // bool
+  applySeaFog: d.u32, // bool
+  applySeaDesaturation: d.u32, // bool
+});
 
 export const ModelDataArray = (n: number) => d.arrayOf(ModelData, n);
 
@@ -53,53 +49,46 @@ export const ModelVertexOutput = {
   applySeaDesaturation: d.interpolate('flat', d.u32), // bool
 } as const;
 
-export const MouseRay = d
-  .struct({
-    activated: d.u32,
-    line: Line3,
-  })
-  .$name('mouse ray');
+export const MouseRay = d.struct({
+  activated: d.u32,
+  line: Line3,
+});
 
-export const FishBehaviorParams = d
-  .struct({
-    separationDist: d.f32,
-    separationStr: d.f32,
-    alignmentDist: d.f32,
-    alignmentStr: d.f32,
-    cohesionDist: d.f32,
-    cohesionStr: d.f32,
-  })
-  .$name('fish behavior params');
+export const FishBehaviorParams = d.struct({
+  separationDist: d.f32,
+  separationStr: d.f32,
+  alignmentDist: d.f32,
+  alignmentStr: d.f32,
+  cohesionDist: d.f32,
+  cohesionStr: d.f32,
+});
 
 // layouts
 
-export const modelVertexLayout = tgpu
-  .vertexLayout((n: number) => d.arrayOf(d.struct(ModelVertexInput), n))
-  .$name('model vertex');
+export const modelVertexLayout = tgpu.vertexLayout((n: number) =>
+  d.arrayOf(d.struct(ModelVertexInput), n)
+);
 
-export const renderInstanceLayout = tgpu
-  .vertexLayout(ModelDataArray, 'instance')
-  .$name('render instance');
+export const renderInstanceLayout = tgpu.vertexLayout(
+  ModelDataArray,
+  'instance',
+);
 
-export const renderBindGroupLayout = tgpu
-  .bindGroupLayout({
-    modelData: { storage: ModelDataArray },
-    modelTexture: { texture: 'float' },
-    camera: { uniform: Camera },
-    sampler: { sampler: 'filtering' },
-    currentTime: { uniform: d.f32 },
-  })
-  .$name('render bind group');
+export const renderBindGroupLayout = tgpu.bindGroupLayout({
+  modelData: { storage: ModelDataArray },
+  modelTexture: { texture: 'float' },
+  camera: { uniform: Camera },
+  sampler: { sampler: 'filtering' },
+  currentTime: { uniform: d.f32 },
+});
 
-export const computeBindGroupLayout = tgpu
-  .bindGroupLayout({
-    currentFishData: { storage: ModelDataArray },
-    nextFishData: {
-      storage: ModelDataArray,
-      access: 'mutable',
-    },
-    mouseRay: { uniform: MouseRay },
-    timePassed: { uniform: d.f32 },
-    fishBehavior: { uniform: FishBehaviorParams },
-  })
-  .$name('compute bind group');
+export const computeBindGroupLayout = tgpu.bindGroupLayout({
+  currentFishData: { storage: ModelDataArray },
+  nextFishData: {
+    storage: ModelDataArray,
+    access: 'mutable',
+  },
+  mouseRay: { uniform: MouseRay },
+  timePassed: { uniform: d.f32 },
+  fishBehavior: { uniform: FishBehaviorParams },
+});

--- a/apps/typegpu-docs/src/content/examples/rendering/3d-fish/tgsl-helpers.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/3d-fish/tgsl-helpers.ts
@@ -19,7 +19,7 @@ export const projectPointOnLine = tgpu['~unstable'].fn(
 export const PosAndNormal = d.struct({
   position: d.vec3f,
   normal: d.vec3f,
-}).$name('PosAndNormal');
+});
 
 export const applySinWave = tgpu['~unstable'].fn(
   [d.u32, PosAndNormal, d.f32],

--- a/apps/typegpu-docs/src/content/examples/rendering/box-raytracing/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/box-raytracing/index.ts
@@ -1,3 +1,4 @@
+import { linearToSrgb, srgbToLinear } from '@typegpu/color';
 import tgpu from 'typegpu';
 import * as d from 'typegpu/data';
 import {
@@ -11,7 +12,6 @@ import {
   pow,
   sub,
 } from 'typegpu/std';
-import { linearToSrgb, srgbToLinear } from '@typegpu/color';
 import { mat4 } from 'wgpu-matrix';
 
 // init canvas and values
@@ -87,7 +87,7 @@ const boxMatrix = root.createReadonly(
           })),
       ),
   ),
-).$name('box_array');
+);
 
 const uniforms = root.createUniform(Uniforms);
 
@@ -154,8 +154,7 @@ const getBoxIntersection = tgpu['~unstable'].fn(
 
   return IntersectionStruct(tMin > 0 && tMax > 0, tMin, tMax);
 }`
-  .$uses({ AxisAlignedBounds, Ray, IntersectionStruct })
-  .$name('box_intersection');
+  .$uses({ AxisAlignedBounds, Ray, IntersectionStruct });
 
 const Varying = {
   rayWorldOrigin: d.vec3f,

--- a/apps/typegpu-docs/src/content/examples/rendering/xor-dev-centrifuge-2/index.html
+++ b/apps/typegpu-docs/src/content/examples/rendering/xor-dev-centrifuge-2/index.html
@@ -1,7 +1,5 @@
 <canvas data-fit-to-container></canvas>
-<p
-  class="absolute px-2 py-1 rounded-xl top-2 mx-auto text-lg text-center text-white bg-black/50"
->
+<p class="absolute px-2 py-1 rounded-xl top-2 mx-auto text-lg text-center text-white bg-black/50">
   Port of "Centrifuge 2" by XorDev (<a
     class="text-purple-300"
     href="https://xordev.com"

--- a/apps/typegpu-docs/src/content/examples/rendering/xor-dev-centrifuge-2/index.html
+++ b/apps/typegpu-docs/src/content/examples/rendering/xor-dev-centrifuge-2/index.html
@@ -1,5 +1,7 @@
 <canvas data-fit-to-container></canvas>
-<p class="absolute px-2 py-1 rounded-xl top-2 mx-auto text-lg text-center text-white bg-black/50">
+<p
+  class="absolute px-2 py-1 rounded-xl top-2 mx-auto text-lg text-center text-white bg-black/50"
+>
   Port of "Centrifuge 2" by XorDev (<a
     class="text-purple-300"
     href="https://xordev.com"

--- a/apps/typegpu-docs/src/content/examples/rendering/xor-dev-runner/index.html
+++ b/apps/typegpu-docs/src/content/examples/rendering/xor-dev-runner/index.html
@@ -1,5 +1,7 @@
 <canvas data-fit-to-container></canvas>
-<p class="absolute px-2 py-1 rounded-xl top-2 mx-auto text-lg text-center text-white bg-black/50">
+<p
+  class="absolute px-2 py-1 rounded-xl top-2 mx-auto text-lg text-center text-white bg-black/50"
+>
   Port of "Runner" by XorDev (<a
     class="text-purple-300"
     href="https://xordev.com"

--- a/apps/typegpu-docs/src/content/examples/rendering/xor-dev-runner/index.html
+++ b/apps/typegpu-docs/src/content/examples/rendering/xor-dev-runner/index.html
@@ -1,7 +1,5 @@
 <canvas data-fit-to-container></canvas>
-<p
-  class="absolute px-2 py-1 rounded-xl top-2 mx-auto text-lg text-center text-white bg-black/50"
->
+<p class="absolute px-2 py-1 rounded-xl top-2 mx-auto text-lg text-center text-white bg-black/50">
   Port of "Runner" by XorDev (<a
     class="text-purple-300"
     href="https://xordev.com"

--- a/apps/typegpu-docs/src/content/examples/simulation/boids-next/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/boids-next/index.ts
@@ -62,16 +62,14 @@ const mainFrag = tgpu['~unstable'].fragmentFn({
   return input.color;
 });
 
-const Params = d
-  .struct({
-    separationDistance: d.f32,
-    separationStrength: d.f32,
-    alignmentDistance: d.f32,
-    alignmentStrength: d.f32,
-    cohesionDistance: d.f32,
-    cohesionStrength: d.f32,
-  })
-  .$name('Params');
+const Params = d.struct({
+  separationDistance: d.f32,
+  separationStrength: d.f32,
+  alignmentDistance: d.f32,
+  alignmentStrength: d.f32,
+  cohesionDistance: d.f32,
+  cohesionStrength: d.f32,
+});
 
 type Params = d.Infer<typeof Params>;
 
@@ -186,15 +184,13 @@ const renderPipeline = root['~unstable']
   .createPipeline()
   .with(vertexLayout, triangleVertexBuffer);
 
-const computeBindGroupLayout = tgpu
-  .bindGroupLayout({
-    currentTrianglePos: { storage: TriangleDataArray },
-    nextTrianglePos: {
-      storage: TriangleDataArray,
-      access: 'mutable',
-    },
-  })
-  .$name('compute');
+const computeBindGroupLayout = tgpu.bindGroupLayout({
+  currentTrianglePos: { storage: TriangleDataArray },
+  nextTrianglePos: {
+    storage: TriangleDataArray,
+    access: 'mutable',
+  },
+});
 
 const { currentTrianglePos, nextTrianglePos } = computeBindGroupLayout.bound;
 

--- a/apps/typegpu-docs/src/content/examples/simulation/confetti/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/confetti/index.ts
@@ -58,7 +58,6 @@ const particleGeometryBuffer = root
         color: COLOR_PALETTE[Math.floor(Math.random() * COLOR_PALETTE.length)],
       })),
   )
-  .$name('geometry')
   .$usage('vertex');
 
 const particleDataBuffer = root
@@ -73,13 +72,15 @@ const particleDataStorage = particleDataBuffer.as('mutable');
 
 // layouts
 
-const geometryLayout = tgpu
-  .vertexLayout((n: number) => d.arrayOf(ParticleGeometry, n), 'instance')
-  .$name('geometry');
+const geometryLayout = tgpu.vertexLayout(
+  (n: number) => d.arrayOf(ParticleGeometry, n),
+  'instance',
+);
 
-const dataLayout = tgpu
-  .vertexLayout((n: number) => d.arrayOf(ParticleData, n), 'instance')
-  .$name('data');
+const dataLayout = tgpu.vertexLayout(
+  (n: number) => d.arrayOf(ParticleData, n),
+  'instance',
+);
 
 // functions
 
@@ -164,14 +165,12 @@ const renderPipeline = root['~unstable']
     topology: 'triangle-strip',
   })
   .createPipeline()
-  .$name('draw confetti')
   .with(geometryLayout, particleGeometryBuffer)
   .with(dataLayout, particleDataBuffer);
 
 const computePipeline = root['~unstable']
   .withCompute(mainCompute)
-  .createPipeline()
-  .$name('move particles');
+  .createPipeline();
 
 // compute and draw
 

--- a/apps/typegpu-docs/src/content/examples/simulation/fluid-with-atomics/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/fluid-with-atomics/index.ts
@@ -48,18 +48,15 @@ function encodeBrushType(brushType: (typeof BrushTypes)[number]) {
   }
 }
 
-const size = root.createUniform(d.vec2u).$name('size');
-const viscosity = root.createUniform(d.u32).$name('viscosity');
+const size = root.createUniform(d.vec2u);
+const viscosity = root.createUniform(d.u32);
 
 const currentStateBuffer = root
   .createBuffer(d.arrayOf(d.u32, 1024 ** 2))
-  .$name('currentState')
   .$usage('storage', 'vertex');
 const currentStateStorage = currentStateBuffer.as('readonly');
 
-const nextState = root
-  .createMutable(d.arrayOf(d.atomic(d.u32), 1024 ** 2))
-  .$name('nextState');
+const nextState = root.createMutable(d.arrayOf(d.atomic(d.u32), 1024 ** 2));
 
 const squareBuffer = root
   .createBuffer(d.arrayOf(d.vec2f, 4), [
@@ -68,8 +65,7 @@ const squareBuffer = root
     d.vec2f(1, 0),
     d.vec2f(1, 1),
   ])
-  .$usage('vertex')
-  .$name('square');
+  .$usage('vertex');
 
 const getIndex = tgpu['~unstable'].fn([d.u32, d.u32], d.u32)((x, y) => {
   const h = size.$.y;

--- a/apps/typegpu-docs/src/content/examples/simulation/gravity/compute.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/gravity/compute.ts
@@ -24,171 +24,165 @@ const isSmaller = tgpu['~unstable'].fn([d.u32, d.u32], d.bool)(
     }
     return false;
   },
-).$name('isSmaller');
+);
 
-export const computeCollisionsShader = tgpu['~unstable']
-  .computeFn({
-    in: { gid: d.builtin.globalInvocationId },
-    workgroupSize: [1],
-  })((input) => {
-    const currentId = input.gid.x;
-    // TODO: replace it with struct copy when Chromium is fixed
-    const current = CelestialBody({
-      position: computeLayout.$.inState[currentId].position,
-      velocity: computeLayout.$.inState[currentId].velocity,
-      mass: computeLayout.$.inState[currentId].mass,
-      collisionBehavior: computeLayout.$.inState[currentId].collisionBehavior,
-      textureIndex: computeLayout.$.inState[currentId].textureIndex,
-      radiusMultiplier: computeLayout.$.inState[currentId].radiusMultiplier,
-      ambientLightFactor: computeLayout.$.inState[currentId].ambientLightFactor,
-      destroyed: computeLayout.$.inState[currentId].destroyed,
-    });
+export const computeCollisionsShader = tgpu['~unstable'].computeFn({
+  in: { gid: d.builtin.globalInvocationId },
+  workgroupSize: [1],
+})((input) => {
+  const currentId = input.gid.x;
+  // TODO: replace it with struct copy when Chromium is fixed
+  const current = CelestialBody({
+    position: computeLayout.$.inState[currentId].position,
+    velocity: computeLayout.$.inState[currentId].velocity,
+    mass: computeLayout.$.inState[currentId].mass,
+    collisionBehavior: computeLayout.$.inState[currentId].collisionBehavior,
+    textureIndex: computeLayout.$.inState[currentId].textureIndex,
+    radiusMultiplier: computeLayout.$.inState[currentId].radiusMultiplier,
+    ambientLightFactor: computeLayout.$.inState[currentId].ambientLightFactor,
+    destroyed: computeLayout.$.inState[currentId].destroyed,
+  });
 
-    const updatedCurrent = current;
-    if (current.destroyed === 0) {
-      for (let i = 0; i < computeLayout.$.celestialBodiesCount; i++) {
-        const otherId = d.u32(i);
-        // TODO: replace it with struct copy when Chromium is fixed
-        const other = CelestialBody({
-          position: computeLayout.$.inState[otherId].position,
-          velocity: computeLayout.$.inState[otherId].velocity,
-          mass: computeLayout.$.inState[otherId].mass,
-          collisionBehavior: computeLayout.$.inState[otherId].collisionBehavior,
-          textureIndex: computeLayout.$.inState[otherId].textureIndex,
-          radiusMultiplier: computeLayout.$.inState[otherId].radiusMultiplier,
-          ambientLightFactor:
-            computeLayout.$.inState[otherId].ambientLightFactor,
-          destroyed: computeLayout.$.inState[otherId].destroyed,
-        });
-        // no collision occurs...
-        if (
-          d.u32(i) === input.gid.x || // ...with itself
-          other.destroyed === 1 || // ...when other is destroyed
-          current.collisionBehavior === none || // ...when current behavior is none
-          other.collisionBehavior === none || // ...when other behavior is none
-          std.distance(current.position, other.position) >=
-            radiusOf(current) + radiusOf(other) // ...when other is too far away
-        ) {
-          continue;
-        }
+  const updatedCurrent = current;
+  if (current.destroyed === 0) {
+    for (let i = 0; i < computeLayout.$.celestialBodiesCount; i++) {
+      const otherId = d.u32(i);
+      // TODO: replace it with struct copy when Chromium is fixed
+      const other = CelestialBody({
+        position: computeLayout.$.inState[otherId].position,
+        velocity: computeLayout.$.inState[otherId].velocity,
+        mass: computeLayout.$.inState[otherId].mass,
+        collisionBehavior: computeLayout.$.inState[otherId].collisionBehavior,
+        textureIndex: computeLayout.$.inState[otherId].textureIndex,
+        radiusMultiplier: computeLayout.$.inState[otherId].radiusMultiplier,
+        ambientLightFactor: computeLayout.$.inState[otherId].ambientLightFactor,
+        destroyed: computeLayout.$.inState[otherId].destroyed,
+      });
+      // no collision occurs...
+      if (
+        d.u32(i) === input.gid.x || // ...with itself
+        other.destroyed === 1 || // ...when other is destroyed
+        current.collisionBehavior === none || // ...when current behavior is none
+        other.collisionBehavior === none || // ...when other behavior is none
+        std.distance(current.position, other.position) >=
+          radiusOf(current) + radiusOf(other) // ...when other is too far away
+      ) {
+        continue;
+      }
 
-        // if we got here, a collision occurs
-        if (
-          current.collisionBehavior === bounce &&
-          other.collisionBehavior === bounce
-        ) {
-          // bounce occurs
-          // push the smaller object outside
-          if (isSmaller(currentId, otherId)) {
-            updatedCurrent.position = std.add(
-              other.position,
-              std.mul(
-                radiusOf(current) + radiusOf(other),
-                std.normalize(std.sub(current.position, other.position)),
-              ),
-            );
-          }
-          // bounce with tiny damping
-          updatedCurrent.velocity = std.mul(
-            0.99,
-            std.sub(
-              updatedCurrent.velocity,
-              std.mul(
-                (((2 * other.mass) / (current.mass + other.mass)) *
-                  std.dot(
-                    std.sub(current.velocity, other.velocity),
-                    std.sub(current.position, other.position),
-                  )) /
-                  std.pow(std.distance(current.position, other.position), 2),
-                std.sub(current.position, other.position),
-              ),
+      // if we got here, a collision occurs
+      if (
+        current.collisionBehavior === bounce &&
+        other.collisionBehavior === bounce
+      ) {
+        // bounce occurs
+        // push the smaller object outside
+        if (isSmaller(currentId, otherId)) {
+          updatedCurrent.position = std.add(
+            other.position,
+            std.mul(
+              radiusOf(current) + radiusOf(other),
+              std.normalize(std.sub(current.position, other.position)),
             ),
           );
+        }
+        // bounce with tiny damping
+        updatedCurrent.velocity = std.mul(
+          0.99,
+          std.sub(
+            updatedCurrent.velocity,
+            std.mul(
+              (((2 * other.mass) / (current.mass + other.mass)) *
+                std.dot(
+                  std.sub(current.velocity, other.velocity),
+                  std.sub(current.position, other.position),
+                )) /
+                std.pow(std.distance(current.position, other.position), 2),
+              std.sub(current.position, other.position),
+            ),
+          ),
+        );
+      } else {
+        // merge occurs
+        const isCurrentAbsorbed = current.collisionBehavior === bounce ||
+          (current.collisionBehavior === merge &&
+            isSmaller(currentId, otherId));
+        if (isCurrentAbsorbed) {
+          // absorbed by the other
+          updatedCurrent.destroyed = 1;
         } else {
-          // merge occurs
-          const isCurrentAbsorbed = current.collisionBehavior === bounce ||
-            (current.collisionBehavior === merge &&
-              isSmaller(currentId, otherId));
-          if (isCurrentAbsorbed) {
-            // absorbed by the other
-            updatedCurrent.destroyed = 1;
-          } else {
-            // absorbs the other
-            const m1 = updatedCurrent.mass;
-            const m2 = other.mass;
-            updatedCurrent.velocity = std.add(
-              std.mul(m1 / (m1 + m2), updatedCurrent.velocity),
-              std.mul(m2 / (m1 + m2), other.velocity),
-            );
-            updatedCurrent.mass = m1 + m2;
-          }
+          // absorbs the other
+          const m1 = updatedCurrent.mass;
+          const m2 = other.mass;
+          updatedCurrent.velocity = std.add(
+            std.mul(m1 / (m1 + m2), updatedCurrent.velocity),
+            std.mul(m2 / (m1 + m2), other.velocity),
+          );
+          updatedCurrent.mass = m1 + m2;
         }
       }
     }
+  }
 
-    computeLayout.$.outState[input.gid.x] = updatedCurrent;
-  })
-  .$name('collisions');
+  computeLayout.$.outState[input.gid.x] = updatedCurrent;
+});
 
-export const computeGravityShader = tgpu['~unstable']
-  .computeFn({
-    in: { gid: d.builtin.globalInvocationId },
-    workgroupSize: [1],
-  })((input) => {
-    // TODO: replace it with struct copy when Chromium is fixed
-    const current = CelestialBody({
-      position: computeLayout.$.inState[input.gid.x].position,
-      velocity: computeLayout.$.inState[input.gid.x].velocity,
-      mass: computeLayout.$.inState[input.gid.x].mass,
-      collisionBehavior: computeLayout.$.inState[input.gid.x].collisionBehavior,
-      textureIndex: computeLayout.$.inState[input.gid.x].textureIndex,
-      radiusMultiplier: computeLayout.$.inState[input.gid.x].radiusMultiplier,
-      ambientLightFactor:
-        computeLayout.$.inState[input.gid.x].ambientLightFactor,
-      destroyed: computeLayout.$.inState[input.gid.x].destroyed,
-    });
-    const dt = timeAccess.$.passed * timeAccess.$.multiplier;
+export const computeGravityShader = tgpu['~unstable'].computeFn({
+  in: { gid: d.builtin.globalInvocationId },
+  workgroupSize: [1],
+})((input) => {
+  // TODO: replace it with struct copy when Chromium is fixed
+  const current = CelestialBody({
+    position: computeLayout.$.inState[input.gid.x].position,
+    velocity: computeLayout.$.inState[input.gid.x].velocity,
+    mass: computeLayout.$.inState[input.gid.x].mass,
+    collisionBehavior: computeLayout.$.inState[input.gid.x].collisionBehavior,
+    textureIndex: computeLayout.$.inState[input.gid.x].textureIndex,
+    radiusMultiplier: computeLayout.$.inState[input.gid.x].radiusMultiplier,
+    ambientLightFactor: computeLayout.$.inState[input.gid.x].ambientLightFactor,
+    destroyed: computeLayout.$.inState[input.gid.x].destroyed,
+  });
+  const dt = timeAccess.$.passed * timeAccess.$.multiplier;
 
-    const updatedCurrent = current;
-    if (current.destroyed === 0) {
-      for (let i = 0; i < computeLayout.$.celestialBodiesCount; i++) {
-        // TODO: replace it with struct copy when Chromium is fixed
-        const other = CelestialBody({
-          position: computeLayout.$.inState[i].position,
-          velocity: computeLayout.$.inState[i].velocity,
-          mass: computeLayout.$.inState[i].mass,
-          collisionBehavior: computeLayout.$.inState[i].collisionBehavior,
-          textureIndex: computeLayout.$.inState[i].textureIndex,
-          radiusMultiplier: computeLayout.$.inState[i].radiusMultiplier,
-          ambientLightFactor: computeLayout.$.inState[i].ambientLightFactor,
-          destroyed: computeLayout.$.inState[i].destroyed,
-        });
+  const updatedCurrent = current;
+  if (current.destroyed === 0) {
+    for (let i = 0; i < computeLayout.$.celestialBodiesCount; i++) {
+      // TODO: replace it with struct copy when Chromium is fixed
+      const other = CelestialBody({
+        position: computeLayout.$.inState[i].position,
+        velocity: computeLayout.$.inState[i].velocity,
+        mass: computeLayout.$.inState[i].mass,
+        collisionBehavior: computeLayout.$.inState[i].collisionBehavior,
+        textureIndex: computeLayout.$.inState[i].textureIndex,
+        radiusMultiplier: computeLayout.$.inState[i].radiusMultiplier,
+        ambientLightFactor: computeLayout.$.inState[i].ambientLightFactor,
+        destroyed: computeLayout.$.inState[i].destroyed,
+      });
 
-        if (d.u32(i) === input.gid.x || other.destroyed === 1) {
-          continue;
-        }
-
-        const dist = std.max(
-          radiusOf(current) + radiusOf(other),
-          std.distance(current.position, other.position),
-        );
-        const gravityForce = (current.mass * other.mass) / dist / dist;
-
-        const direction = std.normalize(
-          std.sub(other.position, current.position),
-        );
-        updatedCurrent.velocity = std.add(
-          updatedCurrent.velocity,
-          std.mul((gravityForce / current.mass) * dt, direction),
-        );
+      if (d.u32(i) === input.gid.x || other.destroyed === 1) {
+        continue;
       }
 
-      updatedCurrent.position = std.add(
-        updatedCurrent.position,
-        std.mul(dt, updatedCurrent.velocity),
+      const dist = std.max(
+        radiusOf(current) + radiusOf(other),
+        std.distance(current.position, other.position),
+      );
+      const gravityForce = (current.mass * other.mass) / dist / dist;
+
+      const direction = std.normalize(
+        std.sub(other.position, current.position),
+      );
+      updatedCurrent.velocity = std.add(
+        updatedCurrent.velocity,
+        std.mul((gravityForce / current.mass) * dt, direction),
       );
     }
 
-    computeLayout.$.outState[input.gid.x] = updatedCurrent;
-  })
-  .$name('gravity');
+    updatedCurrent.position = std.add(
+      updatedCurrent.position,
+      std.mul(dt, updatedCurrent.velocity),
+    );
+  }
+
+  computeLayout.$.outState[input.gid.x] = updatedCurrent;
+});

--- a/apps/typegpu-docs/src/content/examples/simulation/gravity/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/gravity/index.ts
@@ -77,12 +77,11 @@ const cameraInitial = Camera({
     d.mat4x4f(),
   ),
 });
-const camera = root.createUniform(Camera, cameraInitial).$name('camera');
+const camera = root.createUniform(Camera, cameraInitial);
 
 const skyBoxVertexBuffer = root
   .createBuffer(d.arrayOf(SkyBoxVertex, skyBoxVertices.length), skyBoxVertices)
-  .$usage('vertex')
-  .$name('skybox vertices');
+  .$usage('vertex');
 const skyBoxTexture = await loadSkyBox(root);
 const skyBox = skyBoxTexture.createView('sampled', { dimension: 'cube' });
 
@@ -92,10 +91,9 @@ const { vertexBuffer: sphereVertexBuffer, vertexCount: sphereVertexCount } =
 const sphereTextures = await loadSphereTextures(root);
 const celestialBodiesCountBuffer = root
   .createBuffer(d.i32)
-  .$usage('uniform')
-  .$name('celestial bodies count');
-const time = root.createUniform(Time).$name('time');
-const lightSource = root.createUniform(d.vec3f).$name('light source');
+  .$usage('uniform');
+const time = root.createUniform(Time);
+const lightSource = root.createUniform(d.vec3f);
 
 // dynamic resources (recreated every time a preset is selected)
 
@@ -118,14 +116,12 @@ const dynamicResourcesBox = {
 // Pipelines
 const computeCollisionsPipeline = root['~unstable']
   .withCompute(computeCollisionsShader)
-  .createPipeline()
-  .$name('compute collisions');
+  .createPipeline();
 
 const computeGravityPipeline = root['~unstable']
   .with(timeAccess, time)
   .withCompute(computeGravityShader)
-  .createPipeline()
-  .$name('compute gravity');
+  .createPipeline();
 
 const skyBoxPipeline = root['~unstable']
   .with(filteringSamplerSlot, sampler)
@@ -133,8 +129,7 @@ const skyBoxPipeline = root['~unstable']
   .with(cameraAccess, camera)
   .withVertex(skyBoxVertex, renderSkyBoxVertexLayout.attrib)
   .withFragment(skyBoxFragment, { format: presentationFormat })
-  .createPipeline()
-  .$name('render skybox');
+  .createPipeline();
 
 const renderPipeline = root['~unstable']
   .with(filteringSamplerSlot, sampler)
@@ -148,8 +143,7 @@ const renderPipeline = root['~unstable']
     depthCompare: 'less',
   })
   .withPrimitive({ topology: 'triangle-list', cullMode: 'back' })
-  .createPipeline()
-  .$name('render celestial bodies');
+  .createPipeline();
 
 let depthTexture = root.device.createTexture({
   size: [canvas.width, canvas.height, 1],
@@ -234,12 +228,10 @@ async function loadPreset(preset: Preset): Promise<DynamicResources> {
       d.arrayOf(CelestialBody, celestialBodies.length),
       celestialBodies,
     )
-    .$usage('storage')
-    .$name('compute A');
+    .$usage('storage');
   const computeBufferB = root
     .createBuffer(d.arrayOf(CelestialBody, celestialBodies.length))
-    .$usage('storage')
-    .$name('compute B');
+    .$usage('storage');
 
   const computeCollisionsBindGroup = root.createBindGroup(
     computeLayout,

--- a/apps/typegpu-docs/src/content/examples/simulation/gravity/render.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/gravity/render.ts
@@ -13,125 +13,116 @@ import {
   VertexOutput,
 } from './schemas.ts';
 
-export const skyBoxVertex = tgpu['~unstable']
-  .vertexFn({
-    in: {
-      position: d.vec3f,
-      uv: d.vec2f,
-    },
-    out: {
-      pos: d.builtin.position,
-      texCoord: d.vec3f,
-    },
-  })((input) => {
-    const viewPos =
-      std.mul(cameraAccess.$.view, d.vec4f(input.position, 0)).xyz;
+export const skyBoxVertex = tgpu['~unstable'].vertexFn({
+  in: {
+    position: d.vec3f,
+    uv: d.vec2f,
+  },
+  out: {
+    pos: d.builtin.position,
+    texCoord: d.vec3f,
+  },
+})((input) => {
+  const viewPos = std.mul(cameraAccess.$.view, d.vec4f(input.position, 0)).xyz;
 
-    return {
-      pos: std.mul(
-        cameraAccess.$.projection,
-        d.vec4f(viewPos, 1),
-      ),
-      texCoord: input.position.xyz,
-    };
-  })
-  .$name('skybox');
+  return {
+    pos: std.mul(
+      cameraAccess.$.projection,
+      d.vec4f(viewPos, 1),
+    ),
+    texCoord: input.position.xyz,
+  };
+});
 
-export const skyBoxFragment = tgpu['~unstable']
-  .fragmentFn({
-    in: {
-      texCoord: d.vec3f,
-    },
-    out: d.vec4f,
-  })((input) =>
-    std.textureSample(
-      skyBoxSlot.$,
-      filteringSamplerSlot.$,
-      std.normalize(input.texCoord),
-    )
+export const skyBoxFragment = tgpu['~unstable'].fragmentFn({
+  in: {
+    texCoord: d.vec3f,
+  },
+  out: d.vec4f,
+})((input) =>
+  std.textureSample(
+    skyBoxSlot.$,
+    filteringSamplerSlot.$,
+    std.normalize(input.texCoord),
   )
-  .$name('skybox');
+);
 
-export const mainVertex = tgpu['~unstable']
-  .vertexFn({
-    in: {
-      ...VertexInput,
-      instanceIndex: d.builtin.instanceIndex,
-    },
-    out: VertexOutput,
-  })((input) => {
-    // TODO: replace it with struct copy when Chromium is fixed
-    const currentBody = CelestialBody({
-      position: renderLayout.$.celestialBodies[input.instanceIndex].position,
-      velocity: renderLayout.$.celestialBodies[input.instanceIndex].velocity,
-      mass: renderLayout.$.celestialBodies[input.instanceIndex].mass,
-      collisionBehavior:
-        renderLayout.$.celestialBodies[input.instanceIndex].collisionBehavior,
-      textureIndex:
-        renderLayout.$.celestialBodies[input.instanceIndex].textureIndex,
-      radiusMultiplier:
-        renderLayout.$.celestialBodies[input.instanceIndex].radiusMultiplier,
-      ambientLightFactor:
-        renderLayout.$.celestialBodies[input.instanceIndex].ambientLightFactor,
-      destroyed: renderLayout.$.celestialBodies[input.instanceIndex].destroyed,
-    });
+export const mainVertex = tgpu['~unstable'].vertexFn({
+  in: {
+    ...VertexInput,
+    instanceIndex: d.builtin.instanceIndex,
+  },
+  out: VertexOutput,
+})((input) => {
+  // TODO: replace it with struct copy when Chromium is fixed
+  const currentBody = CelestialBody({
+    position: renderLayout.$.celestialBodies[input.instanceIndex].position,
+    velocity: renderLayout.$.celestialBodies[input.instanceIndex].velocity,
+    mass: renderLayout.$.celestialBodies[input.instanceIndex].mass,
+    collisionBehavior:
+      renderLayout.$.celestialBodies[input.instanceIndex].collisionBehavior,
+    textureIndex:
+      renderLayout.$.celestialBodies[input.instanceIndex].textureIndex,
+    radiusMultiplier:
+      renderLayout.$.celestialBodies[input.instanceIndex].radiusMultiplier,
+    ambientLightFactor:
+      renderLayout.$.celestialBodies[input.instanceIndex].ambientLightFactor,
+    destroyed: renderLayout.$.celestialBodies[input.instanceIndex].destroyed,
+  });
 
-    const worldPosition = std.add(
-      std.mul(radiusOf(currentBody), input.position.xyz),
-      currentBody.position,
-    );
+  const worldPosition = std.add(
+    std.mul(radiusOf(currentBody), input.position.xyz),
+    currentBody.position,
+  );
 
-    const camera = cameraAccess.$;
-    const positionOnCanvas = std.mul(
-      camera.projection,
-      std.mul(camera.view, d.vec4f(worldPosition, 1)),
-    );
-    return {
-      position: positionOnCanvas,
-      uv: input.uv,
-      normals: input.normal,
-      worldPosition: worldPosition,
-      sphereTextureIndex: currentBody.textureIndex,
-      destroyed: currentBody.destroyed,
-      ambientLightFactor: currentBody.ambientLightFactor,
-    };
-  })
-  .$name('celestial bodies');
+  const camera = cameraAccess.$;
+  const positionOnCanvas = std.mul(
+    camera.projection,
+    std.mul(camera.view, d.vec4f(worldPosition, 1)),
+  );
+  return {
+    position: positionOnCanvas,
+    uv: input.uv,
+    normals: input.normal,
+    worldPosition: worldPosition,
+    sphereTextureIndex: currentBody.textureIndex,
+    destroyed: currentBody.destroyed,
+    ambientLightFactor: currentBody.ambientLightFactor,
+  };
+});
 
-export const mainFragment = tgpu['~unstable']
-  .fragmentFn({
-    in: VertexOutput,
-    out: d.vec4f,
-  })((input) => {
-    if (input.destroyed === 1) {
-      std.discard();
-    }
+export const mainFragment = tgpu['~unstable'].fragmentFn({
+  in: VertexOutput,
+  out: d.vec4f,
+})((input) => {
+  if (input.destroyed === 1) {
+    std.discard();
+  }
 
-    const lightColor = d.vec3f(1, 0.9, 0.9);
-    const textureColor = std.textureSample(
-      renderLayout.$.celestialBodyTextures,
-      filteringSamplerSlot.$,
-      input.uv,
-      input.sphereTextureIndex,
-    ).xyz;
+  const lightColor = d.vec3f(1, 0.9, 0.9);
+  const textureColor = std.textureSample(
+    renderLayout.$.celestialBodyTextures,
+    filteringSamplerSlot.$,
+    input.uv,
+    input.sphereTextureIndex,
+  ).xyz;
 
-    const ambient = std.mul(
-      input.ambientLightFactor,
-      std.mul(textureColor, lightColor),
-    );
+  const ambient = std.mul(
+    input.ambientLightFactor,
+    std.mul(textureColor, lightColor),
+  );
 
-    const normal = input.normals;
-    const lightDirection = std.normalize(
-      std.sub(lightSourceAccess.$, input.worldPosition),
-    );
-    const cosTheta = std.dot(normal, lightDirection);
-    const diffuse = std.mul(
-      std.max(0, cosTheta),
-      std.mul(textureColor, lightColor),
-    );
+  const normal = input.normals;
+  const lightDirection = std.normalize(
+    std.sub(lightSourceAccess.$, input.worldPosition),
+  );
+  const cosTheta = std.dot(normal, lightDirection);
+  const diffuse = std.mul(
+    std.max(0, cosTheta),
+    std.mul(textureColor, lightColor),
+  );
 
-    const litColor = std.add(ambient, diffuse);
+  const litColor = std.add(ambient, diffuse);
 
-    return d.vec4f(litColor.xyz, 1);
-  })
-  .$name('celestial bodies');
+  return d.vec4f(litColor.xyz, 1);
+});

--- a/apps/typegpu-docs/src/content/examples/simulation/gravity/schemas.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/gravity/schemas.ts
@@ -7,18 +7,16 @@ export const Camera = d.struct({
   projection: d.mat4x4f,
 });
 
-export const CelestialBody = d
-  .struct({
-    destroyed: d.u32, // boolean
-    position: d.vec3f,
-    velocity: d.vec3f,
-    mass: d.f32,
-    radiusMultiplier: d.f32, // radius is calculated from the mass, and then multiplied by this
-    collisionBehavior: d.u32, // value of the collisionBehaviors enum
-    textureIndex: d.u32, // index of the global 2d-array texture for celestial bodies
-    ambientLightFactor: d.f32,
-  })
-  .$name('CelestialBody');
+export const CelestialBody = d.struct({
+  destroyed: d.u32, // boolean
+  position: d.vec3f,
+  velocity: d.vec3f,
+  mass: d.f32,
+  radiusMultiplier: d.f32, // radius is calculated from the mass, and then multiplied by this
+  collisionBehavior: d.u32, // value of the collisionBehaviors enum
+  textureIndex: d.u32, // index of the global 2d-array texture for celestial bodies
+  ambientLightFactor: d.f32,
+});
 
 export const VertexInput = {
   position: d.vec3f,
@@ -36,38 +34,32 @@ export const VertexOutput = {
   ambientLightFactor: d.f32,
 };
 
-export const SkyBoxVertex = d
-  .struct({
-    position: d.vec3f,
-    uv: d.vec2f,
-  })
-  .$name('SkyBoxVertex');
+export const SkyBoxVertex = d.struct({
+  position: d.vec3f,
+  uv: d.vec2f,
+});
 
-export const Time = d
-  .struct({ passed: d.f32, multiplier: d.f32 })
-  .$name('Time');
+export const Time = d.struct({ passed: d.f32, multiplier: d.f32 });
 
 // layouts
-export const computeLayout = tgpu
-  .bindGroupLayout({
-    celestialBodiesCount: {
-      uniform: d.i32,
-      access: 'readonly',
-    },
-    inState: {
-      storage: (n: number) => d.arrayOf(CelestialBody, n),
-      access: 'readonly',
-    },
-    outState: {
-      storage: (n: number) => d.arrayOf(CelestialBody, n),
-      access: 'mutable',
-    },
-  })
-  .$name('compute collisions');
+export const computeLayout = tgpu.bindGroupLayout({
+  celestialBodiesCount: {
+    uniform: d.i32,
+    access: 'readonly',
+  },
+  inState: {
+    storage: (n: number) => d.arrayOf(CelestialBody, n),
+    access: 'readonly',
+  },
+  outState: {
+    storage: (n: number) => d.arrayOf(CelestialBody, n),
+    access: 'mutable',
+  },
+});
 
-export const renderSkyBoxVertexLayout = tgpu
-  .vertexLayout((n) => d.arrayOf(SkyBoxVertex, n))
-  .$name('render skybox');
+export const renderSkyBoxVertexLayout = tgpu.vertexLayout((n) =>
+  d.arrayOf(SkyBoxVertex, n)
+);
 
 export const cameraAccess = tgpu['~unstable'].accessor(Camera);
 export const filteringSamplerSlot = tgpu['~unstable'].slot<TgpuSampler>();
@@ -84,9 +76,7 @@ export const renderBindGroupLayout = tgpu
       storage: (n: number) => d.arrayOf(CelestialBody, n),
       access: 'readonly',
     },
-  })
-  .$name('render');
+  });
 
 export const renderVertexLayout = tgpu
-  .vertexLayout((n) => d.arrayOf(d.struct(VertexInput), n))
-  .$name('render');
+  .vertexLayout((n) => d.arrayOf(d.struct(VertexInput), n));

--- a/apps/typegpu-docs/src/content/examples/simulation/stable-fluid/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/stable-fluid/index.ts
@@ -109,8 +109,7 @@ const plums = await createImageBitmap(await response.blob(), {
 
 const backgroundTexture = root['~unstable']
   .createTexture({ size: [p.N, p.N], format: 'rgba8unorm' })
-  .$usage('sampled', 'render')
-  .$name('background');
+  .$usage('sampled', 'render');
 device.queue.copyExternalImageToTexture(
   { source: plums },
   { texture: root.unwrap(backgroundTexture) },

--- a/apps/typegpu-docs/src/content/examples/tests/wgsl-resolution/index.ts
+++ b/apps/typegpu-docs/src/content/examples/tests/wgsl-resolution/index.ts
@@ -8,21 +8,19 @@ const root = await tgpu.init();
 const TRIANGLE_SIZE = 0.03;
 
 // data structures
-const Params = d
-  .struct({
-    separationDistance: d.f32,
-    separationStrength: d.f32,
-    alignmentDistance: d.f32,
-    alignmentStrength: d.f32,
-    cohesionDistance: d.f32,
-    cohesionStrength: d.f32,
-  })
-  .$name('Params');
+const Params = d.struct({
+  separationDistance: d.f32,
+  separationStrength: d.f32,
+  alignmentDistance: d.f32,
+  alignmentStrength: d.f32,
+  cohesionDistance: d.f32,
+  cohesionStrength: d.f32,
+});
 
 const TriangleData = d.struct({
   position: d.vec2f,
   velocity: d.vec2f,
-}).$name('TriangleData');
+});
 
 const TriangleDataArray = (n: number) => d.arrayOf(TriangleData, n);
 
@@ -31,15 +29,13 @@ const renderBindGroupLayout = tgpu.bindGroupLayout({
   colorPalette: { uniform: d.vec3f },
 });
 
-const computeBindGroupLayout = tgpu
-  .bindGroupLayout({
-    currentTrianglePos: { storage: TriangleDataArray },
-    nextTrianglePos: {
-      storage: TriangleDataArray,
-      access: 'mutable',
-    },
-  })
-  .$name('compute');
+const computeBindGroupLayout = tgpu.bindGroupLayout({
+  currentTrianglePos: { storage: TriangleDataArray },
+  nextTrianglePos: {
+    storage: TriangleDataArray,
+    access: 'mutable',
+  },
+});
 
 const { colorPalette } = renderBindGroupLayout.bound;
 const { currentTrianglePos, nextTrianglePos } = computeBindGroupLayout.bound;

--- a/apps/typegpu-docs/src/content/examples/tests/wgsl-resolution/index.ts
+++ b/apps/typegpu-docs/src/content/examples/tests/wgsl-resolution/index.ts
@@ -50,11 +50,11 @@ const rotate = tgpu['~unstable'].fn([d.vec2f, d.f32], d.vec2f)((v, angle) => {
   const cos = std.cos(angle);
   const sin = std.sin(angle);
   return d.vec2f(v.x * cos - v.y * sin, v.x * sin + v.y * cos);
-});
+}).$name('rotate util');
 
 const getRotationFromVelocity = tgpu['~unstable'].fn([d.vec2f], d.f32)(
   (velocity) => -std.atan2(velocity.x, velocity.y),
-);
+).$name('get rotation from velocity util');
 
 // entry functions
 const VertexOutput = {
@@ -84,12 +84,14 @@ const mainVert = tgpu['~unstable'].vertexFn({
   );
 
   return { position: pos, color };
-});
+}).$name('vertex shader');
 
-const mainFrag = tgpu['~unstable'].fragmentFn({
-  in: VertexOutput,
-  out: d.vec4f,
-})((input) => input.color);
+const mainFrag = tgpu['~unstable']
+  .fragmentFn({
+    in: VertexOutput,
+    out: d.vec4f,
+  })((input) => input.color)
+  .$name('fragment shader');
 
 const mainCompute = tgpu['~unstable'].computeFn({
   in: { gid: d.builtin.globalInvocationId },
@@ -164,7 +166,7 @@ const mainCompute = tgpu['~unstable'].computeFn({
   instanceInfo.position = std.add(instanceInfo.position, instanceInfo.velocity);
 
   nextTrianglePos.value[index] = instanceInfo;
-});
+}).$name('compute shader');
 
 // WGSL resolution
 const resolved = tgpu.resolve({

--- a/packages/typegpu/tests/accessor.test.ts
+++ b/packages/typegpu/tests/accessor.test.ts
@@ -67,10 +67,8 @@ describe('tgpu.accessor', () => {
   });
 
   it('resolves to resolved form of provided JS value', () => {
-    const colorAccessor = tgpu['~unstable'].accessor(d.vec3f).$name('color');
-    const multiplierAccessor = tgpu['~unstable']
-      .accessor(d.f32)
-      .$name('multiplier');
+    const colorAccessor = tgpu['~unstable'].accessor(d.vec3f);
+    const multiplierAccessor = tgpu['~unstable'].accessor(d.f32);
 
     const getColor = tgpu['~unstable']
       .fn([], d.vec3f)(/* wgsl */ `() -> vec3f {
@@ -91,9 +89,7 @@ describe('tgpu.accessor', () => {
   });
 
   it('resolves to default value if no value provided', () => {
-    const colorAccessor = tgpu['~unstable']
-      .accessor(d.vec3f, RED)
-      .$name('color'); // red by default
+    const colorAccessor = tgpu['~unstable'].accessor(d.vec3f, RED); // red by default
 
     const getColor = tgpu['~unstable']
       .fn([], d.vec3f)(/* wgsl */ `() -> vec3f {
@@ -112,9 +108,7 @@ describe('tgpu.accessor', () => {
   });
 
   it('resolves to provided value rather than default value', () => {
-    const colorAccessor = tgpu['~unstable']
-      .accessor(d.vec3f, RED)
-      .$name('color'); // red by default
+    const colorAccessor = tgpu['~unstable'].accessor(d.vec3f, RED); // red by default
 
     const getColor = tgpu['~unstable']
       .fn([], d.vec3f)(/* wgsl */ `() -> vec3f {

--- a/packages/typegpu/tests/align.test.ts
+++ b/packages/typegpu/tests/align.test.ts
@@ -5,13 +5,11 @@ import tgpu from '../src/index.ts';
 
 describe('d.align', () => {
   it('adds @align attribute for custom aligned struct members', () => {
-    const s1 = d
-      .struct({
-        a: d.u32,
-        b: d.align(16, d.u32),
-        c: d.u32,
-      })
-      .$name('s1');
+    const s1 = d.struct({
+      a: d.u32,
+      b: d.align(16, d.u32),
+      c: d.u32,
+    });
 
     expect(tgpu.resolve({ externals: { s1 }, names: 'strict' })).toContain(
       '@align(16) b: u32,',

--- a/packages/typegpu/tests/bindGroupLayout.test.ts
+++ b/packages/typegpu/tests/bindGroupLayout.test.ts
@@ -193,8 +193,7 @@ describe('TgpuBindGroupLayout', () => {
         a: { uniform: vec3f }, // binding 0
         _0: null, // binding 1
         c: { storage: vec3f }, // binding 2
-      })
-      .$name('example_layout');
+      });
 
     expectTypeOf(layout).toEqualTypeOf<
       TgpuBindGroupLayout<{
@@ -207,7 +206,7 @@ describe('TgpuBindGroupLayout', () => {
     root.unwrap(layout); // Creating the WebGPU resource
 
     expect(root.device.createBindGroupLayout).toBeCalledWith({
-      label: 'example_layout',
+      label: 'layout',
       entries: [
         {
           binding: 0,
@@ -688,8 +687,7 @@ describe('TgpuBindGroup', () => {
           size: [1024, 1024, 6],
           format: 'rgba8unorm',
         })
-        .$usage('sampled')
-        .$name('example_texture');
+        .$usage('sampled');
 
       const bindGroup = root.createBindGroup(layoutCube, {
         foo: texture.createView('sampled', {

--- a/packages/typegpu/tests/builtin.test.ts
+++ b/packages/typegpu/tests/builtin.test.ts
@@ -6,11 +6,9 @@ import { resolve } from '../src/resolutionCtx.ts';
 
 describe('builtin', () => {
   it('adds a @builtin attribute to a struct field', () => {
-    const s1 = d
-      .struct({
-        position: d.builtin.position,
-      })
-      .$name('s1');
+    const s1 = d.struct({
+      position: d.builtin.position,
+    });
 
     const opts = {
       names: new StrictNameRegistry(),

--- a/packages/typegpu/tests/computePipeline.test.ts
+++ b/packages/typegpu/tests/computePipeline.test.ts
@@ -11,16 +11,13 @@ import { it } from './utils/extendedIt.ts';
 
 describe('TgpuComputePipeline', () => {
   it('can be created with a compute entry function', ({ root, device }) => {
-    const entryFn = tgpu['~unstable']
-      .computeFn({ workgroupSize: [32] })(() => {
-        // do something
-      })
-      .$name('main');
+    const entryFn = tgpu['~unstable'].computeFn({ workgroupSize: [32] })(() => {
+      // do something
+    });
 
     const computePipeline = root
       .withCompute(entryFn)
-      .createPipeline()
-      .$name('test_pipeline');
+      .createPipeline();
 
     expectTypeOf(computePipeline).toEqualTypeOf<TgpuComputePipeline>();
 
@@ -30,21 +27,17 @@ describe('TgpuComputePipeline', () => {
       compute: {
         module: device.mock.createShaderModule(),
       },
-      label: 'test_pipeline',
+      label: 'computePipeline',
       layout: device.mock.createPipelineLayout(),
     });
   });
 
   it('throws an error if bind groups are missing', ({ root }) => {
-    const layout = tgpu
-      .bindGroupLayout({ alpha: { uniform: d.f32 } })
-      .$name('example-layout');
+    const layout = tgpu.bindGroupLayout({ alpha: { uniform: d.f32 } });
 
-    const entryFn = tgpu['~unstable']
-      .computeFn({ workgroupSize: [1] })(() => {
-        layout.bound.alpha; // Using an entry of the layout
-      })
-      .$name('main');
+    const entryFn = tgpu['~unstable'].computeFn({ workgroupSize: [1] })(() => {
+      layout.bound.alpha; // Using an entry of the layout
+    });
 
     const pipeline = root.withCompute(entryFn).createPipeline();
 
@@ -54,7 +47,7 @@ describe('TgpuComputePipeline', () => {
 
     expect(() => pipeline.dispatchWorkgroups(1))
       .toThrowErrorMatchingInlineSnapshot(
-        `[Error: Missing bind groups for layouts: 'example-layout'. Please provide it using pipeline.with(layout, bindGroup).(...)]`,
+        `[Error: Missing bind groups for layouts: 'layout'. Please provide it using pipeline.with(layout, bindGroup).(...)]`,
       );
   });
 
@@ -72,9 +65,9 @@ describe('TgpuComputePipeline', () => {
 
   describe('Performance Callbacks', () => {
     it('should add performance callback with automatic query set', ({ root }) => {
-      const entryFn = tgpu['~unstable']
-        .computeFn({ workgroupSize: [1] })(() => {})
-        .$name('main');
+      const entryFn = tgpu['~unstable'].computeFn({ workgroupSize: [1] })(
+        () => {},
+      );
 
       const callback = vi.fn();
       const pipeline = root
@@ -94,9 +87,9 @@ describe('TgpuComputePipeline', () => {
     });
 
     it('should create automatic query set when adding performance callback', ({ root, device }) => {
-      const entryFn = tgpu['~unstable']
-        .computeFn({ workgroupSize: [1] })(() => {})
-        .$name('main');
+      const entryFn = tgpu['~unstable'].computeFn({ workgroupSize: [1] })(
+        () => {},
+      );
 
       const callback = vi.fn();
       const pipeline = root
@@ -116,9 +109,9 @@ describe('TgpuComputePipeline', () => {
     });
 
     it('should replace previous performance callback', ({ root }) => {
-      const entryFn = tgpu['~unstable']
-        .computeFn({ workgroupSize: [1] })(() => {})
-        .$name('main');
+      const entryFn = tgpu['~unstable'].computeFn({ workgroupSize: [1] })(
+        () => {},
+      );
 
       const callback1 = vi.fn();
       const callback2 = vi.fn();
@@ -144,9 +137,9 @@ describe('TgpuComputePipeline', () => {
       //@ts-ignore
       device.features = new Set();
 
-      const entryFn = tgpu['~unstable']
-        .computeFn({ workgroupSize: [1] })(() => {})
-        .$name('main');
+      const entryFn = tgpu['~unstable'].computeFn({ workgroupSize: [1] })(
+        () => {},
+      );
 
       const callback = vi.fn();
 
@@ -166,9 +159,9 @@ describe('TgpuComputePipeline', () => {
 
   describe('Timestamp Writes', () => {
     it('should add timestamp writes with custom query set', ({ root }) => {
-      const entryFn = tgpu['~unstable']
-        .computeFn({ workgroupSize: [1] })(() => {})
-        .$name('main');
+      const entryFn = tgpu['~unstable'].computeFn({ workgroupSize: [1] })(
+        () => {},
+      );
 
       const querySet = root.createQuerySet('timestamp', 4);
 
@@ -191,9 +184,9 @@ describe('TgpuComputePipeline', () => {
     });
 
     it('should add timestamp writes with raw GPU query set', ({ root, device }) => {
-      const entryFn = tgpu['~unstable']
-        .computeFn({ workgroupSize: [1] })(() => {})
-        .$name('main');
+      const entryFn = tgpu['~unstable'].computeFn({ workgroupSize: [1] })(
+        () => {},
+      );
 
       const rawQuerySet = device.createQuerySet({
         type: 'timestamp',
@@ -218,9 +211,9 @@ describe('TgpuComputePipeline', () => {
     });
 
     it('should handle optional timestamp write indices', ({ root }) => {
-      const entryFn = tgpu['~unstable']
-        .computeFn({ workgroupSize: [1] })(() => {})
-        .$name('main');
+      const entryFn = tgpu['~unstable'].computeFn({ workgroupSize: [1] })(
+        () => {},
+      );
 
       const querySet = root.createQuerySet('timestamp', 4);
 
@@ -271,9 +264,9 @@ describe('TgpuComputePipeline', () => {
     });
 
     it('should setup timestamp writes in compute pass descriptor', ({ root, commandEncoder }) => {
-      const entryFn = tgpu['~unstable']
-        .computeFn({ workgroupSize: [1] })(() => {})
-        .$name('main');
+      const entryFn = tgpu['~unstable'].computeFn({ workgroupSize: [1] })(
+        () => {},
+      );
 
       const querySet = root.createQuerySet('timestamp', 4);
 
@@ -314,8 +307,7 @@ describe('TgpuComputePipeline', () => {
         .computeFn({ workgroupSize: [1] })(() => {
           layout.bound.data;
         })
-        .$uses({ layout })
-        .$name('main');
+        .$uses({ layout });
 
       const querySet = root.createQuerySet('timestamp', 4);
 
@@ -363,9 +355,9 @@ describe('TgpuComputePipeline', () => {
 
   describe('Combined Performance callback and Timestamp Writes', () => {
     it('should work with both performance callback and custom timestamp writes', ({ root, commandEncoder }) => {
-      const entryFn = tgpu['~unstable']
-        .computeFn({ workgroupSize: [1] })(() => {})
-        .$name('main');
+      const entryFn = tgpu['~unstable'].computeFn({ workgroupSize: [1] })(
+        () => {},
+      );
 
       const querySet = root.createQuerySet('timestamp', 10);
       const callback = vi.fn();
@@ -407,9 +399,9 @@ describe('TgpuComputePipeline', () => {
     });
 
     it('should prioritize custom timestamp writes over automatic ones', ({ root, commandEncoder }) => {
-      const entryFn = tgpu['~unstable']
-        .computeFn({ workgroupSize: [1] })(() => {})
-        .$name('main');
+      const entryFn = tgpu['~unstable'].computeFn({ workgroupSize: [1] })(
+        () => {},
+      );
 
       const querySet = root.createQuerySet('timestamp', 8);
       const callback = vi.fn();

--- a/packages/typegpu/tests/derived.test.ts
+++ b/packages/typegpu/tests/derived.test.ts
@@ -33,7 +33,7 @@ describe('TgpuDerived', () => {
   });
 
   it('memoizes functions using derived values', () => {
-    const foo = tgpu['~unstable'].slot<number>().$name('foo');
+    const foo = tgpu['~unstable'].slot<number>();
     const double = tgpu['~unstable'].derived(() => foo.value * 2);
 
     const getDouble = tgpu['~unstable']

--- a/packages/typegpu/tests/interpolate.test.ts
+++ b/packages/typegpu/tests/interpolate.test.ts
@@ -5,13 +5,11 @@ import { resolve } from '../src/resolutionCtx.ts';
 
 describe('d.interpolate', () => {
   it('adds @interpolate (only interpolation type) attribute for struct members', () => {
-    const s1 = d
-      .struct({
-        a: d.u32,
-        b: d.interpolate('flat', d.u32),
-        c: d.u32,
-      })
-      .$name('s1');
+    const s1 = d.struct({
+      a: d.u32,
+      b: d.interpolate('flat', d.u32),
+      c: d.u32,
+    });
 
     expectTypeOf(s1).toEqualTypeOf<
       d.WgslStruct<{
@@ -29,13 +27,11 @@ describe('d.interpolate', () => {
   });
 
   it('adds @interpolate (with interpolation type and sampling method) attribute for struct members', () => {
-    const s1 = d
-      .struct({
-        a: d.u32,
-        b: d.interpolate('linear, sample', d.f32),
-        c: d.u32,
-      })
-      .$name('s1');
+    const s1 = d.struct({
+      a: d.u32,
+      b: d.interpolate('linear, sample', d.f32),
+      c: d.u32,
+    });
 
     expectTypeOf(s1).toEqualTypeOf<
       d.WgslStruct<{

--- a/packages/typegpu/tests/renderPipeline.test.ts
+++ b/packages/typegpu/tests/renderPipeline.test.ts
@@ -94,9 +94,7 @@ describe('Inter-Stage Variables', () => {
   it('throws an error if bind groups are missing', ({ root }) => {
     const utgpu = tgpu['~unstable'];
 
-    const layout = tgpu
-      .bindGroupLayout({ alpha: { uniform: d.f32 } })
-      .$name('example-layout');
+    const layout = tgpu.bindGroupLayout({ alpha: { uniform: d.f32 } });
 
     const vertexFn = utgpu
       .vertexFn({ out: { pos: d.builtin.position } })(
@@ -118,7 +116,7 @@ describe('Inter-Stage Variables', () => {
     );
 
     expect(() => pipeline.draw(6)).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Missing bind groups for layouts: 'example-layout'. Please provide it using pipeline.with(layout, bindGroup).(...)]`,
+      `[Error: Missing bind groups for layouts: 'layout'. Please provide it using pipeline.with(layout, bindGroup).(...)]`,
     );
   });
 
@@ -148,11 +146,11 @@ describe('Inter-Stage Variables', () => {
     it('should add performance callback with automatic query set', ({ root }) => {
       const vertexFn = tgpu['~unstable'].vertexFn({
         out: { pos: d.builtin.position },
-      })('').$name('vertex');
+      })('');
 
       const fragmentFn = tgpu['~unstable'].fragmentFn({
         out: { color: d.vec4f },
-      })('').$name('fragment');
+      })('');
 
       const callback = vi.fn();
       const pipeline = root
@@ -175,11 +173,11 @@ describe('Inter-Stage Variables', () => {
     it('should create automatic query set when adding performance callback', ({ root, device }) => {
       const vertexFn = tgpu['~unstable'].vertexFn({
         out: { pos: d.builtin.position },
-      })('').$name('vertex');
+      })('');
 
       const fragmentFn = tgpu['~unstable'].fragmentFn({
         out: { color: d.vec4f },
-      })('').$name('fragment');
+      })('');
 
       const callback = vi.fn();
       const pipeline = root
@@ -213,11 +211,11 @@ describe('Inter-Stage Variables', () => {
     it('should replace previous performance callback', ({ root }) => {
       const vertexFn = tgpu['~unstable'].vertexFn({
         out: { pos: d.builtin.position },
-      })('').$name('vertex');
+      })('');
 
       const fragmentFn = tgpu['~unstable'].fragmentFn({
         out: { color: d.vec4f },
-      })('').$name('fragment');
+      })('');
 
       const callback1 = vi.fn();
       const callback2 = vi.fn();
@@ -246,11 +244,11 @@ describe('Inter-Stage Variables', () => {
 
       const vertexFn = tgpu['~unstable'].vertexFn({
         out: { pos: d.builtin.position },
-      })('').$name('vertex');
+      })('');
 
       const fragmentFn = tgpu['~unstable'].fragmentFn({
         out: { color: d.vec4f },
-      })('').$name('fragment');
+      })('');
 
       const callback = vi.fn();
 
@@ -273,11 +271,11 @@ describe('Inter-Stage Variables', () => {
     it('should add timestamp writes with custom query set', ({ root }) => {
       const vertexFn = tgpu['~unstable'].vertexFn({
         out: { pos: d.builtin.position },
-      })('').$name('vertex');
+      })('');
 
       const fragmentFn = tgpu['~unstable'].fragmentFn({
         out: { color: d.vec4f },
-      })('').$name('fragment');
+      })('');
 
       const querySet = root.createQuerySet('timestamp', 4);
 
@@ -303,11 +301,11 @@ describe('Inter-Stage Variables', () => {
     it('should add timestamp writes with raw GPU query set', ({ root, device }) => {
       const vertexFn = tgpu['~unstable'].vertexFn({
         out: { pos: d.builtin.position },
-      })('').$name('vertex');
+      })('');
 
       const fragmentFn = tgpu['~unstable'].fragmentFn({
         out: { color: d.vec4f },
-      })('').$name('fragment');
+      })('');
 
       const rawQuerySet = device.createQuerySet({
         type: 'timestamp',
@@ -335,11 +333,11 @@ describe('Inter-Stage Variables', () => {
     it('should handle optional timestamp write indices', ({ root }) => {
       const vertexFn = tgpu['~unstable'].vertexFn({
         out: { pos: d.builtin.position },
-      })('').$name('vertex');
+      })('');
 
       const fragmentFn = tgpu['~unstable'].fragmentFn({
         out: { color: d.vec4f },
-      })('').$name('fragment');
+      })('');
 
       const querySet = root.createQuerySet('timestamp', 4);
 
@@ -395,11 +393,11 @@ describe('Inter-Stage Variables', () => {
     it('should setup timestamp writes in render pass descriptor', ({ root, commandEncoder }) => {
       const vertexFn = tgpu['~unstable'].vertexFn({
         out: { pos: d.builtin.position },
-      })('').$name('vertex');
+      })('');
 
       const fragmentFn = tgpu['~unstable'].fragmentFn({
         out: { color: d.vec4f },
-      })('').$name('fragment');
+      })('');
 
       const querySet = root.createQuerySet('timestamp', 4);
 
@@ -438,11 +436,11 @@ describe('Inter-Stage Variables', () => {
   it('should handle depth stencil attachments with timestamp writes', ({ root, commandEncoder }) => {
     const vertexFn = tgpu['~unstable'].vertexFn({
       out: { pos: d.builtin.position },
-    })('').$name('vertex');
+    })('');
 
     const fragmentFn = tgpu['~unstable'].fragmentFn({
       out: { color: d.vec4f },
-    })('').$name('fragment');
+    })('');
 
     const querySet = root.createQuerySet('timestamp', 2);
 

--- a/packages/typegpu/tests/size.test.ts
+++ b/packages/typegpu/tests/size.test.ts
@@ -5,13 +5,11 @@ import { resolve } from '../src/resolutionCtx.ts';
 
 describe('d.size', () => {
   it('adds @size attribute for the custom sized struct members', () => {
-    const s1 = d
-      .struct({
-        a: d.u32,
-        b: d.size(16, d.u32),
-        c: d.u32,
-      })
-      .$name('s1');
+    const s1 = d.struct({
+      a: d.u32,
+      b: d.size(16, d.u32),
+      c: d.u32,
+    });
 
     const opts = {
       names: new StrictNameRegistry(),

--- a/packages/typegpu/tests/slot.test.ts
+++ b/packages/typegpu/tests/slot.test.ts
@@ -9,7 +9,7 @@ const GREEN = 'vec3f(0., 1., 0.)';
 
 describe('tgpu.slot', () => {
   it('resolves to default value if no value provided', () => {
-    const colorSlot = tgpu['~unstable'].slot(RED).$name('color'); // red by default
+    const colorSlot = tgpu['~unstable'].slot(RED); // red by default
 
     const getColor = tgpu['~unstable']
       .fn([], d.vec3f)(/* wgsl */ `() -> vec3f {
@@ -30,7 +30,7 @@ describe('tgpu.slot', () => {
   });
 
   it('resolves to provided value rather than default value', () => {
-    const colorSlot = tgpu['~unstable'].slot(RED).$name('color'); // red by default
+    const colorSlot = tgpu['~unstable'].slot(RED); // red by default
 
     const getColor = tgpu['~unstable']
       .fn([], d.vec3f)(/* wgsl */ `() -> vec3f {
@@ -64,7 +64,7 @@ describe('tgpu.slot', () => {
   });
 
   it('resolves to provided value', () => {
-    const colorSlot = tgpu['~unstable'].slot<string>().$name('color'); // no default
+    const colorSlot = tgpu['~unstable'].slot<string>(); // no default
 
     const getColor = tgpu['~unstable']
       .fn([], d.vec3f)(/* wgsl */ `() -> vec3f {
@@ -119,7 +119,7 @@ describe('tgpu.slot', () => {
   });
 
   it('prefers closer scope', () => {
-    const colorSlot = tgpu['~unstable'].slot<string>().$name('color'); // no default
+    const colorSlot = tgpu['~unstable'].slot<string>(); // no default
 
     const getColor = tgpu['~unstable']
       .fn([], d.vec3f)(/* wgsl */ `() -> vec3f {
@@ -172,10 +172,8 @@ describe('tgpu.slot', () => {
   });
 
   it('reuses common nested functions', () => {
-    const sizeSlot = tgpu['~unstable'].slot<1 | 100>().$name('size');
-    const colorSlot = tgpu['~unstable']
-      .slot<typeof RED | typeof GREEN>()
-      .$name('color');
+    const sizeSlot = tgpu['~unstable'].slot<1 | 100>();
+    const colorSlot = tgpu['~unstable'].slot<typeof RED | typeof GREEN>();
 
     const getSize = tgpu['~unstable']
       .fn([], d.f32)(/* wgsl */ `() -> f32 {
@@ -301,10 +299,10 @@ describe('tgpu.slot', () => {
   });
 
   it('unwraps layers of slots', () => {
-    const slotA = tgpu['~unstable'].slot(1).$name('a');
-    const slotB = tgpu['~unstable'].slot(2).$name('b');
-    const slotC = tgpu['~unstable'].slot(3).$name('c');
-    const slotD = tgpu['~unstable'].slot(4).$name('d');
+    const slotA = tgpu['~unstable'].slot(1);
+    const slotB = tgpu['~unstable'].slot(2);
+    const slotC = tgpu['~unstable'].slot(3);
+    const slotD = tgpu['~unstable'].slot(4);
 
     const fn1 = tgpu['~unstable']
       .fn([])('() { let value = slotA; }')

--- a/packages/typegpu/tests/texture.test.ts
+++ b/packages/typegpu/tests/texture.test.ts
@@ -8,10 +8,10 @@ import type {
 } from '../src/core/texture/texture.ts';
 import type { Render, Sampled } from '../src/core/texture/usageExtension.ts';
 import type { F32, I32, U32, Vec4f, Vec4i, Vec4u } from '../src/data/index.ts';
-import './utils/webgpuGlobals.ts';
 import tgpu from '../src/index.ts';
 import { StrictNameRegistry } from '../src/nameRegistry.ts';
 import { it } from './utils/extendedIt.ts';
+import './utils/webgpuGlobals.ts';
 
 describe('TgpuTexture', () => {
   it('makes passing the default, `undefined` or omitting an option prop result in the same type.', ({ root }) => {
@@ -179,7 +179,6 @@ describe('TgpuTexture', () => {
         size: [512, 512, 12],
         format: 'rgba8unorm',
       })
-      .$name('texture')
       .$usage('sampled');
 
     const opts = {

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -1,6 +1,7 @@
 import { JitTranspiler } from 'tgpu-jit';
 import * as tinyest from 'tinyest';
 import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+import { snip } from '../../src/data/dataTypes.ts';
 import * as d from '../../src/data/index.ts';
 import { abstractFloat, abstractInt } from '../../src/data/numeric.ts';
 import { Void } from '../../src/data/wgslTypes.ts';
@@ -13,7 +14,6 @@ import * as std from '../../src/std/index.ts';
 import * as wgslGenerator from '../../src/tgsl/wgslGenerator.ts';
 import { it } from '../utils/extendedIt.ts';
 import { parse, parseResolved } from '../utils/parseResolved.ts';
-import { snip } from '../../src/data/dataTypes.ts';
 
 const { NodeTypeCatalog: NODE } = tinyest;
 
@@ -156,16 +156,14 @@ describe('wgslGenerator', () => {
           })
           .$name('TestStruct'),
       )
-      .$usage('storage')
-      .$name('testBuffer');
+      .$usage('storage');
 
     const testUsage = testBuffer.as('mutable');
 
     const testFn = tgpu['~unstable']
       .fn([], d.u32)(() => {
         return testUsage.value.a + testUsage.value.b.x;
-      })
-      .$name('testFn');
+      });
 
     const astInfo = getMetaData(
       testFn[$internal].implementation as (...args: unknown[]) => unknown,
@@ -223,8 +221,7 @@ describe('wgslGenerator', () => {
   it('generates correct resources for external resource array index access', ({ root }) => {
     const testBuffer = root
       .createBuffer(d.arrayOf(d.u32, 16))
-      .$usage('uniform')
-      .$name('testBuffer');
+      .$usage('uniform');
 
     const testUsage = testBuffer.as('uniform');
 
@@ -280,8 +277,7 @@ describe('wgslGenerator', () => {
           })
           .$name('TestStruct'),
       )
-      .$usage('storage')
-      .$name('testBuffer');
+      .$usage('storage');
 
     const testUsage = testBuffer.as('mutable');
 
@@ -293,8 +289,7 @@ describe('wgslGenerator', () => {
         // biome-ignore lint/style/noNonNullAssertion: <no thanks>
         std.atomicStore(testUsage.value.b.aa[idx]!.x, vec.y);
         return vec;
-      })
-      .$name('testFn');
+      });
 
     const astInfo = getMetaData(
       testFn[$internal].implementation as (...args: unknown[]) => unknown,
@@ -478,8 +473,7 @@ describe('wgslGenerator', () => {
     const testFn = tgpu['~unstable']
       .fn([d.u32], d.f32)((idx) => {
         return derivedV2f.value[idx] as number;
-      })
-      .$name('testFn');
+      });
 
     const astInfo = getMetaData(
       testFn[$internal].implementation as (...args: unknown[]) => unknown,
@@ -722,16 +716,11 @@ describe('wgslGenerator', () => {
   });
 
   it('properly handles .value struct properties in slots', ({ root }) => {
-    const UnfortunateStruct = d
-      .struct({
-        value: d.vec3f,
-      })
-      .$name('UnfortunateStruct');
+    const UnfortunateStruct = d.struct({
+      value: d.vec3f,
+    });
 
-    const testBuffer = root
-      .createBuffer(UnfortunateStruct)
-      .$usage('storage')
-      .$name('testBuffer');
+    const testBuffer = root.createBuffer(UnfortunateStruct).$usage('storage');
 
     const testUsage = testBuffer.as('mutable');
     const testSlot = tgpu['~unstable'].slot(testUsage);
@@ -739,8 +728,7 @@ describe('wgslGenerator', () => {
       .fn([], d.f32)(() => {
         const value = testSlot.value.value;
         return value.x + value.y + value.z;
-      })
-      .$name('testFn');
+      });
 
     const astInfo = getMetaData(
       testFn[$internal].implementation as (...args: unknown[]) => unknown,


### PR DESCRIPTION
- Removed `$name` calls from examples,
- removed `$name` calls from some tests.

After trying to remove the `$name` calls from all tests, I opted to leave it in where it was at least somewhat relevant to the test, so for example when there was a `parseResolved` call or expected errors included the name.