### PR TITLE
feat: Add support for ** operator

### DIFF
--- a/packages/tinyest-for-wgsl/src/parsers.ts
+++ b/packages/tinyest-for-wgsl/src/parsers.ts
@@ -81,7 +81,9 @@ const ASSIGNMENT_OP_MAP = {
   '|=': '|=',
   '^=': '^=',
   '&=': '&=',
-  '**=': '**=',
+  get '**='(): never {
+    throw new Error('The `**=` operator is unsupported in TGSL.');
+  },
   '||=': '||=',
   '&&=': '&&=',
   get '??='(): never {

--- a/packages/tinyest-for-wgsl/src/parsers.ts
+++ b/packages/tinyest-for-wgsl/src/parsers.ts
@@ -52,12 +52,7 @@ const BINARY_OP_MAP = {
   get instanceof(): never {
     throw new Error('The `instanceof` operator is unsupported in TGSL.');
   },
-  get '**'(): never {
-    // TODO: Translate 'a ** b' into 'pow(a, b)'.
-    throw new Error(
-      'The `**` operator is unsupported in TGSL. Use std.pow() instead.',
-    );
-  },
+  '**': '**',
   get '|>'(): never {
     throw new Error('The `|>` operator is unsupported in TGSL.');
   },

--- a/packages/tinyest/src/nodes.ts
+++ b/packages/tinyest/src/nodes.ts
@@ -131,7 +131,8 @@ export type BinaryOperator =
   | '%'
   | '|'
   | '^'
-  | '&';
+  | '&'
+  | '**';
 
 export type BinaryExpression = readonly [
   type: NodeTypeCatalog['binaryExpr'],

--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -818,12 +818,7 @@ function powCpu<T extends AnyFloatVecInstance | number>(
   if (typeof base === 'number' && typeof exponent === 'number') {
     return (base ** exponent) as T;
   }
-  if (
-    typeof base === 'object' &&
-    typeof exponent === 'object' &&
-    'kind' in base &&
-    'kind' in exponent
-  ) {
+  if (isVecInstance(base) && isVecInstance(exponent)) {
     return VectorOps.pow[base.kind](base, exponent) as T;
   }
   throw new Error('Invalid arguments to pow()');

--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -1,4 +1,5 @@
-import { snip } from '../data/snippet.ts';
+import { createDualImpl, dualImpl } from '../core/function/dualImpl.ts';
+import { stitch } from '../core/resolve/stitch.ts';
 import { smoothstepScalar } from '../data/numberOps.ts';
 import {
   abstractFloat,
@@ -8,25 +9,8 @@ import {
   i32,
   u32,
 } from '../data/numeric.ts';
-import { VectorOps } from '../data/vectorOps.ts';
-import type {
-  AnyFloat32VecInstance,
-  AnyFloatVecInstance,
-  AnyIntegerVecInstance,
-  AnyMatInstance,
-  AnyNumericVecInstance,
-  AnySignedVecInstance,
-  AnyWgslData,
-  v2i,
-  v3f,
-  v3h,
-  v3i,
-  v4i,
-} from '../data/wgslTypes.ts';
-import type { Infer } from '../shared/repr.ts';
-import { createDualImpl, dualImpl } from '../core/function/dualImpl.ts';
+import { snip } from '../data/snippet.ts';
 import { abstruct } from '../data/struct.ts';
-import { mul, sub } from './operators.ts';
 import {
   vec2f,
   vec2h,
@@ -38,7 +22,25 @@ import {
   vec4h,
   vec4i,
 } from '../data/vector.ts';
-import { stitch } from '../core/resolve/stitch.ts';
+import { VectorOps } from '../data/vectorOps.ts';
+import {
+  type AnyFloat32VecInstance,
+  type AnyFloatVecInstance,
+  type AnyIntegerVecInstance,
+  type AnyMatInstance,
+  type AnyNumericVecInstance,
+  type AnySignedVecInstance,
+  type AnyWgslData,
+  isNumericSchema,
+  type v2i,
+  type v3f,
+  type v3h,
+  type v3i,
+  type v4i,
+} from '../data/wgslTypes.ts';
+import type { Infer } from '../shared/repr.ts';
+import { unify } from '../tgsl/conversion.ts';
+import { mul, sub } from './operators.ts';
 
 type NumVec = AnyNumericVecInstance;
 
@@ -804,31 +806,41 @@ export const normalize = createDualImpl(
   'normalize',
 );
 
-type PowOverload = {
-  (base: number, exponent: number): number;
-  <T extends AnyFloatVecInstance>(base: T, exponent: T): T;
-};
+function powCpu(base: number, exponent: number): number;
+function powCpu<T extends AnyFloatVecInstance>(
+  base: T,
+  exponent: T,
+): T;
+function powCpu<T extends AnyFloatVecInstance | number>(
+  base: T,
+  exponent: T,
+): T {
+  if (typeof base === 'number' && typeof exponent === 'number') {
+    return (base ** exponent) as T;
+  }
+  if (
+    typeof base === 'object' &&
+    typeof exponent === 'object' &&
+    'kind' in base &&
+    'kind' in exponent
+  ) {
+    return VectorOps.pow[base.kind](base, exponent) as T;
+  }
+  throw new Error('Invalid arguments to pow()');
+}
 
-export const pow: PowOverload = createDualImpl(
-  // CPU implementation
-  <T extends AnyFloatVecInstance | number>(base: T, exponent: T): T => {
-    if (typeof base === 'number' && typeof exponent === 'number') {
-      return (base ** exponent) as T;
-    }
-    if (
-      typeof base === 'object' &&
-      typeof exponent === 'object' &&
-      'kind' in base &&
-      'kind' in exponent
-    ) {
-      return VectorOps.pow[base.kind](base, exponent) as T;
-    }
-    throw new Error('Invalid arguments to pow()');
+export const pow = dualImpl({
+  name: 'pow',
+  signature: (...args) => {
+    const uargs = unify(args, [f32, f16, abstractFloat]) ?? args;
+    return {
+      argTypes: uargs,
+      returnType: isNumericSchema(uargs[0]) ? uargs[1] : uargs[0],
+    };
   },
-  // GPU implementation
-  (base, exponent) => snip(stitch`pow(${base}, ${exponent})`, base.dataType),
-  'pow',
-);
+  normalImpl: powCpu,
+  codegenImpl: (lhs, rhs) => stitch`pow(${lhs}, ${rhs})`,
+});
 
 export const quantizeToF16 = createDualImpl(
   // CPU implementation

--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -32,6 +32,7 @@ import {
   type AnySignedVecInstance,
   type AnyWgslData,
   isNumericSchema,
+  isVecInstance,
   type v2i,
   type v3f,
   type v3h,

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -8,12 +8,13 @@ import {
   isLooseData,
   UnknownData,
 } from '../data/dataTypes.ts';
-import { abstractInt, bool, f16, f32, u32 } from '../data/numeric.ts';
+import { abstractInt, bool, u32 } from '../data/numeric.ts';
 import { isSnippet, snip, type Snippet } from '../data/snippet.ts';
 import * as wgsl from '../data/wgslTypes.ts';
 import { ResolutionError, WgslTypeError } from '../errors.ts';
 import { getName } from '../shared/meta.ts';
 import { $internal } from '../shared/symbols.ts';
+import { pow } from '../std/numeric.ts';
 import { add, div, mul, sub } from '../std/operators.ts';
 import { type FnArgsConversionHint, isMarkedInternal } from '../types.ts';
 import {
@@ -192,11 +193,7 @@ const opCodeToCodegen = {
   '-': sub[$internal].gpuImpl,
   '*': mul[$internal].gpuImpl,
   '/': div[$internal].gpuImpl,
-  '**': (lhsExpr: Snippet, rhsExpr: Snippet) => {
-    const [convLhs, convRhs] =
-      convertToCommonType([lhsExpr, rhsExpr], [f32, f16]) ?? [lhsExpr, rhsExpr];
-    return snip(stitch`pow(${convLhs}, ${convRhs})`, convLhs.dataType);
-  },
+  '**': pow[$internal].gpuImpl,
 } satisfies Partial<
   Record<tinyest.BinaryOperator, (...args: never[]) => unknown>
 >;

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -1,8 +1,8 @@
 import * as tinyest from 'tinyest';
 import { beforeEach, describe, expect } from 'vitest';
-import { snip } from '../../src/data/snippet.ts';
 import * as d from '../../src/data/index.ts';
 import { abstractFloat, abstractInt } from '../../src/data/numeric.ts';
+import { snip } from '../../src/data/snippet.ts';
 import { Void, type WgslArray } from '../../src/data/wgslTypes.ts';
 import { provideCtx } from '../../src/execMode.ts';
 import tgpu from '../../src/index.ts';
@@ -931,5 +931,34 @@ describe('wgslGenerator', () => {
         *val += 1;
       }`),
     );
+  });
+
+  it('generates correct code for pow expression', () => {
+    const four = 4;
+    const power = tgpu.fn([])(() => {
+      const n = 2 ** four;
+    });
+
+    expect(asWgsl(power)).toMatchInlineSnapshot(`
+      "fn power() {
+        var n = pow(2, 4);
+      }"
+    `);
+  });
+
+  it('casts in pow expression when necessary', () => {
+    const power = tgpu.fn([])(() => {
+      const a = d.u32(3);
+      const b = d.i32(5);
+      const m = a ** b;
+    });
+
+    expect(asWgsl(power)).toMatchInlineSnapshot(`
+      "fn power() {
+        var a = 3u;
+        var b = 5i;
+        var m = pow(f32(a), f32(b));
+      }"
+    `);
   });
 });

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -934,6 +934,22 @@ describe('wgslGenerator', () => {
   });
 
   it('generates correct code for pow expression', () => {
+    const power = tgpu.fn([])(() => {
+      const a = d.f32(10);
+      const b = d.f32(3);
+      const n = a ** b;
+    });
+
+    expect(asWgsl(power)).toMatchInlineSnapshot(`
+      "fn power() {
+        var a = 10f;
+        var b = 3f;
+        var n = pow(a, b);
+      }"
+    `);
+  });
+
+  it('calculates pow at comptime when possible', () => {
     const four = 4;
     const power = tgpu.fn([])(() => {
       const n = 2 ** four;
@@ -941,7 +957,7 @@ describe('wgslGenerator', () => {
 
     expect(asWgsl(power)).toMatchInlineSnapshot(`
       "fn power() {
-        var n = pow(2, 4);
+        var n = 16.;
       }"
     `);
   });


### PR DESCRIPTION
JS `**` operator accepts numbers (of course), and WGSL `pow` only accepts floats.

Changes: 
- remove exception throw on `**` use,
- parse `**` to pow, with forced cast to f32/f16,
- add exception throw on `**=` use.


Let me know what you think about the `**=` operator. I think the following transpilation may be a little too drastic, and I don't think the operator is all that useful.
```ts
// TGSL
let a = d.u32(2);
a **= 4;
```
```wgsl
// WGSL
let a = 2u;
a = u32(pow(f32(a), 4f));
```
