### PR TITLE
fix: Change visibility

### DIFF
--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -87,7 +87,7 @@ export type TgpuLayoutEntryBase = {
    * By default, each resource is visible to all shader stage types, but
    * depending on the underlying implementation, this may have performance implications.
    *
-   * @default ['compute'] for mutable resources
+   * @default ['compute', 'fragment] for mutable resources
    * @default ['compute','vertex','fragment'] for everything else
    */
   visibility?: TgpuShaderStage[];
@@ -416,7 +416,7 @@ export class MissingBindingError extends Error {
 // Implementation
 // --------------
 
-const DEFAULT_MUTABLE_VISIBILITY: TgpuShaderStage[] = ['compute'];
+const DEFAULT_MUTABLE_VISIBILITY: TgpuShaderStage[] = ['compute', 'fragment'];
 const DEFAULT_READONLY_VISIBILITY: TgpuShaderStage[] = [
   'compute',
   'vertex',

--- a/packages/typegpu/tests/bindGroupLayout.test.ts
+++ b/packages/typegpu/tests/bindGroupLayout.test.ts
@@ -27,6 +27,8 @@ import './utils/webgpuGlobals.ts';
 
 const DEFAULT_READONLY_VISIBILITY_FLAGS = GPUShaderStage.COMPUTE |
   GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT;
+const DEFAULT_MUTABLE_VISIBILITY_FLAGS = GPUShaderStage.COMPUTE |
+  GPUShaderStage.FRAGMENT;
 
 describe('TgpuBindGroupLayout', () => {
   it('names bound elements', () => {
@@ -158,7 +160,7 @@ describe('TgpuBindGroupLayout', () => {
       entries: [
         {
           binding: 0,
-          visibility: GPUShaderStage.COMPUTE,
+          visibility: DEFAULT_MUTABLE_VISIBILITY_FLAGS,
           buffer: {
             type: 'storage',
           },


### PR DESCRIPTION
Changes:
- Mutable resources have now visibility [`compute`,  `fragment`]

Closes #1654.