### PR TITLE
fix: concretize abstract types when performing division

### DIFF
--- a/packages/typegpu/src/tgsl/generationHelpers.ts
+++ b/packages/typegpu/src/tgsl/generationHelpers.ts
@@ -46,6 +46,7 @@ import {
   isVec,
   isVecInstance,
   isWgslArray,
+  isWgslData,
   isWgslStruct,
   type U32,
 } from '../data/wgslTypes.ts';
@@ -539,7 +540,12 @@ export function convertToCommonType({
   }
 
   if (concretizeTypes) {
-    types = (types as AnyWgslData[]).map(concretize);
+    types = types.map((type) => {
+      if (isWgslData(type)) {
+        return concretize(type);
+      }
+      return type;
+    });
   }
 
   if (DEV && verbose && Array.isArray(restrictTo) && restrictTo.length === 0) {

--- a/packages/typegpu/src/tgsl/generationHelpers.ts
+++ b/packages/typegpu/src/tgsl/generationHelpers.ts
@@ -46,7 +46,6 @@ import {
   isVec,
   isVecInstance,
   isWgslArray,
-  isWgslData,
   isWgslStruct,
   type U32,
 } from '../data/wgslTypes.ts';
@@ -518,7 +517,7 @@ function applyActionToSnippet(
   }
 }
 
-export type ConvertToCommonTypeInfo = {
+export type ConvertToCommonTypeOptions = {
   ctx: GenerationCtx;
   values: Snippet[];
   restrictTo?: AnyData[] | undefined;
@@ -532,20 +531,13 @@ export function convertToCommonType({
   restrictTo,
   concretizeTypes = false,
   verbose = true,
-}: ConvertToCommonTypeInfo): Snippet[] | undefined {
-  let types = values.map((value) => value.dataType);
+}: ConvertToCommonTypeOptions): Snippet[] | undefined {
+  const types = values.map((value) =>
+    concretizeTypes ? concretize(value.dataType as AnyWgslData) : value.dataType
+  );
 
   if (types.some((type) => type === UnknownData)) {
     return undefined;
-  }
-
-  if (concretizeTypes) {
-    types = types.map((type) => {
-      if (isWgslData(type)) {
-        return concretize(type);
-      }
-      return type;
-    });
   }
 
   if (DEV && verbose && Array.isArray(restrictTo) && restrictTo.length === 0) {

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -20,7 +20,6 @@ import {
   concretize,
   convertStructValues,
   convertToCommonType,
-  type ConvertToCommonTypeInfo,
   type GenerationCtx,
   getTypeForIndexAccess,
   getTypeForPropAccess,

--- a/packages/typegpu/tests/tgsl/generationHelpers.test.ts
+++ b/packages/typegpu/tests/tgsl/generationHelpers.test.ts
@@ -25,7 +25,6 @@ import {
   coerceToSnippet,
   convertStructValues,
   convertToCommonType,
-  type ConvertToCommonTypeInfo,
   convertType,
   type GenerationCtx,
   getBestConversion,

--- a/packages/typegpu/tests/tgsl/generationHelpers.test.ts
+++ b/packages/typegpu/tests/tgsl/generationHelpers.test.ts
@@ -25,6 +25,7 @@ import {
   coerceToSnippet,
   convertStructValues,
   convertToCommonType,
+  type ConvertToCommonTypeInfo,
   convertType,
   type GenerationCtx,
   getBestConversion,
@@ -365,7 +366,10 @@ describe('generationHelpers', () => {
     const snippetUnknown = snip('?', UnknownData);
 
     it('converts identical types', () => {
-      const result = convertToCommonType(mockCtx, [snippetF32, snippetF32]);
+      const result = convertToCommonType({
+        ctx: mockCtx,
+        values: [snippetF32, snippetF32],
+      });
       expect(result).toBeDefined();
       expect(result?.length).toBe(2);
       expect(result?.[0]?.dataType).toBe(f32);
@@ -375,11 +379,14 @@ describe('generationHelpers', () => {
     });
 
     it('handles abstract types automatically', () => {
-      const result = convertToCommonType(mockCtx, [
-        snippetAbsFloat,
-        snippetF32,
-        snippetAbsInt,
-      ]);
+      const result = convertToCommonType({
+        ctx: mockCtx,
+        values: [
+          snippetAbsFloat,
+          snippetF32,
+          snippetAbsInt,
+        ],
+      });
       // since WGSL handles all abstract types automatically, this should be basically identity
       expect(result).toBeDefined();
       expect(result?.length).toBe(3);
@@ -392,7 +399,10 @@ describe('generationHelpers', () => {
     });
 
     it('performs implicit casts and warns', () => {
-      const result = convertToCommonType(mockCtx, [snippetI32, snippetF32]);
+      const result = convertToCommonType({
+        ctx: mockCtx,
+        values: [snippetI32, snippetF32],
+      });
       expect(result).toBeDefined();
       expect(result?.length).toBe(2);
       expect(result?.[0]?.dataType).toBe(f32);
@@ -402,7 +412,10 @@ describe('generationHelpers', () => {
     });
 
     it('performs pointer dereferencing', () => {
-      const result = convertToCommonType(mockCtx, [snippetPtrF32, snippetF32]);
+      const result = convertToCommonType({
+        ctx: mockCtx,
+        values: [snippetPtrF32, snippetF32],
+      });
       expect(result).toBeDefined();
       expect(result?.length).toBe(2);
       expect(result?.[0]?.dataType).toBe(f32);
@@ -413,28 +426,34 @@ describe('generationHelpers', () => {
 
     it('returns undefined for incompatible types', () => {
       const snippetVec2f = snip('v2', vec2f);
-      const result = convertToCommonType(mockCtx, [snippetF32, snippetVec2f]);
+      const result = convertToCommonType({
+        ctx: mockCtx,
+        values: [snippetF32, snippetVec2f],
+      });
       expect(result).toBeUndefined();
     });
 
     it('returns undefined if any type is UnknownData', () => {
-      const result = convertToCommonType(mockCtx, [snippetF32, snippetUnknown]);
+      const result = convertToCommonType({
+        ctx: mockCtx,
+        values: [snippetF32, snippetUnknown],
+      });
       expect(result).toBeUndefined();
     });
 
     it('returns undefined for empty input', () => {
-      const result = convertToCommonType(mockCtx, []);
+      const result = convertToCommonType({ ctx: mockCtx, values: [] });
       expect(result).toBeUndefined();
     });
 
     it('respects restrictTo types', () => {
       // [abstractInt, i32] -> common type i32
       // Restrict to f32: requires cast for i32
-      const result = convertToCommonType(
-        mockCtx,
-        [snippetAbsInt, snippetI32],
-        [f32],
-      );
+      const result = convertToCommonType({
+        ctx: mockCtx,
+        values: [snippetAbsInt, snippetI32],
+        restrictTo: [f32],
+      });
       expect(result).toBeDefined();
       expect(result?.length).toBe(2);
       expect(result?.[0]?.dataType).toBe(f32);
@@ -444,11 +463,11 @@ describe('generationHelpers', () => {
     });
 
     it('fails if restrictTo is incompatible', () => {
-      const result = convertToCommonType(
-        mockCtx,
-        [snippetAbsInt, snippetI32],
-        [vec2f],
-      );
+      const result = convertToCommonType({
+        ctx: mockCtx,
+        values: [snippetAbsInt, snippetI32],
+        restrictTo: [vec2f],
+      });
       expect(result).toBeUndefined();
     });
   });

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -997,7 +997,7 @@ describe('wgslGenerator division operator', () => {
     });
     expect(div()).toBe(0.1);
     expect(parseResolved({ divide1: div })).toMatchInlineSnapshot(
-      `"fn div ( ) -> f32 { return ( f32 ( f16 ( ( 1 / 2 ) ) ) / f32 ( 5 ) ) ; }"`,
+      `"fn div ( ) -> f32 { return ( f32 ( f16 ( ( f32 ( 1 ) / f32 ( 2 ) ) ) ) / f32 ( 5 ) ) ; }"`,
     );
   });
 


### PR DESCRIPTION
Changes:
- `convertToCommonType` now has an additional parameter, `concretizeTypes`, which makes the function concretize the types before looking for the best conversion
- `generateExpression` now concretizes types when it encounters division
- tests have been updated accordingly

Closes #1551.