### PR TITLE
feat: Out with flushing, in with batching

### DIFF
--- a/packages/typegpu/src/core/pipeline/renderPipeline.ts
+++ b/packages/typegpu/src/core/pipeline/renderPipeline.ts
@@ -508,7 +508,9 @@ class TgpuRenderPipelineImpl implements TgpuRenderPipeline {
       }
     }
 
-    const pass = branch.commandEncoder.beginRenderPass(renderPassDescriptor);
+    const pass = branch[$internal].commandEncoder.beginRenderPass(
+      renderPassDescriptor,
+    );
 
     pass.setPipeline(memo.pipeline);
 
@@ -569,7 +571,7 @@ class TgpuRenderPipelineImpl implements TgpuRenderPipeline {
         root: branch,
         priors: internals.priors,
       })
-      : branch.flush();
+      : branch[$internal].flush();
   }
 
   drawIndexed(
@@ -617,7 +619,7 @@ class TgpuRenderPipelineImpl implements TgpuRenderPipeline {
         root: branch,
         priors: internals.priors,
       })
-      : branch.flush();
+      : branch[$internal].flush();
   }
 }
 

--- a/packages/typegpu/src/core/pipeline/timeable.ts
+++ b/packages/typegpu/src/core/pipeline/timeable.ts
@@ -151,7 +151,7 @@ export function triggerPerformanceCallback({
     );
   }
 
-  root.commandEncoder.resolveQuerySet(
+  root[$internal].commandEncoder.resolveQuerySet(
     root.unwrap(querySet),
     0,
     querySet.count,
@@ -159,7 +159,7 @@ export function triggerPerformanceCallback({
     0,
   );
 
-  root.flush();
+  root[$internal].flush();
   root.device.queue.onSubmittedWorkDone().then(async () => {
     if (!querySet.available) {
       return;

--- a/packages/typegpu/src/core/querySet/querySet.ts
+++ b/packages/typegpu/src/core/querySet/querySet.ts
@@ -134,7 +134,7 @@ class TgpuQuerySetImpl<T extends GPUQueryType> implements TgpuQuerySet<T> {
   }
 
   async read(): Promise<bigint[]> {
-    this._group.flush();
+    this._group[$internal].flush();
     if (!this._resolveBuffer) {
       throw new Error('QuerySet must be resolved before reading.');
     }

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -25,6 +25,7 @@ import type {
   OmitProps,
   Prettify,
 } from '../../shared/utilityTypes.ts';
+import { $internal } from '../../shared/symbols.ts';
 import type {
   ExtractBindGroupInputFromLayout,
   TgpuBindGroup,
@@ -616,7 +617,23 @@ export interface TgpuRoot extends Unwrapper {
    */
   destroy(): void;
 
+  readonly [$internal]: TgpuRootInternals;
   '~unstable': Omit<ExperimentalTgpuRoot, keyof TgpuRoot>;
+}
+export interface TgpuRootInternals {
+  /**
+   * The current command encoder. This property will
+   * hold the same value throughout the entire `batch()` invocation.
+   * In case of single `draw()` or `dispatchWorkgroups()` call, getter will be used
+   * to create a single-use command encoder.
+   */
+  readonly commandEncoder: GPUCommandEncoder;
+  /**
+   * Causes all commands enqueued by pipelines to be
+   * submitted to the GPU.
+   * If a single `draw()` or `dispatchWorkgroups()` is called, `flush()` is executed after each command.
+   */
+  flush(): void;
 }
 
 export interface ExperimentalTgpuRoot extends TgpuRoot, WithBinding {
@@ -624,11 +641,6 @@ export interface ExperimentalTgpuRoot extends TgpuRoot, WithBinding {
   readonly shaderGenerator?:
     | ShaderGenerator
     | undefined;
-  /**
-   * The current command encoder. This property will
-   * hold the same value until `flush()` is called.
-   */
-  readonly commandEncoder: GPUCommandEncoder;
 
   createTexture<
     TWidth extends number,
@@ -667,10 +679,4 @@ export interface ExperimentalTgpuRoot extends TgpuRoot, WithBinding {
     descriptor: GPURenderPassDescriptor,
     callback: (pass: RenderPass) => void,
   ): void;
-
-  /**
-   * Causes all commands enqueued by pipelines to be
-   * submitted to the GPU.
-   */
-  flush(): void;
 }


### PR DESCRIPTION
Changes:
- tba

TODO:
- [ ] move `flush()` and `commandEncoder()` to `root` internals
- [ ] add tests in `root.test.ts`
- [ ] refactor render pipelines
- [ ] add tests in `renderPipeline.test.ts`
- [ ] refactor compute pipelines 
- [ ] add/change tests in `computePipeline.test.ts`
- [ ] add `batch()` to `root['~unstable']`
- [ ] add tests for `batch()`
- [ ] refactor examples