### PR TITLE
fix: Fix infix operator value resolution for bindings

### DIFF
--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -381,6 +381,8 @@ export function generateExpression(
     }
 
     if (callee.value instanceof InfixDispatch) {
+      const lhs = callee.value.lhs;
+
       // Infix operator dispatch.
       if (!argNodes[0]) {
         throw new WgslTypeError(
@@ -388,7 +390,7 @@ export function generateExpression(
         );
       }
       return callee.value.operator(
-        callee.value.lhs,
+        snip(ctx.resolve(lhs.value), lhs.dataType),
         generateExpression(ctx, argNodes[0]),
       );
     }


### PR DESCRIPTION
This PR ~~fixes~~ (_does not fix_ as it turns out) an issue when fixed entries wouldn't get properly resolved in combination with infix dispatches. Also adds some more tests.

closes #1570 