### PR TITLE
fix: TypeGPU functions using TGSL dependencies declaration order

### DIFF
--- a/packages/typegpu/tests/tgslFn.test.ts
+++ b/packages/typegpu/tests/tgslFn.test.ts
@@ -881,21 +881,21 @@ describe('tgsl fn when using plugin', () => {
     );
   });
 
-  // it('can reference function defined below', () => {
-  //   const bar = tgpu.fn([], d.f32)(() => foo() + 2);
-  //   const foo = tgpu.fn([], d.f32)(() => 1);
+  it('can reference function defined below', () => {
+    const bar = tgpu.fn([], d.f32)(() => foo() + 2);
+    const foo = tgpu.fn([], d.f32)(() => 1);
 
-  //   expect(parseResolved({ bar })).toBe(
-  //     parse(`
-  //       fn foo() -> f32 {
-  //         return 1;
-  //       }
+    expect(parseResolved({ bar })).toBe(
+      parse(`
+        fn foo() -> f32 {
+          return 1;
+        }
 
-  //       fn bar() -> f32 {
-  //         return foo() + 2;
-  //       }`),
-  //   );
-  // });
+        fn bar() -> f32 {
+          return (foo() + 2);
+        }`),
+    );
+  });
 
   // it('throws when it detects a cyclic dependency', () => {
   //   const bar = tgpu.fn([], d.f32)(() => foo() + 2);

--- a/packages/typegpu/tests/tgslFn.test.ts
+++ b/packages/typegpu/tests/tgslFn.test.ts
@@ -897,19 +897,13 @@ describe('tgsl fn when using plugin', () => {
     );
   });
 
+  // TODO: throw an error when cyclic dependency is detected
   // it('throws when it detects a cyclic dependency', () => {
-  //   const bar = tgpu.fn([], d.f32)(() => foo() + 2);
-  //   const foo = tgpu.fn([], d.f32)(() => 1);
+  //   let bar: TgpuFn;
+  //   let foo: TgpuFn;
+  //   bar = tgpu.fn([], d.f32)(() => foo() + 2);
+  //   foo = tgpu.fn([], d.f32)(() => bar() - 2);
 
-  //   expect(parseResolved({ bar })).toBe(
-  //     parse(`
-  //       fn foo() -> f32 {
-  //         return 1;
-  //       }
-
-  //       fn bar() -> f32 {
-  //         return foo() + 2;
-  //       }`),
-  //   );
+  //   expect(() => parseResolved({ bar })).toThrowErrorMatchingInlineSnapshot(``);
   // });
 });

--- a/packages/typegpu/tests/tgslFn.test.ts
+++ b/packages/typegpu/tests/tgslFn.test.ts
@@ -574,36 +574,6 @@ describe('TGSL tgpu.fn function', () => {
     );
   });
 
-  it('(when using plugin) can be invoked for a constant with "kernel" directive', () => {
-    const addKernelJs = (x: number, y: number) => {
-      'kernel';
-      return x + y;
-    };
-
-    const add = tgpu.fn([d.u32, d.u32])(addKernelJs);
-
-    expect(addKernelJs(2, 3)).toBe(5);
-    expect(add(2, 3)).toBe(5);
-    expect(parseResolved({ add })).toBe(
-      parse(`fn add(x: u32, y: u32){
-          return (x + y);
-        }`),
-    );
-  });
-
-  it('(when using plugin) can be invoked for inline function with no directive', () => {
-    const add = tgpu.fn([d.u32, d.u32])(
-      (x, y) => x + y,
-    );
-
-    expect(add(2, 3)).toBe(5);
-    expect(parseResolved({ add })).toBe(
-      parse(`fn add(x: u32, y: u32){
-          return (x + y);
-        }`),
-    );
-  });
-
   it('resolves a function with a pointer parameter', () => {
     const addOnes = tgpu.fn([d.ptrStorage(d.vec3f, 'read-write')])((ptr) => {
       ptr.x += 1;
@@ -878,4 +848,68 @@ describe('tgpu.fn arguments', () => {
 
     expect(vec).toStrictEqual(d.vec3f());
   });
+});
+
+describe('tgsl fn when using plugin', () => {
+  it('can be invoked for a constant with "kernel" directive', () => {
+    const addKernelJs = (x: number, y: number) => {
+      'kernel';
+      return x + y;
+    };
+
+    const add = tgpu.fn([d.u32, d.u32])(addKernelJs);
+
+    expect(addKernelJs(2, 3)).toBe(5);
+    expect(add(2, 3)).toBe(5);
+    expect(parseResolved({ add })).toBe(
+      parse(`fn add(x: u32, y: u32){
+          return (x + y);
+        }`),
+    );
+  });
+
+  it('can be invoked for inline function with no directive', () => {
+    const add = tgpu.fn([d.u32, d.u32])(
+      (x, y) => x + y,
+    );
+
+    expect(add(2, 3)).toBe(5);
+    expect(parseResolved({ add })).toBe(
+      parse(`fn add(x: u32, y: u32){
+          return (x + y);
+        }`),
+    );
+  });
+
+  // it('can reference function defined below', () => {
+  //   const bar = tgpu.fn([], d.f32)(() => foo() + 2);
+  //   const foo = tgpu.fn([], d.f32)(() => 1);
+
+  //   expect(parseResolved({ bar })).toBe(
+  //     parse(`
+  //       fn foo() -> f32 {
+  //         return 1;
+  //       }
+
+  //       fn bar() -> f32 {
+  //         return foo() + 2;
+  //       }`),
+  //   );
+  // });
+
+  // it('throws when it detects a cyclic dependency', () => {
+  //   const bar = tgpu.fn([], d.f32)(() => foo() + 2);
+  //   const foo = tgpu.fn([], d.f32)(() => 1);
+
+  //   expect(parseResolved({ bar })).toBe(
+  //     parse(`
+  //       fn foo() -> f32 {
+  //         return 1;
+  //       }
+
+  //       fn bar() -> f32 {
+  //         return foo() + 2;
+  //       }`),
+  //   );
+  // });
 });

--- a/packages/unplugin-typegpu/src/babel.ts
+++ b/packages/unplugin-typegpu/src/babel.ts
@@ -54,13 +54,19 @@ function functionToTranspiled(
       i('ast'),
       template.expression`${embedJSON({ params, body, externalNames })}`(),
     ),
-    types.objectProperty(
+    types.objectMethod(
+      'get',
       i('externals'),
-      types.objectExpression(
-        externalNames.map((name) =>
-          types.objectProperty(i(name), i(name), false, true)
+      [],
+      types.blockStatement([
+        types.returnStatement(
+          types.objectExpression(
+            externalNames.map((name) =>
+              types.objectProperty(i(name), i(name), false, true)
+            ),
+          ),
         ),
-      ),
+      ]),
     ),
   ]);
 

--- a/packages/unplugin-typegpu/src/index.ts
+++ b/packages/unplugin-typegpu/src/index.ts
@@ -172,18 +172,6 @@ const typegpu: UnpluginInstance<Options, false> = createUnplugin(
             const { params, body, externalNames } = transpileFn(def);
             const isFunctionStatement = def.type === 'FunctionDeclaration';
 
-            if (
-              isFunctionStatement &&
-              name &&
-              code
-                  .slice(0, def.start)
-                  .search(new RegExp(`(?<![\\w_.])${name}(?![\\w_])`)) !== -1
-            ) {
-              console.warn(
-                `File ${id}: function "${name}" might have been referenced before its usage. Function statements are no longer hoisted after being transformed by the plugin.`,
-              );
-            }
-
             const metadata = `{
               v: ${FORMAT_VERSION},
               ast: ${embedJSON({ params, body, externalNames })},

--- a/packages/unplugin-typegpu/src/index.ts
+++ b/packages/unplugin-typegpu/src/index.ts
@@ -172,6 +172,18 @@ const typegpu: UnpluginInstance<Options, false> = createUnplugin(
             const { params, body, externalNames } = transpileFn(def);
             const isFunctionStatement = def.type === 'FunctionDeclaration';
 
+            if (
+              isFunctionStatement &&
+              name &&
+              code
+                  .slice(0, def.start)
+                  .search(new RegExp(`(?<![\\w_.])${name}(?![\\w_])`)) !== -1
+            ) {
+              console.warn(
+                `File ${id}: function "${name}" might have been referenced before its usage. Function statements are no longer hoisted after being transformed by the plugin.`,
+              );
+            }
+
             const metadata = `{
               v: ${FORMAT_VERSION},
               ast: ${embedJSON({ params, body, externalNames })},

--- a/packages/unplugin-typegpu/src/index.ts
+++ b/packages/unplugin-typegpu/src/index.ts
@@ -175,7 +175,7 @@ const typegpu: UnpluginInstance<Options, false> = createUnplugin(
             const metadata = `{
               v: ${FORMAT_VERSION},
               ast: ${embedJSON({ params, body, externalNames })},
-              externals: {${externalNames.join(', ')}},
+              get externals() { return {${externalNames.join(', ')}}; },
             }`;
 
             assignMetadata(magicString, def, metadata);

--- a/packages/unplugin-typegpu/test/aliasing.test.ts
+++ b/packages/unplugin-typegpu/test/aliasing.test.ts
@@ -82,7 +82,7 @@ describe('[ROLLUP] tgpu alias gathering', () => {
             }), {
                     v: 1,
                     ast: {"params":[],"body":[0,[]],"externalNames":[]},
-                    externals: {},
+                    get externals() { return {}; },
                   }) && $.f)({})));
       "
     `);
@@ -104,7 +104,7 @@ describe('[ROLLUP] tgpu alias gathering', () => {
             }), {
                     v: 1,
                     ast: {"params":[],"body":[0,[]],"externalNames":[]},
-                    externals: {},
+                    get externals() { return {}; },
                   }) && $.f)({})));
       "
     `);
@@ -126,7 +126,7 @@ describe('[ROLLUP] tgpu alias gathering', () => {
             }), {
                     v: 1,
                     ast: {"params":[],"body":[0,[]],"externalNames":[]},
-                    externals: {},
+                    get externals() { return {}; },
                   }) && $.f)({})));
       "
     `);

--- a/packages/unplugin-typegpu/test/aliasing.test.ts
+++ b/packages/unplugin-typegpu/test/aliasing.test.ts
@@ -18,7 +18,9 @@ describe('[BABEL] tgpu alias gathering', () => {
       }, {
         v: 1,
         ast: {"params":[],"body":[0,[[13,"x",[1,[5,"2"],"+",[5,"2"]]]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({}));"
     `);
   });
@@ -39,7 +41,9 @@ describe('[BABEL] tgpu alias gathering', () => {
       }, {
         v: 1,
         ast: {"params":[],"body":[0,[[13,"x",[1,[5,"2"],"+",[5,"2"]]]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({}));"
     `);
   });
@@ -60,7 +64,9 @@ describe('[BABEL] tgpu alias gathering', () => {
       }, {
         v: 1,
         ast: {"params":[],"body":[0,[[13,"x",[1,[5,"2"],"+",[5,"2"]]]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({}));"
     `);
   });

--- a/packages/unplugin-typegpu/test/auto-naming.test.ts
+++ b/packages/unplugin-typegpu/test/auto-naming.test.ts
@@ -24,7 +24,9 @@ describe('[BABEL] auto naming', () => {
         var fn = (globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu.fn([])(($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = () => {}, {
           v: 1,
           ast: {"params":[],"body":[0,[]],"externalNames":[]},
-          externals: {}
+          get externals() {
+            return {};
+          }
         }) && $.f)({})), "fn");
         let shell = (globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu.fn([]), "shell");
         console.log(bindGroupLayout, vertexLayout);"
@@ -126,14 +128,18 @@ describe('[BABEL] auto naming', () => {
         const myFunction = (globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu.fn([])(($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = () => 0, {
           v: 1,
           ast: {"params":[],"body":[0,[[10,[5,"0"]]]],"externalNames":[]},
-          externals: {}
+          get externals() {
+            return {};
+          }
         }) && $.f)({})), "myFunction");
         const myComputeFn = (globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu['~unstable'].computeFn({
           workgroupSize: [1]
         })(($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = () => {}, {
           v: 1,
           ast: {"params":[],"body":[0,[]],"externalNames":[]},
-          externals: {}
+          get externals() {
+            return {};
+          }
         }) && $.f)({})), "myComputeFn");
         const myVertexFn = (globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu['~unstable'].vertexFn({
           out: {
@@ -144,7 +150,9 @@ describe('[BABEL] auto naming', () => {
         }), {
           v: 1,
           ast: {"params":[],"body":[0,[[10,[104,{"ret":[5,"0"]}]]]],"externalNames":[]},
-          externals: {}
+          get externals() {
+            return {};
+          }
         }) && $.f)({})), "myVertexFn");
         const myFragmentFn = (globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu['~unstable'].fragmentFn({
           in: {
@@ -154,8 +162,10 @@ describe('[BABEL] auto naming', () => {
         })(($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = () => d.vec4f(), {
           v: 1,
           ast: {"params":[],"body":[0,[[10,[6,[7,"d","vec4f"],[]]]]],"externalNames":["d"]},
-          externals: {
-            d
+          get externals() {
+            return {
+              d
+            };
           }
         }) && $.f)({})), "myFragmentFn");"
       `);

--- a/packages/unplugin-typegpu/test/auto-naming.test.ts
+++ b/packages/unplugin-typegpu/test/auto-naming.test.ts
@@ -304,7 +304,7 @@ describe('[ROLLUP] auto naming', () => {
               ((globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu.fn([])((($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => {}), {
                       v: 1,
                       ast: {"params":[],"body":[0,[]],"externalNames":[]},
-                      externals: {},
+                      get externals() { return {}; },
                     }) && $.f)({}))), "fn"));
 
               console.log(bindGroupLayout, vertexLayout);
@@ -412,20 +412,20 @@ describe('[ROLLUP] auto naming', () => {
         ((globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu.fn([])((($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => 0), {
                       v: 1,
                       ast: {"params":[],"body":[0,[[10,[5,"0"]]]],"externalNames":[]},
-                      externals: {},
+                      get externals() { return {}; },
                     }) && $.f)({}))), "myFunction"));
               ((globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu['~unstable'].computeFn({ workgroupSize: [1] })(
                 (($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => {}), {
                       v: 1,
                       ast: {"params":[],"body":[0,[]],"externalNames":[]},
-                      externals: {},
+                      get externals() { return {}; },
                     }) && $.f)({})),
               ), "myComputeFn"));
               ((globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu['~unstable'].vertexFn({ out: { ret: d.i32 } })(
                 (($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => ({ ret: 0 })), {
                       v: 1,
                       ast: {"params":[],"body":[0,[[10,[104,{"ret":[5,"0"]}]]]],"externalNames":[]},
-                      externals: {},
+                      get externals() { return {}; },
                     }) && $.f)({})),
               ), "myVertexFn"));
               ((globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu['~unstable'].fragmentFn({
@@ -435,7 +435,7 @@ describe('[ROLLUP] auto naming', () => {
                 (($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => d.vec4f()), {
                       v: 1,
                       ast: {"params":[],"body":[0,[[10,[6,[7,"d","vec4f"],[]]]]],"externalNames":["d"]},
-                      externals: {d},
+                      get externals() { return {d}; },
                     }) && $.f)({})),
               ), "myFragmentFn"));
         "

--- a/packages/unplugin-typegpu/test/kernel-directive.test.ts
+++ b/packages/unplugin-typegpu/test/kernel-directive.test.ts
@@ -419,6 +419,21 @@ describe('[ROLLUP] "kernel" directive', () => {
     `);
   });
 
+  it('throws when hoisting was meant to be used', async () => {
+    const code = `\
+      const sum = add(1, 2);
+      function add(a, b) {
+        'kernel';
+        return a + b;
+      };
+    `;
+
+    await rollupTransform(code);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      `File  virtual:code: function "add" might have been referenced before its usage. Function statements are no longer hoisted after being transformed by the plugin.`,
+    );
+  });
+
   it('parses when no typegpu import', async () => {
     const code = `\
       function add(a, b) {

--- a/packages/unplugin-typegpu/test/kernel-directive.test.ts
+++ b/packages/unplugin-typegpu/test/kernel-directive.test.ts
@@ -242,7 +242,7 @@ describe('[ROLLUP] "kernel" directive', () => {
             }), {
                     v: 1,
                     ast: {"params":[{"type":"i","name":"a"},{"type":"i","name":"b"}],"body":[0,[[10,[1,"a","+","b"]]]],"externalNames":[]},
-                    externals: {},
+                    get externals() { return {}; },
                   }) && $.f)({}));
 
             console.log(addGPU);
@@ -283,7 +283,7 @@ describe('[ROLLUP] "kernel" directive', () => {
             }), {
                     v: 1,
                     ast: {"params":[{"type":"i","name":"a"},{"type":"i","name":"b"}],"body":[0,[[10,[1,"a","+","b"]]]],"externalNames":[]},
-                    externals: {},
+                    get externals() { return {}; },
                   }) && $.f)({})));
 
             shell((a, b) => {
@@ -319,7 +319,7 @@ describe('[ROLLUP] "kernel" directive', () => {
             }), {
                     v: 1,
                     ast: {"params":[{"type":"i","name":"a"},{"type":"i","name":"b"}],"body":[0,[[10,[1,"a","+","b"]]]],"externalNames":[]},
-                    externals: {},
+                    get externals() { return {}; },
                   }) && $.f)({})));
 
             shell(function(a, b) {
@@ -356,7 +356,7 @@ describe('[ROLLUP] "kernel" directive', () => {
             }), {
                     v: 1,
                     ast: {"params":[{"type":"i","name":"a"},{"type":"i","name":"b"}],"body":[0,[[10,[1,"a","+","b"]]]],"externalNames":[]},
-                    externals: {},
+                    get externals() { return {}; },
                   }) && $.f)({})));
 
             shell(function addCPU(a, b) {
@@ -393,7 +393,7 @@ describe('[ROLLUP] "kernel" directive', () => {
             }), {
                     v: 1,
                     ast: {"params":[{"type":"i","name":"a"},{"type":"i","name":"b"}],"body":[0,[[10,[1,"a","+","b"]]]],"externalNames":[]},
-                    externals: {},
+                    get externals() { return {}; },
                   }) && $.f)({}));
 
             console.log(addGPU);
@@ -422,7 +422,7 @@ describe('[ROLLUP] "kernel" directive', () => {
             }), {
                     v: 1,
                     ast: {"params":[{"type":"i","name":"a"},{"type":"i","name":"b"}],"body":[0,[[10,[1,"a","+","b"]]]],"externalNames":[]},
-                    externals: {},
+                    get externals() { return {}; },
                   }) && $.f)({}));
       "
     `);

--- a/packages/unplugin-typegpu/test/kernel-directive.test.ts
+++ b/packages/unplugin-typegpu/test/kernel-directive.test.ts
@@ -407,21 +407,6 @@ describe('[ROLLUP] "kernel" directive', () => {
     `);
   });
 
-  it('throws when hoisting was meant to be used', async () => {
-    const code = `\
-      const sum = add(1, 2);
-      function add(a, b) {
-        'kernel';
-        return a + b;
-      };
-    `;
-
-    await rollupTransform(code);
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      `File  virtual:code: function "add" might have been referenced before its usage. Function statements are no longer hoisted after being transformed by the plugin.`,
-    );
-  });
-
   it('parses when no typegpu import', async () => {
     const code = `\
       function add(a, b) {

--- a/packages/unplugin-typegpu/test/kernel-directive.test.ts
+++ b/packages/unplugin-typegpu/test/kernel-directive.test.ts
@@ -25,7 +25,9 @@ describe('[BABEL] "kernel" directive', () => {
       }, {
         v: 1,
         ast: {"params":[{"type":"i","name":"a"},{"type":"i","name":"b"}],"body":[0,[[10,[1,"a","+","b"]]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({});
       const addCPU = (a, b) => {
         return a + b;
@@ -59,7 +61,9 @@ describe('[BABEL] "kernel" directive', () => {
       }, {
         v: 1,
         ast: {"params":[{"type":"i","name":"a"},{"type":"i","name":"b"}],"body":[0,[[10,[1,"a","+","b"]]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({}));
       shell((a, b) => {
         return a + b;
@@ -93,7 +97,9 @@ describe('[BABEL] "kernel" directive', () => {
       }, {
         v: 1,
         ast: {"params":[{"type":"i","name":"a"},{"type":"i","name":"b"}],"body":[0,[[10,[1,"a","+","b"]]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({}));
       shell(function (a, b) {
         return a + b;
@@ -127,7 +133,9 @@ describe('[BABEL] "kernel" directive', () => {
       }, {
         v: 1,
         ast: {"params":[{"type":"i","name":"a"},{"type":"i","name":"b"}],"body":[0,[[10,[1,"a","+","b"]]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({}));
       shell(function addCPU(a, b) {
         return a + b;
@@ -158,7 +166,9 @@ describe('[BABEL] "kernel" directive', () => {
       }, {
         v: 1,
         ast: {"params":[{"type":"i","name":"a"},{"type":"i","name":"b"}],"body":[0,[[10,[1,"a","+","b"]]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({});
       function addCPU(a, b) {
         return a + b;
@@ -182,7 +192,9 @@ describe('[BABEL] "kernel" directive', () => {
       }, {
         v: 1,
         ast: {"params":[{"type":"i","name":"a"},{"type":"i","name":"b"}],"body":[0,[[10,[1,"a","+","b"]]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({});
       ;"
     `);

--- a/packages/unplugin-typegpu/test/parser-options.test.ts
+++ b/packages/unplugin-typegpu/test/parser-options.test.ts
@@ -20,7 +20,9 @@ describe('[BABEL] parser options', () => {
       }, {
         v: 1,
         ast: {"params":[],"body":[0,[[13,"x",[1,[5,"2"],"+",[5,"2"]]]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({}));"
     `);
 

--- a/packages/unplugin-typegpu/test/parser-options.test.ts
+++ b/packages/unplugin-typegpu/test/parser-options.test.ts
@@ -60,7 +60,7 @@ describe('[ROLLUP] tgpu alias gathering', async () => {
             }), {
                     v: 1,
                     ast: {"params":[],"body":[0,[]],"externalNames":[]},
-                    externals: {},
+                    get externals() { return {}; },
                   }) && $.f)({})));
 
             console.log(increment);

--- a/packages/unplugin-typegpu/test/tgsl-transpiling.test.ts
+++ b/packages/unplugin-typegpu/test/tgsl-transpiling.test.ts
@@ -39,9 +39,11 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
       }, {
         v: 1,
         ast: {"params":[{"type":"i","name":"input"}],"body":[0,[[13,"tmp",[7,[7,"counter","value"],"x"]],[2,[7,[7,"counter","value"],"x"],"=",[7,[7,"counter","value"],"y"]],[2,[7,[7,"counter","value"],"y"],"+=","tmp"],[2,[7,[7,"counter","value"],"z"],"+=",[6,[7,"d","f32"],[[7,[7,"input","num"],"x"]]]]]],"externalNames":["counter","d"]},
-        externals: {
-          counter,
-          d
+        get externals() {
+          return {
+            counter,
+            d
+          };
         }
       }) && $.f)({}));"
     `);
@@ -74,21 +76,27 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
       }, {
         v: 1,
         ast: {"params":[{"type":"i","name":"input"}],"body":[0,[[13,"x",true]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({}));
       const b = tgpu.fn([])(($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = () => {
         const y = 2 + 2;
       }, {
         v: 1,
         ast: {"params":[],"body":[0,[[13,"y",[1,[5,"2"],"+",[5,"2"]]]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({}));
       const cx = 2;
       const c = tgpu.fn([])(($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = () => cx, {
         v: 1,
         ast: {"params":[],"body":[0,[[10,"cx"]]],"externalNames":["cx"]},
-        externals: {
-          cx
+        get externals() {
+          return {
+            cx
+          };
         }
       }) && $.f)({}));
       const d = tgpu.fn([])('() {}');"
@@ -136,7 +144,9 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
       }, {
         v: 1,
         ast: {"params":[{"type":"i","name":"input"}],"body":[0,[[13,"x",true]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({}));
       const funcWithAs = tgpu['~unstable'].computeFn({
         workgroupSize: [1]
@@ -145,7 +155,9 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
       }, {
         v: 1,
         ast: {"params":[{"type":"i","name":"input"}],"body":[0,[[13,"x",true]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({}));
       const funcWithSatisfies = tgpu['~unstable'].computeFn({
         workgroupSize: [1]
@@ -154,7 +166,9 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
       }, {
         v: 1,
         ast: {"params":[{"type":"i","name":"input"}],"body":[0,[[13,"x",true]]],"externalNames":[]},
-        externals: {}
+        get externals() {
+          return {};
+        }
       }) && $.f)({}));"
     `);
   });

--- a/packages/unplugin-typegpu/test/tgsl-transpiling.test.ts
+++ b/packages/unplugin-typegpu/test/tgsl-transpiling.test.ts
@@ -198,7 +198,7 @@ describe('[ROLLUP] plugin for transpiling tgsl functions to tinyest', () => {
                   }), {
                     v: 1,
                     ast: {"params":[{"type":"i","name":"input"}],"body":[0,[[13,"tmp",[7,[7,"counter","value"],"x"]],[2,[7,[7,"counter","value"],"x"],"=",[7,[7,"counter","value"],"y"]],[2,[7,[7,"counter","value"],"y"],"+=","tmp"],[2,[7,[7,"counter","value"],"z"],"+=",[6,[7,"d","f32"],[[7,[7,"input","num"],"x"]]]]]],"externalNames":["counter","d"]},
-                    externals: {counter, d},
+                    get externals() { return {counter, d}; },
                   }) && $.f)({})));
       "
     `);
@@ -229,21 +229,21 @@ describe('[ROLLUP] plugin for transpiling tgsl functions to tinyest', () => {
               }), {
                     v: 1,
                     ast: {"params":[{"type":"i","name":"input"}],"body":[0,[[13,"x",true]]],"externalNames":[]},
-                    externals: {},
+                    get externals() { return {}; },
                   }) && $.f)({})));
 
               tgpu.fn([])((($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => {
               }), {
                     v: 1,
                     ast: {"params":[],"body":[0,[[13,"y",[1,[5,"2"],"+",[5,"2"]]]]],"externalNames":[]},
-                    externals: {},
+                    get externals() { return {}; },
                   }) && $.f)({})));
 
               const cx = 2;
               tgpu.fn([])((($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => cx), {
                     v: 1,
                     ast: {"params":[],"body":[0,[[10,"cx"]]],"externalNames":["cx"]},
-                    externals: {cx},
+                    get externals() { return {cx}; },
                   }) && $.f)({})));
 
               tgpu.fn([])('() {}');


### PR DESCRIPTION
The change allows for a function to reference another function defined later on.
This could potentially lead to people attempting to write recursive functions.

TypeScript screams when either of the following happens (something something _any_):
```ts
const bar = tgpu.fn([], d.f32)(() => foo() + 2);
const foo = tgpu.fn([], d.f32)(() => bar() - 2);
```
```ts
const bar = () => foo() + 2;
const foo = () => bar() - 2;
```

However, the following is fine:
```ts
let bar: TgpuFn; 
let foo: TgpuFn;
bar = tgpu.fn([], d.f32)(() => foo() + 2);
foo = tgpu.fn([], d.f32)(() => bar() - 2);
```
and in this case we get a stack overflow:
```ts
Resolution of the following tree failed: 
- <root>
- fn:bar
- foo: Resolution of the following tree failed: 
- call:foo
- fn:foo
- bar: Resolution of the following tree failed: 
- call:bar
- fn:bar
...
```
Should we try to detect this situation? This would probably require resolve to hold a set of items it is currently trying to resolve, it seems pretty doable. On the other hand, this is already illegal in wgsl, and it is not too difficult to know what is going on when seeing an error like this.