### PR TITLE
chore: Example logs cleanup

### DIFF
--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.html
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.html
@@ -2,7 +2,9 @@
 <div class="example">
   <canvas></canvas>
   <div class="predictions-container">
-    <div class="predictions-label">Predictions</div>
+    <div class="predictions-label">
+      Predictions (-.--ms)
+    </div>
 
     <div class="bars-container">
       <div class="bar">O</div>

--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -353,7 +353,7 @@ window.addEventListener('mouseup', mouseUpEventListener);
 const touchEndEventListener = () => {
   uiState.lastPos = null;
 };
-canvas.addEventListener('touchend', touchEndEventListener);
+window.addEventListener('touchend', touchEndEventListener);
 
 function centerImage(data: number[]) {
   const mass = data.reduce((acc, value) => acc + value, 0);

--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -335,14 +335,16 @@ canvas.addEventListener('mousedown', () => {
   uiState.isDrawing = true;
 });
 
-window.addEventListener('mouseup', () => {
+const mouseUpEventListener = () => {
   uiState.isDrawing = false;
   uiState.lastPos = null;
-});
+};
+window.addEventListener('mouseup', mouseUpEventListener);
 
-canvas.addEventListener('touchend', () => {
+const touchEndEventListener = () => {
   uiState.lastPos = null;
-});
+};
+canvas.addEventListener('touchend', touchEndEventListener);
 
 function centerImage(data: number[]) {
   const mass = data.reduce((acc, value) => acc + value, 0);
@@ -463,6 +465,8 @@ export const controls = {
 
 export function onCleanup() {
   disposed = true;
+  window.removeEventListener('mouseup', mouseUpEventListener);
+  window.removeEventListener('touchend', touchEndEventListener);
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -182,10 +182,7 @@ function createNetwork(layers: [LayerData, LayerData][]): Network {
       querySet.resolve();
       const results = await querySet.read();
       const timeInMs = Number(results[1] - results[0]) / 1_000_000;
-      const formattedTimeInMs = timeInMs.toLocaleString('en-US', {
-        maximumFractionDigits: 2,
-        minimumFractionDigits: 2,
-      });
+      const formattedTimeInMs = timeInMs.toFixed(2);
       const predictionLabel = document.querySelector<HTMLDivElement>(
         '.predictions-label',
       );

--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -181,9 +181,18 @@ function createNetwork(layers: [LayerData, LayerData][]): Network {
     if (querySet?.available) {
       querySet.resolve();
       const results = await querySet.read();
-      console.log(
-        `Inference took ${Number(results[1] - results[0]) / 1_000_000} ms`,
+      const timeInMs = Number(results[1] - results[0]) / 1_000_000;
+      const formattedTimeInMs = timeInMs.toLocaleString('en-US', {
+        maximumFractionDigits: 2,
+        minimumFractionDigits: 2,
+      });
+      const predictionLabel = document.querySelector<HTMLDivElement>(
+        '.predictions-label',
       );
+      if (!predictionLabel) {
+        throw new Error('Missing prediction label.');
+      }
+      predictionLabel.innerText = `Predictions (${formattedTimeInMs}ms)`;
     }
 
     // Read the output

--- a/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/content/examples/algorithms/mnist-inference/index.ts
@@ -451,7 +451,7 @@ canvas.addEventListener('touchmove', (event) => {
     ((touch.clientY - canvasPos.top) * window.devicePixelRatio) / cellSize,
   );
   handleDrawing(x, y);
-});
+}, { passive: false });
 
 export const controls = {
   Reset: {

--- a/apps/typegpu-docs/src/content/examples/image-processing/ascii-filter/index.ts
+++ b/apps/typegpu-docs/src/content/examples/image-processing/ascii-filter/index.ts
@@ -46,7 +46,7 @@ const characterFn = tgpu.fn([d.u32, d.vec2f], d.f32)((n, p) => {
   // Convert 2D bitmap position to 1D bit index (row-major order)
   const a = d.u32(std.add(pos.x, std.mul(5, pos.y)));
   // Extract the bit at position 'a' from the character bitmap 'n'
-  if ((n >> a) & 1) {
+  if (d.bool((n >> a) & 1)) {
     return 1;
   }
   return 0;

--- a/apps/typegpu-docs/src/content/examples/rendering/3d-fish/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/3d-fish/index.ts
@@ -410,7 +410,7 @@ canvas.addEventListener('mousedown', async (event) => {
   }
 });
 
-window.addEventListener('mouseup', (event) => {
+const mouseUpEventListener = (event: MouseEvent) => {
   if (event.button === 0) {
     isLeftPressed = false;
   }
@@ -420,7 +420,8 @@ window.addEventListener('mouseup', (event) => {
       activated: 0,
     });
   }
-});
+};
+window.addEventListener('mouseup', mouseUpEventListener);
 
 canvas.addEventListener('mousemove', () => {
   if (!isPopupDiscarded) {
@@ -428,7 +429,7 @@ canvas.addEventListener('mousemove', () => {
   }
 });
 
-window.addEventListener('mousemove', (event) => {
+const mouseMoveEventListener = (event: MouseEvent) => {
   const dx = event.clientX - previousMouseX;
   const dy = event.clientY - previousMouseY;
   previousMouseX = event.clientX;
@@ -441,7 +442,8 @@ window.addEventListener('mousemove', (event) => {
   if (isRightPressed) {
     updateMouseRay(event.clientX, event.clientY);
   }
-});
+};
+window.addEventListener('mousemove', mouseMoveEventListener);
 
 // Touch controls
 
@@ -455,7 +457,7 @@ canvas.addEventListener('touchstart', async (event) => {
   }
 });
 
-window.addEventListener('touchmove', (event) => {
+const touchMoveEventListener = (event: TouchEvent) => {
   if (event.touches.length === 1) {
     const dx = event.touches[0].clientX - previousMouseX;
     const dy = event.touches[0].clientY - previousMouseY;
@@ -465,13 +467,15 @@ window.addEventListener('touchmove', (event) => {
     updateCameraTarget(dx, dy);
     updateMouseRay(event.touches[0].clientX, event.touches[0].clientY);
   }
-});
+};
+window.addEventListener('touchmove', touchMoveEventListener);
 
-window.addEventListener('touchend', () => {
+const touchEndEventListener = () => {
   mouseRayBuffer.writePartial({
     activated: 0,
   });
-});
+};
+window.addEventListener('touchend', touchEndEventListener);
 
 // observer and cleanup
 
@@ -495,6 +499,10 @@ resizeObserver.observe(canvas);
 
 export function onCleanup() {
   disposed = true;
+  window.removeEventListener('mouseup', mouseUpEventListener);
+  window.removeEventListener('mousemove', mouseMoveEventListener);
+  window.removeEventListener('touchmove', touchMoveEventListener);
+  window.removeEventListener('touchend', touchEndEventListener);
   resizeObserver.disconnect();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/content/examples/rendering/3d-fish/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/3d-fish/index.ts
@@ -455,7 +455,7 @@ canvas.addEventListener('touchstart', async (event) => {
     updateMouseRay(event.touches[0].clientX, event.touches[0].clientY);
     controlsPopup.style.opacity = '0';
   }
-});
+}, { passive: false });
 
 const touchMoveEventListener = (event: TouchEvent) => {
   if (event.touches.length === 1) {

--- a/apps/typegpu-docs/src/content/examples/rendering/cubemap-reflection/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/cubemap-reflection/index.ts
@@ -389,7 +389,7 @@ canvas.addEventListener('wheel', (event: WheelEvent) => {
     d.mat4x4f(),
   );
   cameraBuffer.writePartial({ view: newView, position: newCameraPos });
-});
+}, { passive: false });
 
 canvas.addEventListener('mousedown', (event) => {
   isDragging = true;
@@ -403,7 +403,7 @@ canvas.addEventListener('touchstart', (event) => {
     prevX = event.touches[0].clientX;
     prevY = event.touches[0].clientY;
   }
-});
+}, { passive: true });
 
 canvas.addEventListener('mouseup', () => {
   isDragging = false;
@@ -434,7 +434,7 @@ canvas.addEventListener('touchmove', (event) => {
 
     updateCameraOrbit(dx, dy);
   }
-});
+}, { passive: false });
 
 function hideHelp() {
   const helpElem = document.getElementById('help');
@@ -443,7 +443,7 @@ function hideHelp() {
   }
 }
 for (const eventName of ['click', 'keydown', 'wheel', 'touchstart']) {
-  canvas.addEventListener(eventName, hideHelp, { once: true });
+  canvas.addEventListener(eventName, hideHelp, { once: true, passive: true });
 }
 
 export const controls = {

--- a/apps/typegpu-docs/src/content/examples/rendering/cubemap-reflection/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/cubemap-reflection/index.ts
@@ -405,11 +405,11 @@ canvas.addEventListener('touchstart', (event) => {
   }
 });
 
-window.addEventListener('mouseup', () => {
+canvas.addEventListener('mouseup', () => {
   isDragging = false;
 });
 
-window.addEventListener('touchend', () => {
+canvas.addEventListener('touchend', () => {
   isDragging = false;
 });
 
@@ -443,7 +443,7 @@ function hideHelp() {
   }
 }
 for (const eventName of ['click', 'keydown', 'wheel', 'touchstart']) {
-  window.addEventListener(eventName, hideHelp, { once: true });
+  canvas.addEventListener(eventName, hideHelp, { once: true });
 }
 
 export const controls = {

--- a/apps/typegpu-docs/src/content/examples/rendering/cubemap-reflection/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/cubemap-reflection/index.ts
@@ -398,22 +398,25 @@ canvas.addEventListener('mousedown', (event) => {
 });
 
 canvas.addEventListener('touchstart', (event) => {
+  event.preventDefault();
   if (event.touches.length === 1) {
     isDragging = true;
     prevX = event.touches[0].clientX;
     prevY = event.touches[0].clientY;
   }
-}, { passive: true });
+}, { passive: false });
 
-canvas.addEventListener('mouseup', () => {
+const mouseUpEventListener = () => {
   isDragging = false;
-});
+};
+window.addEventListener('mouseup', mouseUpEventListener);
 
-canvas.addEventListener('touchend', () => {
+const touchEndEventListener = () => {
   isDragging = false;
-});
+};
+window.addEventListener('touchend', touchEndEventListener);
 
-canvas.addEventListener('mousemove', (event) => {
+const mouseMoveEventListener = (event: MouseEvent) => {
   const dx = event.clientX - prevX;
   const dy = event.clientY - prevY;
   prevX = event.clientX;
@@ -422,9 +425,10 @@ canvas.addEventListener('mousemove', (event) => {
   if (isDragging) {
     updateCameraOrbit(dx, dy);
   }
-});
+};
+window.addEventListener('mousemove', mouseMoveEventListener);
 
-canvas.addEventListener('touchmove', (event) => {
+const touchMoveEventListener = (event: TouchEvent) => {
   if (isDragging && event.touches.length === 1) {
     event.preventDefault();
     const dx = event.touches[0].clientX - prevX;
@@ -434,7 +438,10 @@ canvas.addEventListener('touchmove', (event) => {
 
     updateCameraOrbit(dx, dy);
   }
-}, { passive: false });
+};
+window.addEventListener('touchmove', touchMoveEventListener, {
+  passive: false,
+});
 
 function hideHelp() {
   const helpElem = document.getElementById('help');
@@ -544,6 +551,10 @@ export const controls = {
 
 export function onCleanup() {
   exampleDestroyed = true;
+  window.removeEventListener('mouseup', mouseUpEventListener);
+  window.removeEventListener('mousemove', mouseMoveEventListener);
+  window.removeEventListener('touchmove', touchMoveEventListener);
+  window.removeEventListener('touchend', touchEndEventListener);
   resizeObserver.unobserve(canvas);
   icosphereGenerator.destroy();
   cubemapTexture.destroy();

--- a/apps/typegpu-docs/src/content/examples/rendering/function-visualizer/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/function-visualizer/index.ts
@@ -454,7 +454,7 @@ canvas.addEventListener('mousedown', (event) => {
   lastPos = [event.clientX, event.clientY];
 });
 
-window.addEventListener('mousemove', (event) => {
+const mouseMoveEventListener = (event: MouseEvent) => {
   if (lastPos === null) {
     return;
   }
@@ -475,11 +475,13 @@ window.addEventListener('mousemove', (event) => {
   );
 
   lastPos = currentPos;
-});
+};
+window.addEventListener('mousemove', mouseMoveEventListener);
 
-window.addEventListener('mouseup', (_) => {
+const mouseUpEventListener = () => {
   lastPos = null;
-});
+};
+window.addEventListener('mouseup', mouseUpEventListener);
 
 canvas.addEventListener('wheel', (event) => {
   event.preventDefault();
@@ -494,7 +496,7 @@ canvas.addEventListener('wheel', (event) => {
   );
 });
 
-// Mouse interaction
+// Touch interaction
 
 canvas.addEventListener('touchstart', (event) => {
   event.preventDefault();
@@ -503,7 +505,7 @@ canvas.addEventListener('touchstart', (event) => {
   }
 });
 
-window.addEventListener('touchmove', (event) => {
+const touchMoveEventListener = (event: TouchEvent) => {
   if (lastPos === null || event.touches.length !== 1) {
     return;
   }
@@ -521,11 +523,13 @@ window.addEventListener('touchmove', (event) => {
   );
 
   lastPos = currentPos;
-});
+};
+window.addEventListener('touchmove', touchMoveEventListener);
 
-window.addEventListener('touchend', () => {
+const touchEndEventListener = () => {
   lastPos = null;
-});
+};
+window.addEventListener('touchend', touchEndEventListener);
 
 // Resize observer and cleanup
 
@@ -614,6 +618,10 @@ export const controls = {
 
 export function onCleanup() {
   destroyed = true;
+  window.removeEventListener('mouseup', mouseUpEventListener);
+  window.removeEventListener('mousemove', mouseMoveEventListener);
+  window.removeEventListener('touchmove', touchMoveEventListener);
+  window.removeEventListener('touchend', touchEndEventListener);
   resizeObserver.disconnect();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/content/examples/rendering/function-visualizer/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/function-visualizer/index.ts
@@ -494,7 +494,7 @@ canvas.addEventListener('wheel', (event) => {
     [scale, scale, 1],
     properties.transformation,
   );
-});
+}, { passive: false });
 
 // Touch interaction
 
@@ -503,7 +503,7 @@ canvas.addEventListener('touchstart', (event) => {
   if (event.touches.length === 1) {
     lastPos = [event.touches[0].clientX, event.touches[0].clientY];
   }
-});
+}, { passive: false });
 
 const touchMoveEventListener = (event: TouchEvent) => {
   if (lastPos === null || event.touches.length !== 1) {

--- a/apps/typegpu-docs/src/content/examples/rendering/two-boxes/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/two-boxes/index.ts
@@ -420,10 +420,11 @@ canvas.addEventListener('mousedown', (event) => {
   prevY = event.clientY;
 });
 
-window.addEventListener('mouseup', () => {
+const mouseUpEventListener = () => {
   isRightDragging = false;
   isDragging = false;
-});
+};
+window.addEventListener('mouseup', mouseUpEventListener);
 
 canvas.addEventListener('mousemove', (event) => {
   const dx = event.clientX - prevX;
@@ -470,13 +471,14 @@ canvas.addEventListener('touchmove', (event: TouchEvent) => {
   }
 });
 
-canvas.addEventListener('touchend', (event: TouchEvent) => {
+const touchEndEventListener = (event: TouchEvent) => {
   event.preventDefault();
   if (event.touches.length === 0) {
     isRightDragging = false;
     isDragging = false;
   }
-});
+};
+window.addEventListener('touchend', touchEndEventListener);
 
 const resizeObserver = new ResizeObserver(() => {
   createDepthAndMsaaTextures();
@@ -485,6 +487,8 @@ resizeObserver.observe(canvas);
 
 export function onCleanup() {
   disposed = true;
+  window.removeEventListener('mouseup', mouseUpEventListener);
+  window.removeEventListener('touchend', touchEndEventListener);
   resizeObserver.disconnect();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/content/examples/rendering/two-boxes/index.ts
+++ b/apps/typegpu-docs/src/content/examples/rendering/two-boxes/index.ts
@@ -386,7 +386,7 @@ canvas.addEventListener('mouseout', () => {
 // handle mobile devices
 canvas.addEventListener('touchstart', () => {
   helpInfo.style.opacity = '0';
-});
+}, { passive: true });
 canvas.addEventListener('touchend', () => {
   helpInfo.style.opacity = '1';
 });
@@ -406,7 +406,7 @@ canvas.addEventListener('wheel', (event: WheelEvent) => {
     d.mat4x4f(),
   );
   cameraBuffer.writePartial({ view: newView });
-});
+}, { passive: false });
 
 canvas.addEventListener('mousedown', (event) => {
   if (event.button === 0) {
@@ -453,7 +453,7 @@ canvas.addEventListener('touchstart', (event: TouchEvent) => {
   // Use the first touch for rotation.
   prevX = event.touches[0].clientX;
   prevY = event.touches[0].clientY;
-});
+}, { passive: false });
 
 canvas.addEventListener('touchmove', (event: TouchEvent) => {
   event.preventDefault();
@@ -469,7 +469,7 @@ canvas.addEventListener('touchmove', (event: TouchEvent) => {
   if (isRightDragging && event.touches.length === 2) {
     updateCubesRotation(dx, dy);
   }
-});
+}, { passive: false });
 
 const touchEndEventListener = (event: TouchEvent) => {
   event.preventDefault();

--- a/apps/typegpu-docs/src/content/examples/simulation/gravity/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/gravity/index.ts
@@ -381,15 +381,17 @@ canvas.addEventListener('touchstart', (event) => {
   }
 });
 
-window.addEventListener('mouseup', () => {
+const mouseUpEventListener = () => {
   isDragging = false;
-});
+};
+window.addEventListener('mouseup', mouseUpEventListener);
 
-window.addEventListener('touchend', () => {
+const touchEndEventListener = () => {
   isDragging = false;
-});
+};
+window.addEventListener('touchend', touchEndEventListener);
 
-window.addEventListener('mousemove', (event) => {
+const mouseMoveEventListener = (event: MouseEvent) => {
   const dx = event.clientX - prevX;
   const dy = event.clientY - prevY;
   prevX = event.clientX;
@@ -398,9 +400,10 @@ window.addEventListener('mousemove', (event) => {
   if (isDragging) {
     updateCameraOrbit(dx, dy);
   }
-});
+};
+window.addEventListener('mousemove', mouseMoveEventListener);
 
-canvas.addEventListener('touchmove', (event) => {
+const touchMoveEventListener = (event: TouchEvent) => {
   if (isDragging && event.touches.length === 1) {
     event.preventDefault();
     const dx = event.touches[0].clientX - prevX;
@@ -410,7 +413,8 @@ canvas.addEventListener('touchmove', (event) => {
 
     updateCameraOrbit(dx, dy);
   }
-});
+};
+window.addEventListener('touchmove', touchMoveEventListener);
 
 function hideHelp() {
   const helpElem = document.getElementById('help');
@@ -419,11 +423,15 @@ function hideHelp() {
   }
 }
 for (const eventName of ['click', 'keydown', 'wheel', 'touchstart']) {
-  window.addEventListener(eventName, hideHelp, { once: true });
+  canvas.addEventListener(eventName, hideHelp, { once: true });
 }
 
 export function onCleanup() {
   destroyed = true;
+  window.removeEventListener('mouseup', mouseUpEventListener);
+  window.removeEventListener('mousemove', mouseMoveEventListener);
+  window.removeEventListener('touchend', touchEndEventListener);
+  window.removeEventListener('touchmove', touchMoveEventListener);
   resizeObserver.unobserve(canvas);
   root.destroy();
 }

--- a/apps/typegpu-docs/src/content/examples/simulation/gravity/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/gravity/index.ts
@@ -365,7 +365,7 @@ canvas.addEventListener('wheel', (event: WheelEvent) => {
 
   cameraPosition = d.vec3f(newCamX, newCamY, newCamZ);
   updateCameraPosition();
-});
+}, { passive: false });
 
 canvas.addEventListener('mousedown', (event) => {
   isDragging = true;
@@ -379,7 +379,7 @@ canvas.addEventListener('touchstart', (event) => {
     prevX = event.touches[0].clientX;
     prevY = event.touches[0].clientY;
   }
-});
+}, { passive: true });
 
 const mouseUpEventListener = () => {
   isDragging = false;
@@ -423,7 +423,7 @@ function hideHelp() {
   }
 }
 for (const eventName of ['click', 'keydown', 'wheel', 'touchstart']) {
-  canvas.addEventListener(eventName, hideHelp, { once: true });
+  canvas.addEventListener(eventName, hideHelp, { once: true, passive: true });
 }
 
 export function onCleanup() {

--- a/apps/typegpu-docs/src/content/examples/simulation/stable-fluid/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/stable-fluid/index.ts
@@ -420,12 +420,15 @@ canvas.addEventListener('touchstart', (e) => {
   };
 }, { passive: false });
 
-window.addEventListener('mouseup', () => {
+const mouseUpEventListener = () => {
   brushState.isDown = false;
-});
-window.addEventListener('touchend', () => {
+};
+window.addEventListener('mouseup', mouseUpEventListener);
+
+const touchEndEventListener = () => {
   brushState.isDown = false;
-});
+};
+window.addEventListener('touchend', touchEndEventListener);
 
 canvas.addEventListener('mousemove', (e) => {
   const x = e.offsetX * devicePixelRatio;
@@ -452,7 +455,7 @@ function hideHelp() {
   }
 }
 for (const eventName of ['click', 'touchstart']) {
-  window.addEventListener(eventName, hideHelp, { once: true });
+  canvas.addEventListener(eventName, hideHelp, { once: true });
 }
 
 export const controls = {
@@ -505,8 +508,9 @@ export const controls = {
 };
 
 export function onCleanup() {
+  window.removeEventListener('mouseup', mouseUpEventListener);
+  window.removeEventListener('touchend', touchEndEventListener);
   root.destroy();
-  root.device.destroy();
 }
 
 // #endregion

--- a/apps/typegpu-docs/src/content/examples/simulation/stable-fluid/index.ts
+++ b/apps/typegpu-docs/src/content/examples/simulation/stable-fluid/index.ts
@@ -455,7 +455,7 @@ function hideHelp() {
   }
 }
 for (const eventName of ['click', 'touchstart']) {
-  canvas.addEventListener(eventName, hideHelp, { once: true });
+  canvas.addEventListener(eventName, hideHelp, { once: true, passive: true });
 }
 
 export const controls = {

--- a/apps/typegpu-docs/src/content/examples/tests/copy-error/index.ts
+++ b/apps/typegpu-docs/src/content/examples/tests/copy-error/index.ts
@@ -98,7 +98,6 @@ if (!table) {
   throw new Error('Nowhere to display the results');
 }
 
-console.log(input, result);
 table.innerText = (input.getUint32(12) === result.getUint32(12))
   ? 'The bug DOES NOT occur on this device.'
   : 'The bug DOES occur on this device.';


### PR DESCRIPTION
Changes:
- cleanup window listeners in all examples (before, some of these tried to write to buffers that were deleted),
- add passive annotations to event listenets,
- remove implicit casts from examples,
- remove logs from Mnist Inference and Struct Copy Test,
- display inference time in Mnist Inference.

To sum up, examples should not throw or log anything when clicking through them (except errors on invalid functions in function visualizer).