### PR TITLE
feat: Struct default constructor

### DIFF
--- a/apps/typegpu-docs/src/content/docs/reference/data-schema-cheatsheet.mdx
+++ b/apps/typegpu-docs/src/content/docs/reference/data-schema-cheatsheet.mdx
@@ -49,7 +49,7 @@ const c = vec4f(b.xz, a.xx);  // 0, 2, 1, 1
 
 ## Constructor conventions
 
-Scalar, vector and matrix schemas can be called with no arguments to get a default value of the type represented by the schema.
+Scalar, vector, matrix and struct schemas can be called with no arguments to get a default value of the type represented by the schema. Arrays are a WIP.
 
 ```ts
 import { f32, bool, vec3f } from 'typegpu/data';

--- a/packages/typegpu/src/core/function/tgpuFn.ts
+++ b/packages/typegpu/src/core/function/tgpuFn.ts
@@ -1,5 +1,5 @@
 import { type AnyData, snip, UnknownData } from '../../data/dataTypes.ts';
-import { schemaCallWrapper } from '../../data/utils.ts';
+import { schemaCloneWrapper } from '../../data/utils.ts';
 import { Void } from '../../data/wgslTypes.ts';
 import { createDualImpl } from '../../shared/generators.ts';
 import type { TgpuNamable } from '../../shared/meta.ts';
@@ -233,7 +233,7 @@ function createFn<ImplSchema extends AnyFn>(
       }
 
       const castAndCopiedArgs = args.map((arg, index) =>
-        schemaCallWrapper(shell.argTypes[index], arg)
+        schemaCloneWrapper(shell.argTypes[index], arg)
       ) as InferArgs<Parameters<ImplSchema>>;
 
       return implementation(...castAndCopiedArgs);

--- a/packages/typegpu/src/data/struct.ts
+++ b/packages/typegpu/src/data/struct.ts
@@ -1,6 +1,6 @@
 import { getName, setName } from '../shared/meta.ts';
 import { $internal } from '../shared/symbols.ts';
-import { schemaCallWrapper } from './utils.ts';
+import { schemaCloneWrapper, schemaDefaultWrapper } from './utils.ts';
 import type { AnyWgslData, WgslStruct } from './wgslTypes.ts';
 
 // ----------
@@ -23,11 +23,16 @@ export function struct<TProps extends Record<string, AnyWgslData>>(
 ): WgslStruct<TProps> {
   // in the schema call, create and return a deep copy
   // by wrapping all the values in corresponding schema calls
-  const structSchema = <T extends TProps>(instanceProps: T) =>
+  const structSchema = <T extends TProps>(instanceProps?: T) =>
     Object.fromEntries(
       Object.entries(props).map((
         [key, schema],
-      ) => [key, schemaCallWrapper(schema, instanceProps[key])]),
+      ) => [
+        key,
+        instanceProps
+          ? schemaCloneWrapper(schema, instanceProps[key])
+          : schemaDefaultWrapper(schema),
+      ]),
     );
   Object.setPrototypeOf(structSchema, WgslStructImpl);
   structSchema.propTypes = props;

--- a/packages/typegpu/src/data/utils.ts
+++ b/packages/typegpu/src/data/utils.ts
@@ -1,16 +1,31 @@
 /**
  * A wrapper for `schema(item)` call.
- * Logs a warning if the schema is not callable.
+ * Throws an error if the schema is not callable.
  */
-export function schemaCallWrapper<T>(schema: unknown, item: T): T {
-  let result = item;
+export function schemaCloneWrapper<T>(schema: unknown, item: T): T {
   try {
-    result = (
-      schema as unknown as ((item: typeof result) => typeof result)
-    )(item);
+    return (schema as unknown as ((item: T) => T))(item);
   } catch {
     const maybeType = (schema as { type: string })?.type;
-    console.warn(`Schema of type ${maybeType ?? '<unknown>'} is not callable.`);
+    throw new Error(
+      `Schema of type ${
+        maybeType ?? '<unknown>'
+      } is not callable or was called with invalid arguments.`,
+    );
   }
-  return result;
+}
+
+/**
+ * A wrapper for `schema()` call.
+ * Throws an error if the schema is not callable.
+ */
+export function schemaDefaultWrapper<T>(schema: unknown): T {
+  try {
+    return (schema as unknown as (() => T))();
+  } catch {
+    const maybeType = (schema as { type: string })?.type;
+    throw new Error(
+      `Schema of type ${maybeType ?? '<unknown>'} is not callable.`,
+    );
+  }
 }

--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -1166,6 +1166,7 @@ export interface WgslStruct<
   TProps extends Record<string, BaseData> = Record<string, BaseData>,
 > extends TgpuNamable {
   (props: Prettify<InferRecord<TProps>>): Prettify<InferRecord<TProps>>;
+  (): Prettify<InferRecord<TProps>>;
   readonly [$internal]: true;
   readonly type: 'struct';
   readonly propTypes: TProps;

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -333,8 +333,8 @@ export function generateExpression(
         return snip(`${resolvedId}(${argValues.join(', ')})`, id.value);
       }
 
-      return snip(`(${argValues.join(', ')})`, id.value);
       // The type of the return value is the struct itself
+      return snip(`(${argValues.join(', ')})`, id.value);
     }
 
     if (!isMarkedInternal(id.value)) {

--- a/packages/typegpu/tests/struct.test.ts
+++ b/packages/typegpu/tests/struct.test.ts
@@ -300,26 +300,27 @@ describe('struct', () => {
   // });
 
   it('resolves to correct wgsl', () => {
-    const schema = struct({
-      nested: struct({ prop1: vec2f, prop2: u32 }).$name('nestedStruct'),
-    }).$name('outerStruct');
+    const Nested = struct({ prop1: vec2f, prop2: u32 });
+    const Outer = struct({
+      nested: Nested,
+    });
 
-    const fn = tgpu.fn([])(() => {
-      const defaultValue = schema();
-    }).$name('testFunction');
+    const testFunction = tgpu.fn([])(() => {
+      const defaultValue = Outer();
+    });
 
-    expect(parseResolved({ fn })).toBe(parse(`
-        struct nestedStruct {
+    expect(parseResolved({ testFunction })).toBe(parse(`
+        struct Nested {
           prop1: vec2f,
           prop2: u32,
         }
 
-        struct outerStruct {
-          nested: nestedStruct,
+        struct Outer {
+          nested: Nested,
         }
 
         fn testFunction() {
-          var defaultValue = outerStruct();
+          var defaultValue = Outer();
         }
       `));
   });

--- a/packages/typegpu/tests/struct.test.ts
+++ b/packages/typegpu/tests/struct.test.ts
@@ -296,7 +296,7 @@ describe('struct', () => {
 
   //   const defaultStruct = schema();
 
-  //   expect(defaultStruct).toStrictEqual({ arr: [1] });
+  //   expect(defaultStruct).toStrictEqual({ arr: [0] });
   // });
 
   it('resolves to correct wgsl', () => {


### PR DESCRIPTION
Structs can now be called with no arguments in order to get a default value of the struct (as long as there are no nested arrays inside).

This is a prerequisite for #1254 (`d.arrayOf(myStruct, 4)()`)