### PR TITLE
fix: Add support for packed vertex formats in compiled writer and improve the writer selection logic

### DIFF
--- a/packages/typegpu/src/data/compiledIO.ts
+++ b/packages/typegpu/src/data/compiledIO.ts
@@ -86,16 +86,16 @@ export function buildWriter(
   }
 
   if (wgsl.isWgslArray(node) || isDisarray(node)) {
-    const arrSchema = node as wgsl.WgslArray;
     const elementSize = roundUp(
-      sizeOf(arrSchema.elementType),
-      alignmentOf(arrSchema.elementType),
+      sizeOf(node.elementType),
+      alignmentOf(node),
     );
+    console.log(elementSize);
     let code = '';
 
-    code += `for (let i = 0; i < ${arrSchema.elementCount}; i++) {\n`;
+    code += `for (let i = 0; i < ${node.elementCount}; i++) {\n`;
     code += buildWriter(
-      arrSchema.elementType,
+      node.elementType,
       `(${offsetExpr} + i * ${elementSize})`,
       `${valueExpr}[i]`,
     );

--- a/packages/typegpu/src/data/dataIO.ts
+++ b/packages/typegpu/src/data/dataIO.ts
@@ -267,17 +267,17 @@ const dataWriters = {
     output.writeUint8(value.w * 255);
   },
   snorm8(output, _, value: number) {
-    output.writeUint8(value * 127 + 128);
+    output.writeInt8(Math.round(value * 127));
   },
   snorm8x2(output, _, value: wgsl.v2f) {
-    output.writeUint8(value.x * 127 + 128);
-    output.writeUint8(value.y * 127 + 128);
+    output.writeInt8(Math.round(value.x * 127));
+    output.writeInt8(Math.round(value.y * 127));
   },
   snorm8x4(output, _, value: wgsl.v4f) {
-    output.writeUint8(value.x * 127 + 128);
-    output.writeUint8(value.y * 127 + 128);
-    output.writeUint8(value.z * 127 + 128);
-    output.writeUint8(value.w * 127 + 128);
+    output.writeInt8(Math.round(value.x * 127));
+    output.writeInt8(Math.round(value.y * 127));
+    output.writeInt8(Math.round(value.z * 127));
+    output.writeInt8(Math.round(value.w * 127));
   },
   uint16(output, _, value: number) {
     output.writeUint16(value);
@@ -319,17 +319,17 @@ const dataWriters = {
     output.writeUint16(value.w * 65535);
   },
   snorm16(output, _, value: number) {
-    output.writeUint16(value * 32767 + 32768);
+    output.writeInt16(Math.round(value * 32767));
   },
   snorm16x2(output, _, value: wgsl.v2f) {
-    output.writeUint16(value.x * 32767 + 32768);
-    output.writeUint16(value.y * 32767 + 32768);
+    output.writeInt16(Math.round(value.x * 32767));
+    output.writeInt16(Math.round(value.y * 32767));
   },
   snorm16x4(output, _, value: wgsl.v4f) {
-    output.writeUint16(value.x * 32767 + 32768);
-    output.writeUint16(value.y * 32767 + 32768);
-    output.writeUint16(value.z * 32767 + 32768);
-    output.writeUint16(value.w * 32767 + 32768);
+    output.writeInt16(Math.round(value.x * 32767));
+    output.writeInt16(Math.round(value.y * 32767));
+    output.writeInt16(Math.round(value.z * 32767));
+    output.writeInt16(Math.round(value.w * 32767));
   },
   float16(output, _, value: number) {
     output.writeFloat16(value);
@@ -401,9 +401,9 @@ const dataWriters = {
   'unorm10-10-10-2'(output, _, value: wgsl.v4f) {
     let packed = 0;
     packed |= ((value.x * 1023) & 1023) << 22; // r (10 bits)
-    packed |= ((value.x * 1023) & 1023) << 12; // g (10 bits)
-    packed |= ((value.y * 1023) & 1023) << 2; // b (10 bits)
-    packed |= (value.z * 3) & 3; // a (2 bits)
+    packed |= ((value.y * 1023) & 1023) << 12; // g (10 bits)
+    packed |= ((value.z * 1023) & 1023) << 2; // b (10 bits)
+    packed |= (value.w * 3) & 3; // a (2 bits)
     output.writeUint32(packed);
   },
   'unorm8x4-bgra'(output, _, value: wgsl.v4f) {
@@ -695,15 +695,14 @@ const dataReaders = {
       i.readUint8() / 255,
       i.readUint8() / 255,
     ),
-  snorm8: (i) => (i.readUint8() - 128) / 127,
-  snorm8x2: (i) =>
-    vec2f((i.readUint8() - 128) / 127, (i.readUint8() - 128) / 127),
+  snorm8: (i) => i.readInt8() / 127,
+  snorm8x2: (i) => vec2f(i.readInt8() / 127, i.readInt8() / 127),
   snorm8x4: (i) =>
     vec4f(
-      (i.readUint8() - 128) / 127,
-      (i.readUint8() - 128) / 127,
-      (i.readUint8() - 128) / 127,
-      (i.readUint8() - 128) / 127,
+      i.readInt8() / 127,
+      i.readInt8() / 127,
+      i.readInt8() / 127,
+      i.readInt8() / 127,
     ),
   uint16: (i) => i.readUint16(),
   uint16x2: (i) => vec2u(i.readUint16(), i.readUint16()),
@@ -722,15 +721,15 @@ const dataReaders = {
       i.readUint16() / 65535,
       i.readUint16() / 65535,
     ),
-  snorm16: (i) => (i.readUint16() - 32768) / 32767,
+  snorm16: (i) => i.readInt16() / 32767,
   snorm16x2: (i): wgsl.v2f =>
-    vec2f(dataReaders.snorm16(i), dataReaders.snorm16(i)),
+    vec2f(i.readInt16() / 32767, i.readInt16() / 32767),
   snorm16x4: (i): wgsl.v4f =>
     vec4f(
-      dataReaders.snorm16(i),
-      dataReaders.snorm16(i),
-      dataReaders.snorm16(i),
-      dataReaders.snorm16(i),
+      i.readInt16() / 32767,
+      i.readInt16() / 32767,
+      i.readInt16() / 32767,
+      i.readInt16() / 32767,
     ),
   float16(i) {
     return i.readFloat16();

--- a/packages/typegpu/src/data/vertexFormatData.ts
+++ b/packages/typegpu/src/data/vertexFormatData.ts
@@ -250,3 +250,12 @@ export type PackedData =
   | sint32x4
   | unorm10_10_10_2
   | unorm8x4_bgra;
+
+export function isPackedData(
+  value: unknown,
+): value is PackedData {
+  return (value as PackedData)?.[$internal] &&
+    Object.keys(formatToWGSLType).includes(
+      (value as PackedData)?.type,
+    );
+}

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -316,21 +316,21 @@ describe('TgpuBuffer', () => {
     expect(rawBuffer).toBeDefined();
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 8, new Uint8Array([-1, 127, -1, 127]), 0, 4],
+      [rawBuffer, 8, new Uint8Array([255, 127, 255, 127]), 0, 4],
     ]);
 
     buffer.writePartial({ b: d.vec2f(-0.5, 0.5) });
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 8, new Uint8Array([-1, 127, -1, 127]), 0, 4],
-      [rawBuffer, 16, new Uint8Array([64, -65]), 0, 2],
+      [rawBuffer, 8, new Uint8Array([255, 127, 255, 127]), 0, 4],
+      [rawBuffer, 16, new Uint8Array([193, 64]), 0, 2],
     ]);
 
     buffer.writePartial({ c: { d: 3 } });
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 8, new Uint8Array([-1, 127, -1, 127]), 0, 4],
-      [rawBuffer, 16, new Uint8Array([64, -65]), 0, 2],
+      [rawBuffer, 8, new Uint8Array([255, 127, 255, 127]), 0, 4],
+      [rawBuffer, 16, new Uint8Array([193, 64]), 0, 2],
       [rawBuffer, 18, new Uint8Array([3, 0, 0, 0]), 0, 4],
     ]);
   });

--- a/packages/typegpu/tests/compiledIO.test.ts
+++ b/packages/typegpu/tests/compiledIO.test.ts
@@ -6,6 +6,7 @@ import {
 import * as d from '../src/data/index.ts';
 import { sizeOf } from '../src/data/sizeOf.ts';
 import { it } from './utils/extendedIt.ts';
+import tgpu from '../src/index.ts';
 
 describe('buildWriter', () => {
   it('should compile a writer for a struct', () => {
@@ -246,5 +247,223 @@ describe('createCompileInstructions', () => {
     writer(dataView, 0, [1, 2, 3, 4, 5]);
 
     expect([...new Uint16Array(arr)]).toStrictEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('should compile a writer for struct with size attribute', () => {
+    const schema = d.struct({
+      a: d.size(16, d.f32),
+      b: d.arrayOf(d.f32, 2),
+    });
+
+    const builtWriter = buildWriter(schema, 'offset', 'value');
+    expect(builtWriter).toMatchInlineSnapshot(`
+      "output.setFloat32((offset + 0), value.a, littleEndian);
+      for (let i = 0; i < 2; i++) {
+      output.setFloat32(((offset + 16) + i * 4), value.b[i], littleEndian);
+      }
+      "
+    `);
+
+    const writer = getCompiledWriterForSchema(schema);
+
+    const arr = new ArrayBuffer(sizeOf(schema));
+    const dataView = new DataView(arr);
+
+    writer(dataView, 0, { a: 1.0, b: [2.0, 3.0] });
+
+    expect([...new Float32Array(arr)]).toStrictEqual([1.0, 0, 0, 0, 2.0, 3.0]);
+  });
+
+  it('should compile a writer for struct with align attribute', () => {
+    const schema = d.struct({
+      a: d.f32,
+      b: d.align(64, d.arrayOf(d.f32, 2)),
+    });
+
+    console.log(tgpu.resolve({ externals: { schema } }));
+
+    const builtWriter = buildWriter(schema, 'offset', 'value');
+    expect(builtWriter).toMatchInlineSnapshot(`
+      "output.setFloat32((offset + 0), value.a, littleEndian);
+      for (let i = 0; i < 2; i++) {
+      output.setFloat32(((offset + 64) + i * 4), value.b[i], littleEndian);
+      }
+      "
+    `);
+
+    const writer = getCompiledWriterForSchema(schema);
+
+    console.log(sizeOf(schema));
+    console.log(d.alignmentOf(schema));
+    const arr = new ArrayBuffer(sizeOf(schema));
+    const dataView = new DataView(arr);
+
+    writer(dataView, 0, { a: 1.0, b: [2.0, 3.0] });
+
+    expect([...new Float32Array(arr)]).toStrictEqual([
+      1.0,
+      ...Array.from({ length: 15 }).map(() => 0), // padding
+      2.0,
+      3.0,
+      ...Array.from({ length: 14 }).map(() => 0), // padding
+    ]);
+  });
+
+  it('should compile a writer for unstruct', () => {
+    const unstruct = d.unstruct({
+      a: d.vec3f,
+      b: d.vec4f,
+    });
+
+    const builtWriter = buildWriter(unstruct, 'offset', 'value');
+    expect(builtWriter).toMatchInlineSnapshot(`
+      "output.setFloat32(((offset + 0) + 0), value.a.x, littleEndian);
+      output.setFloat32(((offset + 0) + 4), value.a.y, littleEndian);
+      output.setFloat32(((offset + 0) + 8), value.a.z, littleEndian);
+      output.setFloat32(((offset + 12) + 0), value.b.x, littleEndian);
+      output.setFloat32(((offset + 12) + 4), value.b.y, littleEndian);
+      output.setFloat32(((offset + 12) + 8), value.b.z, littleEndian);
+      output.setFloat32(((offset + 12) + 12), value.b.w, littleEndian);
+      "
+    `);
+
+    const writer = getCompiledWriterForSchema(unstruct);
+
+    const arr = new ArrayBuffer(sizeOf(unstruct));
+    const dataView = new DataView(arr);
+
+    writer(dataView, 0, {
+      a: d.vec3f(1, 2, 3),
+      b: d.vec4f(3, 4, 5, 6),
+    });
+
+    expect([...new Float32Array(arr)]).toStrictEqual([1, 2, 3, 3, 4, 5, 6]);
+  });
+
+  it('should compile a writer for a disarray', () => {
+    const disarray = d.disarrayOf(d.vec3f, 3);
+
+    const builtWriter = buildWriter(disarray, 'offset', 'value');
+    expect(builtWriter).toMatchInlineSnapshot(`
+      "for (let i = 0; i < 3; i++) {
+      output.setFloat32(((offset + i * 12) + 0), value[i].x, littleEndian);
+      output.setFloat32(((offset + i * 12) + 4), value[i].y, littleEndian);
+      output.setFloat32(((offset + i * 12) + 8), value[i].z, littleEndian);
+      }
+      "
+    `);
+
+    const writer = getCompiledWriterForSchema(disarray);
+
+    const arr = new ArrayBuffer(sizeOf(disarray));
+    const dataView = new DataView(arr);
+
+    writer(dataView, 0, [d.vec3f(1, 2, 3), d.vec3f(4, 5, 6), d.vec3f(7, 8, 9)]);
+
+    expect([...new Float32Array(arr)]).toStrictEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+    ]);
+  });
+
+  it('should compile for a disarray of unstructs', () => {
+    const unstruct = d.unstruct({
+      a: d.vec3f,
+      b: d.vec4f,
+    });
+    const disarray = d.disarrayOf(unstruct, 2);
+
+    const builtWriter = buildWriter(disarray, 'offset', 'value');
+    expect(builtWriter).toMatchInlineSnapshot(`
+      "for (let i = 0; i < 2; i++) {
+      output.setFloat32((((offset + i * 28) + 0) + 0), value[i].a.x, littleEndian);
+      output.setFloat32((((offset + i * 28) + 0) + 4), value[i].a.y, littleEndian);
+      output.setFloat32((((offset + i * 28) + 0) + 8), value[i].a.z, littleEndian);
+      output.setFloat32((((offset + i * 28) + 12) + 0), value[i].b.x, littleEndian);
+      output.setFloat32((((offset + i * 28) + 12) + 4), value[i].b.y, littleEndian);
+      output.setFloat32((((offset + i * 28) + 12) + 8), value[i].b.z, littleEndian);
+      output.setFloat32((((offset + i * 28) + 12) + 12), value[i].b.w, littleEndian);
+      }
+      "
+    `);
+
+    const writer = getCompiledWriterForSchema(disarray);
+
+    const arr = new ArrayBuffer(sizeOf(disarray));
+    const dataView = new DataView(arr);
+
+    writer(dataView, 0, [
+      { a: d.vec3f(1, 2, 3), b: d.vec4f(4, 5, 6, 7) },
+      { a: d.vec3f(8, 9, 10), b: d.vec4f(11, 12, 13, 14) },
+    ]);
+
+    expect([...new Float32Array(arr)]).toStrictEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+    ]);
+  });
+
+  it('should work for unstructs with loose data', () => {
+    const unstruct = d.unstruct({
+      a: d.uint16x2,
+      b: d.unorm10_10_10_2,
+      c: d.uint8x2,
+      d: d.unorm8x4,
+    });
+
+    const unstructWriter = buildWriter(unstruct, 'offset', 'value');
+    expect(unstructWriter).toMatchInlineSnapshot(`
+      "output.undefined((offset + 0), value.a, littleEndian);
+      output.undefined((offset + 4), value.b, littleEndian);
+      output.undefined((offset + 8), value.c, littleEndian);
+      output.undefined((offset + 10), value.d, littleEndian);
+      "
+    `);
+
+    const writer = getCompiledWriterForSchema(unstruct);
+
+    const arr = new ArrayBuffer(sizeOf(unstruct));
+    const dataView = new DataView(arr);
+
+    writer(dataView, 0, {
+      a: d.vec2u(1, 2),
+      b: d.vec4f(3, 4, 5, 6),
+      c: d.vec2u(7, 8),
+      d: d.vec4f(9, 10, 11, 12),
+    });
+
+    expect([...new Uint16Array(arr)]).toStrictEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+    ]);
   });
 });

--- a/packages/typegpu/tests/compiledIO.test.ts
+++ b/packages/typegpu/tests/compiledIO.test.ts
@@ -90,7 +90,9 @@ describe('createCompileInstructions', () => {
       b: d.vec3f,
     });
 
-    const writer = getCompiledWriterForSchema(struct);
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(struct)!;
+
     const arr = new ArrayBuffer(sizeOf(struct));
     const dataView = new DataView(arr);
 
@@ -107,7 +109,8 @@ describe('createCompileInstructions', () => {
       c: d.arrayOf(d.u32, 3),
     });
 
-    const writer = getCompiledWriterForSchema(struct);
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(struct)!;
 
     const arr = new ArrayBuffer(sizeOf(struct));
     const dataView = new DataView(arr);
@@ -133,7 +136,8 @@ describe('createCompileInstructions', () => {
       c: d.arrayOf(d.struct({ d: d.u32 }), 3),
     });
 
-    const writer = getCompiledWriterForSchema(struct);
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(struct)!;
 
     const arr = new ArrayBuffer(sizeOf(struct));
     const dataView = new DataView(arr);
@@ -152,7 +156,8 @@ describe('createCompileInstructions', () => {
   it('should compile a writer for an array', () => {
     const array = d.arrayOf(d.vec3f, 5);
 
-    const writer = getCompiledWriterForSchema(array);
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(array)!;
 
     const arr = new ArrayBuffer(sizeOf(array));
     const dataView = new DataView(arr);
@@ -178,7 +183,9 @@ describe('createCompileInstructions', () => {
     const Schema = d.struct({
       transform: d.mat4x4f,
     });
-    const writer = getCompiledWriterForSchema(Schema);
+
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(Schema)!;
 
     const arr = new ArrayBuffer(sizeOf(Schema));
     const dataView = new DataView(arr);
@@ -197,7 +204,9 @@ describe('createCompileInstructions', () => {
     const Schema = d.struct({
       transform: d.mat3x3f,
     });
-    const writer = getCompiledWriterForSchema(Schema);
+
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(Schema)!;
 
     const arr = new ArrayBuffer(sizeOf(Schema));
     const dataView = new DataView(arr);
@@ -215,7 +224,9 @@ describe('createCompileInstructions', () => {
     const Schema = d.struct({
       transform: d.mat2x2f,
     });
-    const writer = getCompiledWriterForSchema(Schema);
+
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(Schema)!;
 
     const arr = new ArrayBuffer(sizeOf(Schema));
     const dataView = new DataView(arr);
@@ -239,7 +250,8 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const writer = getCompiledWriterForSchema(array);
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(array)!;
 
     const arr = new ArrayBuffer(sizeOf(array));
     const dataView = new DataView(arr);
@@ -264,7 +276,8 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const writer = getCompiledWriterForSchema(schema);
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(schema)!;
 
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
@@ -291,7 +304,8 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const writer = getCompiledWriterForSchema(schema);
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(schema)!;
 
     console.log(sizeOf(schema));
     console.log(d.alignmentOf(schema));
@@ -327,7 +341,8 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const writer = getCompiledWriterForSchema(unstruct);
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(unstruct)!;
 
     const arr = new ArrayBuffer(sizeOf(unstruct));
     const dataView = new DataView(arr);
@@ -353,7 +368,8 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const writer = getCompiledWriterForSchema(disarray);
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(disarray)!;
 
     const arr = new ArrayBuffer(sizeOf(disarray));
     const dataView = new DataView(arr);
@@ -394,7 +410,8 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const writer = getCompiledWriterForSchema(disarray);
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(disarray)!;
 
     const arr = new ArrayBuffer(sizeOf(disarray));
     const dataView = new DataView(arr);
@@ -432,38 +449,176 @@ describe('createCompileInstructions', () => {
 
     const unstructWriter = buildWriter(unstruct, 'offset', 'value');
     expect(unstructWriter).toMatchInlineSnapshot(`
-      "output.undefined((offset + 0), value.a, littleEndian);
-      output.undefined((offset + 4), value.b, littleEndian);
-      output.undefined((offset + 8), value.c, littleEndian);
-      output.undefined((offset + 10), value.d, littleEndian);
+      "output.setUint16(((offset + 0) + 0), value.a.x, littleEndian);
+      output.setUint16(((offset + 0) + 2), value.a.y, littleEndian);
+      output.setUint32((offset + 4), ((value.b.x*1023&0x3FF)<<22)|((value.b.y*1023&0x3FF)<<12)|((value.b.z*1023&0x3FF)<<2)|(value.b.w*3&3), littleEndian);
+      output.setUint8(((offset + 8) + 0), value.c.x, littleEndian);
+      output.setUint8(((offset + 8) + 1), value.c.y, littleEndian);
+      output.setUint8(((offset + 10) + 0), value.d.x * 255, littleEndian);
+      output.setUint8(((offset + 10) + 1), value.d.y * 255, littleEndian);
+      output.setUint8(((offset + 10) + 2), value.d.z * 255, littleEndian);
+      output.setUint8(((offset + 10) + 3), value.d.w * 255, littleEndian);
       "
     `);
-
-    const writer = getCompiledWriterForSchema(unstruct);
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const writer = getCompiledWriterForSchema(unstruct)!;
 
     const arr = new ArrayBuffer(sizeOf(unstruct));
     const dataView = new DataView(arr);
 
     writer(dataView, 0, {
       a: d.vec2u(1, 2),
-      b: d.vec4f(3, 4, 5, 6),
+      b: d.vec4f(0.25, 0.5, 0.75, 1),
       c: d.vec2u(7, 8),
-      d: d.vec4f(9, 10, 11, 12),
+      d: d.vec4f(0.34, 0.67, 0.91, 1),
     });
 
-    expect([...new Uint16Array(arr)]).toStrictEqual([
+    const result = [
+      ...new Uint16Array(arr, 0, 2),
+      ...new Uint8Array(arr, 4, 4),
+      ...new Uint8Array(arr, 8, 2),
+      ...new Uint8Array(arr, 10, 4),
+    ];
+
+    expect(result).toEqual([
       1,
       2,
-      3,
-      4,
-      5,
-      6,
+      255,
+      251,
+      223,
+      63,
       7,
       8,
-      9,
-      10,
-      11,
-      12,
+      86,
+      170,
+      232,
+      255,
+    ]);
+  });
+
+  it('should work for disarrays of unstructs containing loose data', () => {
+    const unstruct = d.unstruct({
+      a: d.unorm16x2,
+      b: d.unorm8x4_bgra,
+      c: d.snorm8x4,
+      d: d.snorm16x2,
+      e: d.sint8x2,
+      f: d.sint16x2,
+    });
+
+    const disarray = d.disarrayOf(unstruct, 2);
+    const disarrayWriter = buildWriter(disarray, 'offset', 'value');
+    expect(disarrayWriter).toMatchInlineSnapshot(`
+      "for (let i = 0; i < 2; i++) {
+      output.setUint16((((offset + i * 22) + 0) + 0), value[i].a.x * 65535, littleEndian);
+      output.setUint16((((offset + i * 22) + 0) + 2), value[i].a.y * 65535, littleEndian);
+      output.setUint8((((offset + i * 22) + 4) + 0), value[i].b.z * 255);
+      output.setUint8((((offset + i * 22) + 4) + 1), value[i].b.y * 255);
+      output.setUint8((((offset + i * 22) + 4) + 2), value[i].b.x * 255);
+      output.setUint8((((offset + i * 22) + 4) + 3), value[i].b.w * 255);
+      output.setInt8((((offset + i * 22) + 8) + 0), Math.round(value[i].c.x * 127), littleEndian);
+      output.setInt8((((offset + i * 22) + 8) + 1), Math.round(value[i].c.y * 127), littleEndian);
+      output.setInt8((((offset + i * 22) + 8) + 2), Math.round(value[i].c.z * 127), littleEndian);
+      output.setInt8((((offset + i * 22) + 8) + 3), Math.round(value[i].c.w * 127), littleEndian);
+      output.setInt16((((offset + i * 22) + 12) + 0), Math.round(value[i].d.x * 32767), littleEndian);
+      output.setInt16((((offset + i * 22) + 12) + 2), Math.round(value[i].d.y * 32767), littleEndian);
+      output.setInt8((((offset + i * 22) + 16) + 0), value[i].e.x, littleEndian);
+      output.setInt8((((offset + i * 22) + 16) + 1), value[i].e.y, littleEndian);
+      output.setInt16((((offset + i * 22) + 18) + 0), value[i].f.x, littleEndian);
+      output.setInt16((((offset + i * 22) + 18) + 2), value[i].f.y, littleEndian);
+      }
+      "
+    `);
+
+    // biome-ignore lint/style/noNonNullAssertion: <it's a test>
+    const compiled = getCompiledWriterForSchema(disarray)!;
+
+    const arr = new ArrayBuffer(sizeOf(disarray));
+    const dataView = new DataView(arr);
+
+    compiled(dataView, 0, [
+      {
+        a: d.vec2f(0.5, 0.25),
+        b: d.vec4f(0.25, 0.5, 0.75, 1),
+        c: d.vec4f(-0.5, 0.5, -0.25, 0.75),
+        d: d.vec2f(0.34, 0.67),
+        e: d.vec2i(1, 2),
+        f: d.vec2i(3, 4),
+      },
+      {
+        a: d.vec2f(0.75, 1.0),
+        b: d.vec4f(0.1, 0.2, 0.3, 0.4),
+        c: d.vec4f(0.1, -0.1, 0.9, -0.9),
+        d: d.vec2f(-0.5, 0.8),
+        e: d.vec2i(5, 6),
+        f: d.vec2i(7, 8),
+      },
+    ]);
+
+    const result = [
+      ...new Uint8Array(arr, 0, 44),
+    ];
+
+    expect(result).toEqual([
+      // First element
+      // a: unorm16x2 vec2f(0.5, 0.25) -> [32767, 16383] -> [255, 127, 255, 63]
+      255,
+      127,
+      255,
+      63,
+      // b: unorm8x4_bgra vec4f(0.25, 0.5, 0.75, 1) -> BGRA [191, 127, 63, 255]
+      191,
+      127,
+      63,
+      255,
+      // c: snorm8x4 vec4f(-0.5, 0.5, -0.25, 0.75) -> [-63, 64, -32, 95]
+      193,
+      64,
+      224,
+      95,
+      // d: snorm16x2 vec2f(0.34, 0.67) -> [11141, 21954] -> [133, 43, 194, 85]
+      133,
+      43,
+      194,
+      85,
+      // e: sint8x2 vec2i(1, 2) -> [1, 2]
+      1,
+      2,
+      // f: sint16x2 vec2i(3, 4) -> [3, 0, 4, 0]
+      3,
+      0,
+      4,
+      0,
+
+      // Second element
+      // a: unorm16x2 vec2f(0.75, 1.0) -> [49151, 65535] -> [255, 191, 255, 255]
+      255,
+      191,
+      255,
+      255,
+      // b: unorm8x4_bgra vec4f(0.1, 0.2, 0.3, 0.4) -> BGRA [76, 51, 25, 102]
+      76,
+      51,
+      25,
+      102,
+      // c: snorm8x4 vec4f(0.1, -0.1, 0.9, -0.9) -> [13, -13, 114, -114]
+      13,
+      243,
+      114,
+      142,
+      // d: snorm16x2 vec2f(-0.5, 0.8) -> [-16383, 26214] -> [1, 192, 102, 102]
+      1,
+      192,
+      102,
+      102,
+      // e: sint8x2 vec2i(5, 6) -> [5, 6]
+      5,
+      6,
+      // f: sint16x2 vec2i(7, 8) -> [7, 0, 8, 0]
+      7,
+      0,
+      8,
+      0,
     ]);
   });
 });


### PR DESCRIPTION
Up until now loose data was not supported in compiled writers (despite vaguely looking like it was). This PR adds support for them as well as introducing a fallback in case we fail to compile the writer.