### PR TITLE
fix: Unify operand types in arithmetic operators

### DIFF
--- a/packages/typegpu/src/std/operators.ts
+++ b/packages/typegpu/src/std/operators.ts
@@ -225,7 +225,6 @@ function cpuDiv<T extends NumVec | number>(lhs: number, rhs: T): T; // mixed div
 function cpuDiv<T extends NumVec | number>(lhs: T, rhs: number): T; // mixed division
 function cpuDiv(lhs: NumVec | number, rhs: NumVec | number): NumVec | number {
   if (typeof lhs === 'number' && typeof rhs === 'number') {
-    console.log('Div: scalar / scalar');
     return lhs / rhs;
   }
   if (typeof lhs === 'number' && isVecInstance(rhs)) {
@@ -248,15 +247,11 @@ export const div = createDualImpl(
   // CODEGEN implementation
   (lhs, rhs) => {
     const [convLhs, convRhs] = tryUnify([lhs, rhs], [f32, f16], true);
-    console.log(
-      `Pre: ${lhs.value}(${lhs.dataType.type}), ${rhs.value}(${rhs.dataType.type})\nPost: ${convLhs.value}(${convLhs.dataType.type}), ${convRhs.value}(${convRhs.dataType.type})`,
-    );
 
     if (
       (typeof lhs.value === 'number' || isVecInstance(lhs.value)) &&
       (typeof rhs.value === 'number' || isVecInstance(rhs.value))
     ) {
-      console.log('PRECOMPUTING');
       // Precomputing
       return snip(
         cpuDiv(lhs.value as never, rhs.value as never),

--- a/packages/typegpu/src/std/operators.ts
+++ b/packages/typegpu/src/std/operators.ts
@@ -33,7 +33,7 @@ function tryUnify<T extends Snippet[]>(
     concretizeTypes,
     verbose,
   });
-  return converted ? (converted as T) : values;
+  return converted ?? values;
 }
 
 type NumVec = AnyNumericVecInstance;

--- a/packages/typegpu/src/std/operators.ts
+++ b/packages/typegpu/src/std/operators.ts
@@ -23,6 +23,7 @@ function tryUnify<T extends Snippet[]>(
   values: T,
   restrictTo?: AnyWgslData[],
   concretizeTypes = false,
+  verbose = true,
 ): T {
   const ctx = getResolutionCtx() as ResolutionCtx;
   const converted = convertToCommonType({
@@ -30,6 +31,7 @@ function tryUnify<T extends Snippet[]>(
     values,
     restrictTo,
     concretizeTypes,
+    verbose,
   });
   return converted ? (converted as T) : values;
 }
@@ -246,7 +248,7 @@ export const div = createDualImpl(
   cpuDiv,
   // CODEGEN implementation
   (lhs, rhs) => {
-    const [convLhs, convRhs] = tryUnify([lhs, rhs], [f32, f16], true);
+    const [convLhs, convRhs] = tryUnify([lhs, rhs], [f32, f16], true, false);
 
     if (
       (typeof lhs.value === 'number' || isVecInstance(lhs.value)) &&

--- a/packages/typegpu/src/std/operators.ts
+++ b/packages/typegpu/src/std/operators.ts
@@ -1,12 +1,12 @@
 import { stitch } from '../core/resolve/stitch.ts';
 import { createDualImpl } from '../core/function/dualImpl.ts';
-import { f16, f32 } from '../data/numeric.ts';
 import { isSnippetNumeric, snip, type Snippet } from '../data/snippet.ts';
 import { vecTypeToConstructor } from '../data/vector.ts';
 import { VectorOps } from '../data/vectorOps.ts';
 import {
   type AnyMatInstance,
   type AnyNumericVecInstance,
+  type AnyWgslData,
   isFloat32VecInstance,
   isMatInstance,
   isVecInstance,
@@ -17,6 +17,22 @@ import { convertToCommonType } from '../tgsl/generationHelpers.ts';
 import { getResolutionCtx } from '../execMode.ts';
 import type { ResolutionCtx } from '../types.ts';
 import { $internal } from '../shared/symbols.ts';
+import { f16, f32 } from '../data/numeric.ts';
+
+function tryUnify<T extends Snippet[]>(
+  values: T,
+  restrictTo?: AnyWgslData[],
+  concretizeTypes = false,
+): T {
+  const ctx = getResolutionCtx() as ResolutionCtx;
+  const converted = convertToCommonType({
+    ctx,
+    values,
+    restrictTo,
+    concretizeTypes,
+  });
+  return converted ? (converted as T) : values;
+}
 
 type NumVec = AnyNumericVecInstance;
 type Mat = AnyMatInstance;
@@ -58,7 +74,10 @@ export const add = createDualImpl(
   cpuAdd,
   // CODEGEN implementation
   (lhs, rhs) => {
-    const resultType = isSnippetNumeric(lhs) ? rhs.dataType : lhs.dataType;
+    const [convLhs, convRhs] = tryUnify([lhs, rhs]);
+    const resultType = isSnippetNumeric(convLhs)
+      ? convRhs.dataType
+      : convLhs.dataType;
 
     if (
       (typeof lhs.value === 'number' ||
@@ -72,7 +91,7 @@ export const add = createDualImpl(
       return snip(cpuAdd(lhs.value as never, rhs.value as never), resultType);
     }
 
-    return snip(stitch`(${lhs} + ${rhs})`, resultType);
+    return snip(stitch`(${convLhs} + ${convRhs})`, resultType);
   },
   'add',
 );
@@ -99,7 +118,10 @@ export const sub = createDualImpl(
   cpuSub,
   // CODEGEN implementation
   (lhs, rhs) => {
-    const resultType = isSnippetNumeric(lhs) ? rhs.dataType : lhs.dataType;
+    const [convLhs, convRhs] = tryUnify([lhs, rhs]);
+    const resultType = isSnippetNumeric(convLhs)
+      ? convRhs.dataType
+      : convLhs.dataType;
 
     if (
       (typeof lhs.value === 'number' ||
@@ -113,7 +135,7 @@ export const sub = createDualImpl(
       return snip(cpuSub(lhs.value as never, rhs.value as never), resultType);
     }
 
-    return snip(stitch`(${lhs} - ${rhs})`, resultType);
+    return snip(stitch`(${convLhs} - ${convRhs})`, resultType);
   },
   'sub',
 );
@@ -164,20 +186,21 @@ export const mul = createDualImpl(
   cpuMul,
   // GPU implementation
   (lhs, rhs) => {
-    const returnType = isSnippetNumeric(lhs)
+    const [convLhs, convRhs] = tryUnify([lhs, rhs]);
+    const returnType = isSnippetNumeric(convLhs)
       // Scalar * Scalar/Vector/Matrix
-      ? rhs.dataType
-      : isSnippetNumeric(rhs)
+      ? convRhs.dataType
+      : isSnippetNumeric(convRhs)
       // Vector/Matrix * Scalar
-      ? lhs.dataType
-      : lhs.dataType.type.startsWith('vec')
+      ? convLhs.dataType
+      : convLhs.dataType.type.startsWith('vec')
       // Vector * Vector/Matrix
-      ? lhs.dataType
-      : rhs.dataType.type.startsWith('vec')
+      ? convLhs.dataType
+      : convRhs.dataType.type.startsWith('vec')
       // Matrix * Vector
-      ? rhs.dataType
+      ? convRhs.dataType
       // Matrix * Matrix
-      : lhs.dataType;
+      : convLhs.dataType;
 
     if (
       (typeof lhs.value === 'number' ||
@@ -191,7 +214,7 @@ export const mul = createDualImpl(
       return snip(cpuMul(lhs.value as never, rhs.value as never), returnType);
     }
 
-    return snip(stitch`(${lhs} * ${rhs})`, returnType);
+    return snip(stitch`(${convLhs} * ${convRhs})`, returnType);
   },
   'mul',
 );
@@ -202,6 +225,7 @@ function cpuDiv<T extends NumVec | number>(lhs: number, rhs: T): T; // mixed div
 function cpuDiv<T extends NumVec | number>(lhs: T, rhs: number): T; // mixed division
 function cpuDiv(lhs: NumVec | number, rhs: NumVec | number): NumVec | number {
   if (typeof lhs === 'number' && typeof rhs === 'number') {
+    console.log('Div: scalar / scalar');
     return lhs / rhs;
   }
   if (typeof lhs === 'number' && isVecInstance(rhs)) {
@@ -223,35 +247,24 @@ export const div = createDualImpl(
   cpuDiv,
   // CODEGEN implementation
   (lhs, rhs) => {
-    let conv: [Snippet, Snippet] = [lhs, rhs];
-
-    if (isSnippetNumeric(lhs) && isSnippetNumeric(rhs)) {
-      const ctx = getResolutionCtx() as ResolutionCtx;
-      const converted = convertToCommonType({
-        ctx,
-        values: [lhs, rhs],
-        restrictTo: [f32, f16],
-        concretizeTypes: true,
-      }) as
-        | [Snippet, Snippet]
-        | undefined;
-      if (converted) {
-        conv = converted;
-      }
-    }
-
-    const lhsVal = conv[0].value;
-    const rhsVal = conv[1].value;
+    const [convLhs, convRhs] = tryUnify([lhs, rhs], [f32, f16], true);
+    console.log(
+      `Pre: ${lhs.value}(${lhs.dataType.type}), ${rhs.value}(${rhs.dataType.type})\nPost: ${convLhs.value}(${convLhs.dataType.type}), ${convRhs.value}(${convRhs.dataType.type})`,
+    );
 
     if (
-      (typeof lhsVal === 'number' || isVecInstance(lhsVal)) &&
-      (typeof rhsVal === 'number' || isVecInstance(rhsVal))
+      (typeof lhs.value === 'number' || isVecInstance(lhs.value)) &&
+      (typeof rhs.value === 'number' || isVecInstance(rhs.value))
     ) {
+      console.log('PRECOMPUTING');
       // Precomputing
-      return snip(cpuDiv(lhsVal as never, rhsVal as never), conv[0].dataType);
+      return snip(
+        cpuDiv(lhs.value as never, rhs.value as never),
+        convLhs.dataType,
+      );
     }
 
-    return snip(stitch`(${conv[0]} / ${conv[1]})`, conv[0].dataType);
+    return snip(stitch`(${convLhs} / ${convRhs})`, convLhs.dataType);
   },
   'div',
 );
@@ -294,8 +307,9 @@ export const mod: ModOverload = createDualImpl(
   },
   // GPU implementation
   (a, b) => {
-    const type = isSnippetNumeric(a) ? b.dataType : a.dataType;
-    return snip(stitch`(${a} % ${b})`, type);
+    const [convA, convB] = tryUnify([a, b]);
+    const type = isSnippetNumeric(convA) ? convB.dataType : convA.dataType;
+    return snip(stitch`(${convA} % ${convB})`, type);
   },
   'mod',
 );

--- a/packages/typegpu/src/tgsl/generationHelpers.ts
+++ b/packages/typegpu/src/tgsl/generationHelpers.ts
@@ -521,8 +521,16 @@ export function convertToCommonType({
   concretizeTypes = false,
   verbose = true,
 }: ConvertToCommonTypeOptions): Snippet[] | undefined {
+  const needsConcretization = concretizeTypes &&
+    // If we have any concrete type among the values, we don't need to concretize
+    !values.some((value) =>
+      concretize(value.dataType as AnyWgslData) === value.dataType
+    );
+
   const types = values.map((value) =>
-    concretizeTypes ? concretize(value.dataType as AnyWgslData) : value.dataType
+    needsConcretization
+      ? concretize(value.dataType as AnyWgslData)
+      : value.dataType
   );
 
   if (types.some((type) => type === UnknownData)) {

--- a/packages/typegpu/src/tgsl/generationHelpers.ts
+++ b/packages/typegpu/src/tgsl/generationHelpers.ts
@@ -506,21 +506,21 @@ function applyActionToSnippet(
   }
 }
 
-export type ConvertToCommonTypeOptions = {
+export type ConvertToCommonTypeOptions<T extends Snippet[]> = {
   ctx: ResolutionCtx;
-  values: Snippet[];
+  values: T;
   restrictTo?: AnyData[] | undefined;
   concretizeTypes?: boolean | undefined;
   verbose?: boolean | undefined;
 };
 
-export function convertToCommonType({
+export function convertToCommonType<T extends Snippet[]>({
   ctx,
   values,
   restrictTo,
   concretizeTypes = false,
   verbose = true,
-}: ConvertToCommonTypeOptions): Snippet[] | undefined {
+}: ConvertToCommonTypeOptions<T>): T | undefined {
   const needsConcretization = concretizeTypes &&
     // If we have any concrete type among the values, we don't need to concretize
     !values.some((value) =>
@@ -565,7 +565,7 @@ Consider using explicit conversions instead.`,
     const action = conversion.actions[index];
     invariant(action, 'Action should not be undefined');
     return applyActionToSnippet(ctx, value, action, conversion.targetType);
-  });
+  }) as T;
 }
 
 export function tryConvertSnippet(

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -215,11 +215,9 @@ export function generateExpression(
 
     const converted = convertToCommonType({
       ctx,
-      values: [lhsExpr, rhsExpr],
+      values: [lhsExpr, rhsExpr] as const,
       restrictTo: forcedType,
-    }) as
-      | [Snippet, Snippet]
-      | undefined;
+    });
     const [convLhs, convRhs] = converted || [lhsExpr, rhsExpr];
 
     const lhsStr = ctx.resolve(convLhs.value);

--- a/packages/typegpu/tests/compiledIO.test.ts
+++ b/packages/typegpu/tests/compiledIO.test.ts
@@ -6,7 +6,6 @@ import {
 import * as d from '../src/data/index.ts';
 import { sizeOf } from '../src/data/sizeOf.ts';
 import { it } from './utils/extendedIt.ts';
-import tgpu from '../src/index.ts';
 
 describe('buildWriter', () => {
   it('should compile a writer for a struct', () => {
@@ -292,8 +291,6 @@ describe('createCompileInstructions', () => {
       a: d.f32,
       b: d.align(64, d.arrayOf(d.f32, 2)),
     });
-
-    console.log(tgpu.resolve({ externals: { schema } }));
 
     const builtWriter = buildWriter(schema, 'offset', 'value');
     expect(builtWriter).toMatchInlineSnapshot(`

--- a/packages/typegpu/tests/struct.test.ts
+++ b/packages/typegpu/tests/struct.test.ts
@@ -388,8 +388,6 @@ describe('abstruct', () => {
       return result.exp;
     });
 
-    console.log(tgpu.resolve({ externals: { testFn } }));
-
     expect(parseResolved({ testFn })).toBe(
       parse(`
         fn testFn(x: f32) -> f32 {

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -997,7 +997,7 @@ describe('wgslGenerator division operator', () => {
     });
     expect(div()).toBe(0.1);
     expect(parseResolved({ divide1: div })).toMatchInlineSnapshot(
-      `"fn div ( ) -> f32 { return ( f32 ( f16 ( ( f32 ( 1 ) / f32 ( 2 ) ) ) ) / f32 ( 5 ) ) ; }"`,
+      `"fn div ( ) -> f32 { return ( f32 ( f16 ( 0.5 ) ) / f32 ( 5 ) ) ; }"`,
     );
   });
 


### PR DESCRIPTION
Currently we are inferring operator result types incorrectly, which causes some examples (e.g., cubemap reflection) to break.
The bug is caused by naively assigning:
```ts
const resultType = isSnippetNumeric(lhs) ? rhs.dataType : lhs.dataType;
```
This breaks as soon as something like:
```
u32(1.5) + 1
```
happens. Here we incorrectly infer this expression to be of type abstractInt.
This PR uses the type conversion system to properly deduce operator return type.