### PR TITLE
feat(@typegpu/react): Custom vertex shader for `useRender` hook

### DIFF
--- a/apps/typegpu-docs/src/examples/react/triangle/index.tsx
+++ b/apps/typegpu-docs/src/examples/react/triangle/index.tsx
@@ -1,22 +1,26 @@
-import * as d from 'typegpu/data';
-import { useFrame, useRender, useUniformValue } from '@typegpu/react';
-import { hsvToRgb } from '@typegpu/color';
+import { d } from 'typegpu';
+import { useRender } from '@typegpu/react';
 
 function App() {
-  const time = useUniformValue(d.f32, 0);
-
-  useFrame(() => {
-    time.value = performance.now() / 1000;
-  });
-
   const { ref } = useRender({
-    fragment: () => {
+    vertex: ({ vertexIndex }) => {
       'use gpu';
-      const t = time.$;
-      const rgb = hsvToRgb(d.vec3f(t * 0.5, 1, 1));
-      return d.vec4f(rgb, 1);
+      const pos = [d.vec2f(-1, -1), d.vec2f(3, -1), d.vec2f(-1, 3)];
+      const uv = [d.vec2f(0, 1), d.vec2f(2, 1), d.vec2f(0, -1)];
+
+      return {
+        pos: d.vec4f(pos[vertexIndex], 0, 1),
+        uv: uv[vertexIndex],
+      };
+    },
+    fragment: ({ uv }) => {
+      'use gpu';
+      return d.vec4f(uv.x, uv.y, 1, 1);
     },
   });
+
+  // TODO: Provide a time variable to the shader with useUniformValue
+  // TODO: Make the gradient shift colors over time using hsvToRgb from @typegpu/color
 
   return (
     <main>

--- a/packages/typegpu-react/src/use-render.ts
+++ b/packages/typegpu-react/src/use-render.ts
@@ -4,35 +4,42 @@ import { useRoot } from './root-context.tsx';
 import { useMemo, useRef } from 'react';
 import { useFrame } from './use-frame.ts';
 
-type InferRecord<T> = {
-  [K in keyof T]: d.Infer<T[K]>;
+type InferGPURecord<T> = {
+  [K in keyof T]: d.InferGPU<T[K]>;
 };
 
-export interface UseRenderOptions {
-  vertex?: () => void;
+const DefaultVertexInput = {
+  vertexIndex: d.builtin.vertexIndex,
+};
 
-  /**
-   * A TypeGPU function that runs per-pixel on the GPU.
-   */
-  fragment: (input: InferRecord<typeof DefaultVarying>) => d.v4f;
-}
+const DefaultVertexOutput = {
+  pos: d.builtin.position,
+  uv: d.vec2f,
+};
 
 const DefaultVarying = {
   uv: d.vec2f,
 };
 
-const fullScreenTriangle = tgpu['~unstable'].vertexFn({
-  in: { vertexIndex: d.builtin.vertexIndex },
-  out: { pos: d.builtin.position, ...DefaultVarying },
-})((input) => {
-  const pos = [d.vec2f(-1, -1), d.vec2f(3, -1), d.vec2f(-1, 3)];
-  const uv = [d.vec2f(0, 1), d.vec2f(2, 1), d.vec2f(0, -1)];
+const DefaultFragmentInput = {
+  uv: d.vec2f,
+};
 
-  return {
-    pos: d.vec4f(pos[input.vertexIndex] as d.v2f, 0, 1),
-    uv: uv[input.vertexIndex] as d.v2f,
-  };
-});
+type VertexFnInput = InferGPURecord<typeof DefaultVertexInput>;
+type VertexFnOutput = InferGPURecord<typeof DefaultVertexOutput>;
+type FragmentFnOutput = d.v4f;
+
+export interface UseRenderOptions {
+  /**
+   * A kernel function that runs per-vertex on the GPU.
+   */
+  vertex: (input: VertexFnInput) => VertexFnOutput;
+
+  /**
+   * A TypeGPU function that runs per-pixel on the GPU.
+   */
+  fragment: (input: InferGPURecord<typeof DefaultVarying>) => FragmentFnOutput;
+}
 
 const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
@@ -41,26 +48,36 @@ export function useRender(options: UseRenderOptions) {
   const ctxRef = useRef<GPUCanvasContext>(null);
   const root = useRoot();
 
-  // Only considering the first passed-in fragment function.
+  // Only considering the first passed-in shaders function.
   // This assumes that users won't swap shaders in the same useRender call,
   // but we can make this more robust by computing a hash with unplugin-typegpu.
   // TODO: You can also use the React Nook trick to track functions based on their
   //       place in the code. Simpler and more reliable? ((x)=>x)``
+  const vertexRef = useRef(options.vertex);
   const fragmentRef = useRef(options.fragment);
 
+  const vertexFn = useMemo(() => {
+    return tgpu.vertexFn({
+      in: { ...DefaultVertexInput },
+      out: { ...DefaultVertexOutput },
+    })(vertexRef.current);
+  }, []);
+
   const fragmentFn = useMemo(() => {
-    return tgpu['~unstable'].fragmentFn({
-      in: { ...DefaultVarying },
+    return tgpu.fragmentFn({
+      in: { ...DefaultFragmentInput },
       out: d.vec4f,
     })(fragmentRef.current);
   }, []);
 
   const pipeline = useMemo(() => {
-    return root['~unstable']
-      .withVertex(fullScreenTriangle, {})
-      .withFragment(fragmentFn, { format: presentationFormat })
-      .createPipeline();
-  }, [root, fragmentFn]);
+    return root.createRenderPipeline({
+      vertex: vertexFn,
+      // TODO: Fix this
+      // eslint-disable-next-line: typescript-eslint(no-explicit-any)
+      fragment: fragmentFn as any,
+    });
+  }, [root, vertexFn, fragmentFn]);
 
   useFrame(() => {
     const canvas = ref.current;

--- a/packages/typegpu-react/src/use-uniform-value.ts
+++ b/packages/typegpu-react/src/use-uniform-value.ts
@@ -21,7 +21,7 @@ function initialValueFromSchema<T extends d.AnyWgslData>(
 
 export function useUniformValue<TSchema extends d.AnyWgslData, TValue extends d.Infer<TSchema>>(
   schema: ValidateUniformSchema<TSchema>,
-  initialValue?: TValue | undefined,
+  initialValue?: TValue,
 ): UniformValue<TSchema, TValue> {
   const root = useRoot();
 


### PR DESCRIPTION
## Changes

* The `useRender` hook options interface now requires a `vertex` function, which takes a typed input and returns a typed output.
* The React triangle example is updated to explicitly provide a `vertex` function.