### PR TITLE
fix: Export `TgpuQuerySet`

### DIFF
--- a/packages/typegpu/src/index.ts
+++ b/packages/typegpu/src/index.ts
@@ -138,6 +138,7 @@ export type { InitFromDeviceOptions, InitOptions } from './core/root/init.ts';
 export type { TgpuConst } from './core/constant/tgpuConstant.ts';
 export type { TgpuVar, VariableScope } from './core/variable/tgpuVariable.ts';
 export type { TgpuSampler } from './core/sampler/sampler.ts';
+export type { TgpuQuerySet } from './core/querySet/querySet.ts';
 export type {
   BindLayoutEntry,
   ExtractBindGroupInputFromLayout,


### PR DESCRIPTION
Exporting `TgpuQuerySet` fom tgpu core