### PR TITLE
fix: Prevent autocasting lhs of assignment expressions

### DIFF
--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -139,12 +139,14 @@ export function generateExpression(
     const lhsExpr = generateExpression(ctx, lhs);
     const rhsExpr = generateExpression(ctx, rhs);
 
+    const forcedType = expression[0] === NODE.assignmentExpr
+      ? [lhsExpr.dataType as AnyData]
+      : [];
+
     const converted = convertToCommonType(
       ctx,
       [lhsExpr, rhsExpr],
-      expression[0] === NODE.assignmentExpr
-        ? [lhsExpr.dataType as AnyData]
-        : [],
+      forcedType,
     ) as
       | [Snippet, Snippet]
       | undefined;

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -139,7 +139,13 @@ export function generateExpression(
     const lhsExpr = generateExpression(ctx, lhs);
     const rhsExpr = generateExpression(ctx, rhs);
 
-    const converted = convertToCommonType(ctx, [lhsExpr, rhsExpr]) as
+    const converted = convertToCommonType(
+      ctx,
+      [lhsExpr, rhsExpr],
+      expression[0] === NODE.assignmentExpr
+        ? [lhsExpr.dataType as AnyData]
+        : [],
+    ) as
       | [Snippet, Snippet]
       | undefined;
     const [convLhs, convRhs] = converted || [lhsExpr, rhsExpr];

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -542,6 +542,26 @@ describe('wgslGenerator', () => {
     );
   });
 
+  it('does not autocast lhs of an assignment', () => {
+    const testFn = tgpu.fn([], d.u32)(() => {
+      let a = d.u32(12);
+      const b = d.f32(2.5);
+      a = b;
+
+      return a;
+    });
+
+    expect(parseResolved({ testFn })).toBe(
+      parse(`
+      fn testFn() -> u32 {
+        var a = u32(12);
+        var b = f32(2.5);
+        a = u32(b);
+        return a;
+      }`),
+    );
+  });
+
   it('generates correct code for array expressions with struct elements', () => {
     const TestStruct = d.struct({
       x: d.u32,
@@ -854,10 +874,10 @@ describe('wgslGenerator', () => {
 
     expect(() => parseResolved({ cleantestFn: testFn }))
       .toThrowErrorMatchingInlineSnapshot(`
-[Error: Resolution of the following tree failed: 
+[Error: Resolution of the following tree failed:
 - <root>
 - fn:testFn
-- internalTestFn: Resolution of the following tree failed: 
+- internalTestFn: Resolution of the following tree failed:
 - internalTestFn: Cannot convert argument of type 'array' to 'vec2f' for function internalTestFn]
 `);
   });
@@ -869,7 +889,7 @@ describe('wgslGenerator', () => {
     });
 
     expect(() => parseResolved({ testFn })).toThrowErrorMatchingInlineSnapshot(`
-[Error: Resolution of the following tree failed: 
+[Error: Resolution of the following tree failed:
 - <root>
 - fn:testFn
 - translate4: Cannot read properties of undefined (reading 'value')]
@@ -884,10 +904,10 @@ describe('wgslGenerator', () => {
     });
 
     expect(() => parseResolved({ testFn })).toThrowErrorMatchingInlineSnapshot(`
-[Error: Resolution of the following tree failed: 
+[Error: Resolution of the following tree failed:
 - <root>
 - fn:testFn
-- vec4f: Resolution of the following tree failed: 
+- vec4f: Resolution of the following tree failed:
 - vec4f: Cannot convert argument of type 'array' to 'f32' for function vec4f]
 `);
   });

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -877,7 +877,7 @@ describe('wgslGenerator', () => {
 [Error: Resolution of the following tree failed: 
 - <root>
 - fn:testFn
-- internalTestFn: Resolution of the following tree failed:
+- internalTestFn: Resolution of the following tree failed: 
 - internalTestFn: Cannot convert argument of type 'array' to 'vec2f' for function internalTestFn]
 `);
   });

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -874,7 +874,7 @@ describe('wgslGenerator', () => {
 
     expect(() => parseResolved({ cleantestFn: testFn }))
       .toThrowErrorMatchingInlineSnapshot(`
-[Error: Resolution of the following tree failed:
+[Error: Resolution of the following tree failed: 
 - <root>
 - fn:testFn
 - internalTestFn: Resolution of the following tree failed:

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -889,7 +889,7 @@ describe('wgslGenerator', () => {
     });
 
     expect(() => parseResolved({ testFn })).toThrowErrorMatchingInlineSnapshot(`
-[Error: Resolution of the following tree failed:
+[Error: Resolution of the following tree failed: 
 - <root>
 - fn:testFn
 - translate4: Cannot read properties of undefined (reading 'value')]

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -907,7 +907,7 @@ describe('wgslGenerator', () => {
 [Error: Resolution of the following tree failed: 
 - <root>
 - fn:testFn
-- vec4f: Resolution of the following tree failed:
+- vec4f: Resolution of the following tree failed: 
 - vec4f: Cannot convert argument of type 'array' to 'f32' for function vec4f]
 `);
   });

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -904,7 +904,7 @@ describe('wgslGenerator', () => {
     });
 
     expect(() => parseResolved({ testFn })).toThrowErrorMatchingInlineSnapshot(`
-[Error: Resolution of the following tree failed:
+[Error: Resolution of the following tree failed: 
 - <root>
 - fn:testFn
 - vec4f: Resolution of the following tree failed:


### PR DESCRIPTION
This needs to get merged before 0.6.0 as it's a pretty bad bug

<img width="779" alt="Screenshot 2025-07-07 at 12 26 56" src="https://github.com/user-attachments/assets/3295c205-01c2-4312-8d6a-b1ade60450ee" />
