### PR TITLE
feat: Add a function to deep-compare schemas

### DIFF
--- a/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/index.html
+++ b/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/index.html
@@ -1,1 +1,1 @@
-<div class='result'>Wait for the tests to finish running...</div>;
+<div class="result">Wait for the tests to finish running...</div>;

--- a/packages/typegpu/src/data/deepEqual.ts
+++ b/packages/typegpu/src/data/deepEqual.ts
@@ -1,0 +1,99 @@
+import type { AnyAttribute } from './attributes.ts';
+import { isLooseData, isUnstruct } from './dataTypes.ts';
+import type { AnyData } from './dataTypes.ts';
+import { isDecorated, isWgslArray, isWgslStruct } from './wgslTypes.ts';
+
+/**
+ * Performs a deep comparison of two TypeGPU data schemas.
+ *
+ * @param a The first data schema to compare.
+ * @param b The second data schema to compare.
+ * @returns `true` if the schemas are deeply equal, `false` otherwise.
+ *
+ * @example
+ * ```ts
+ * import { vec3f, struct, deepEqual } from 'typegpu/data';
+ *
+ * const schema1 = struct({ a: vec3f });
+ * const schema2 = struct({ a: vec3f });
+ * const schema3 = struct({ b: vec3f });
+ *
+ * console.log(deepEqual(schema1, schema2)); // true
+ * console.log(deepEqual(schema1, schema3)); // false
+ * ```
+ */
+export function deepEqual(a: AnyData, b: AnyData): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (a.type !== b.type) {
+    return false;
+  }
+
+  if (isWgslStruct(a) && isWgslStruct(b)) {
+    const aProps = a.propTypes;
+    const bProps = b.propTypes;
+    const aKeys = Object.keys(aProps);
+    const bKeys = Object.keys(bProps);
+
+    if (aKeys.length !== bKeys.length) {
+      return false;
+    }
+
+    aKeys.sort();
+    bKeys.sort();
+
+    if (aKeys.join() !== bKeys.join()) {
+      return false;
+    }
+
+    for (const key of aKeys) {
+      if (!deepEqual(aProps[key], bProps[key])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (isWgslArray(a) && isWgslArray(b)) {
+    return (
+      a.elementCount === b.elementCount &&
+      deepEqual(a.elementType as AnyData, b.elementType as AnyData)
+    );
+  }
+
+  if (isDecorated(a) && isDecorated(b)) {
+    if (!deepEqual(a.inner as AnyData, b.inner as AnyData)) {
+      return false;
+    }
+    if (a.attribs.length !== b.attribs.length) {
+      return false;
+    }
+    // TODO: A more robust comparison might be needed if attribute order is not guaranteed.
+    // For now, assuming attributes are ordered.
+    for (let i = 0; i < a.attribs.length; i++) {
+      const attrA = a.attribs[i] as AnyAttribute;
+      const attrB = b.attribs[i] as AnyAttribute;
+      if (attrA.type !== attrB.type) return false;
+      if (attrA.params?.length !== attrB.params?.length) return false;
+      if (attrA.params) {
+        for (let j = 0; j < attrA.params.length; j++) {
+          if (attrA.params[j] !== attrB.params[j]) return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  if (isUnstruct(a) && isUnstruct(b)) {
+    return deepEqual(a, b);
+  }
+
+  if (isLooseData(a) && isLooseData(b)) {
+    // TODO: This is a simplified check. A a more detailed comparison might be necessary.
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  return true;
+}

--- a/packages/typegpu/src/data/deepEqual.ts
+++ b/packages/typegpu/src/data/deepEqual.ts
@@ -1,5 +1,5 @@
 import type { AnyAttribute } from './attributes.ts';
-import { isLooseData, isUnstruct } from './dataTypes.ts';
+import { isDisarray, isLooseData, isUnstruct } from './dataTypes.ts';
 import type { AnyData } from './dataTypes.ts';
 import { isDecorated, isWgslArray, isWgslStruct } from './wgslTypes.ts';
 
@@ -87,7 +87,33 @@ export function deepEqual(a: AnyData, b: AnyData): boolean {
   }
 
   if (isUnstruct(a) && isUnstruct(b)) {
-    return deepEqual(a, b);
+    const aProps = a.propTypes;
+    const bProps = b.propTypes;
+    const aKeys = Object.keys(aProps);
+    const bKeys = Object.keys(bProps);
+
+    if (aKeys.length !== bKeys.length) {
+      return false;
+    }
+
+    // For unstructs, order of properties matters.
+    if (aKeys.join() !== bKeys.join()) {
+      return false;
+    }
+
+    for (const key of aKeys) {
+      if (!deepEqual(aProps[key], bProps[key])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (isDisarray(a) && isDisarray(b)) {
+    return (
+      a.elementCount === b.elementCount &&
+      deepEqual(a.elementType as AnyData, b.elementType as AnyData)
+    );
   }
 
   if (isLooseData(a) && isLooseData(b)) {

--- a/packages/typegpu/src/data/index.ts
+++ b/packages/typegpu/src/data/index.ts
@@ -166,6 +166,7 @@ export {
 export { PUBLIC_sizeOf as sizeOf } from './sizeOf.ts';
 export { PUBLIC_alignmentOf as alignmentOf } from './alignmentOf.ts';
 export { builtin } from '../builtin.ts';
+export { deepEqual } from './deepEqual.ts';
 export type {
   AnyBuiltin,
   BuiltinClipDistances,

--- a/packages/typegpu/tests/data/deepEqual.test.ts
+++ b/packages/typegpu/tests/data/deepEqual.test.ts
@@ -1,21 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
+  align,
+  arrayOf,
   deepEqual,
+  disarrayOf,
+  f16,
   f32,
-  u32,
   i32,
-  vec2f,
-  vec3f,
-  vec2u,
+  location,
   mat2x2f,
   mat3x3f,
   struct,
+  u32,
   unstruct,
-  arrayOf,
-  disarrayOf,
-  align,
-  location,
-  f16,
+  vec2f,
+  vec2u,
+  vec3f,
 } from '../../src/data/index.ts';
 
 describe('deepEqual', () => {

--- a/packages/typegpu/tests/data/deepEqual.test.ts
+++ b/packages/typegpu/tests/data/deepEqual.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deepEqual,
+  f32,
+  u32,
+  i32,
+  vec2f,
+  vec3f,
+  vec2u,
+  mat2x2f,
+  mat3x3f,
+  struct,
+  unstruct,
+  arrayOf,
+  disarrayOf,
+  align,
+  location,
+  f16,
+} from '../../src/data/index.ts';
+
+describe('deepEqual', () => {
+  it('compares simple types', () => {
+    expect(deepEqual(f32, f32)).toBe(true);
+    expect(deepEqual(u32, u32)).toBe(true);
+    expect(deepEqual(f32, u32)).toBe(false);
+    expect(deepEqual(f32, f16)).toBe(false);
+  });
+
+  it('compares vector types', () => {
+    expect(deepEqual(vec2f, vec2f)).toBe(true);
+    expect(deepEqual(vec3f, vec3f)).toBe(true);
+    expect(deepEqual(vec2f, vec3f)).toBe(false);
+    expect(deepEqual(vec2f, vec2u)).toBe(false);
+  });
+
+  it('compares matrix types', () => {
+    expect(deepEqual(mat2x2f, mat2x2f)).toBe(true);
+    expect(deepEqual(mat3x3f, mat3x3f)).toBe(true);
+    expect(deepEqual(mat2x2f, mat3x3f)).toBe(false);
+  });
+
+  it('compares struct types', () => {
+    const struct1 = struct({ a: f32, b: vec2u });
+    const struct2 = struct({ a: f32, b: vec2u });
+    const struct3 = struct({ b: vec2u, a: f32 }); // different order
+    const struct4 = struct({ a: u32, b: vec2u }); // different prop type
+    const struct5 = struct({ a: f32, c: vec2u }); // different prop name
+    const struct6 = struct({ a: f32 }); // different number of props
+
+    expect(deepEqual(struct1, struct2)).toBe(true);
+    expect(deepEqual(struct1, struct3)).toBe(true); // property order shouldn't matter
+    expect(deepEqual(struct1, struct4)).toBe(false);
+    expect(deepEqual(struct1, struct5)).toBe(false);
+    expect(deepEqual(struct1, struct6)).toBe(false);
+  });
+
+  it('compares nested struct types', () => {
+    const nested1 = struct({ c: i32 });
+    const nested2 = struct({ c: i32 });
+    const nested3 = struct({ c: u32 });
+
+    const struct1 = struct({ a: f32, b: nested1 });
+    const struct2 = struct({ a: f32, b: nested2 });
+    const struct3 = struct({ a: f32, b: nested3 });
+
+    expect(deepEqual(struct1, struct2)).toBe(true);
+    expect(deepEqual(struct1, struct3)).toBe(false);
+  });
+
+  it('compares array types', () => {
+    const array1 = arrayOf(f32, 4);
+    const array2 = arrayOf(f32, 4);
+    const array3 = arrayOf(u32, 4);
+    const array4 = arrayOf(f32, 5);
+
+    expect(deepEqual(array1, array2)).toBe(true);
+    expect(deepEqual(array1, array3)).toBe(false);
+    expect(deepEqual(array1, array4)).toBe(false);
+  });
+
+  it('compares arrays of structs', () => {
+    const struct1 = struct({ a: f32 });
+    const struct2 = struct({ a: f32 });
+    const struct3 = struct({ a: u32 });
+
+    const array1 = arrayOf(struct1, 2);
+    const array2 = arrayOf(struct2, 2);
+    const array3 = arrayOf(struct3, 2);
+
+    expect(deepEqual(array1, array2)).toBe(true);
+    expect(deepEqual(array1, array3)).toBe(false);
+  });
+
+  it('compares decorated types', () => {
+    const decorated1 = align(16, f32);
+    const decorated2 = align(16, f32);
+    const decorated3 = align(8, f32);
+    const decorated4 = align(16, u32);
+    const decorated5 = location(0, f32);
+
+    expect(deepEqual(decorated1, decorated2)).toBe(true);
+    expect(deepEqual(decorated1, decorated3)).toBe(false);
+    expect(deepEqual(decorated1, decorated4)).toBe(false);
+    expect(deepEqual(decorated1, decorated5)).toBe(false);
+  });
+
+  it('compares loose data types', () => {
+    const unstruct1 = unstruct({ a: f32 });
+    const unstruct2 = unstruct({ a: f32 });
+    const unstruct3 = unstruct({ b: f32 });
+
+    const disarray1 = disarrayOf(u32, 4);
+    const disarray2 = disarrayOf(u32, 4);
+    const disarray3 = disarrayOf(u32, 5);
+
+    expect(deepEqual(unstruct1, unstruct2)).toBe(true);
+    expect(deepEqual(unstruct1, unstruct3)).toBe(false);
+    expect(deepEqual(disarray1, disarray2)).toBe(true);
+    expect(deepEqual(disarray1, disarray3)).toBe(false);
+  });
+
+  it('compares different kinds of types', () => {
+    expect(deepEqual(f32, vec2f)).toBe(false);
+    expect(deepEqual(struct({ a: f32 }), unstruct({ a: f32 }))).toBe(false);
+    expect(deepEqual(arrayOf(f32, 4), disarrayOf(f32, 4))).toBe(false);
+    expect(deepEqual(struct({ a: f32 }), f32)).toBe(false);
+  });
+});

--- a/packages/typegpu/tests/data/deepEqual.test.ts
+++ b/packages/typegpu/tests/data/deepEqual.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   align,
   arrayOf,
+  atomic,
   deepEqual,
   disarrayOf,
   f16,
@@ -17,6 +18,7 @@ import {
   vec2u,
   vec3f,
 } from '../../src/data/index.ts';
+import { ptrPrivate, ptrStorage, ptrWorkgroup } from '../../src/data/ptr.ts';
 
 describe('deepEqual', () => {
   it('compares simple types', () => {
@@ -97,6 +99,45 @@ describe('deepEqual', () => {
     const decorated3 = align(8, f32);
     const decorated4 = align(16, u32);
     const decorated5 = location(0, f32);
+
+    expect(deepEqual(decorated1, decorated2)).toBe(true);
+    expect(deepEqual(decorated1, decorated3)).toBe(false);
+    expect(deepEqual(decorated1, decorated4)).toBe(false);
+    expect(deepEqual(decorated1, decorated5)).toBe(false);
+  });
+
+  it('compares pointer types', () => {
+    const ptr1 = ptrPrivate(f32);
+    const ptr2 = ptrPrivate(f32);
+    const ptr3 = ptrWorkgroup(f32);
+    const ptr4 = ptrPrivate(u32);
+    const ptr5 = ptrStorage(f32, 'read');
+    const ptr6 = ptrStorage(f32, 'read-write');
+
+    expect(deepEqual(ptr1, ptr2)).toBe(true);
+    expect(deepEqual(ptr1, ptr3)).toBe(false);
+    expect(deepEqual(ptr1, ptr4)).toBe(false);
+    expect(deepEqual(ptr5, ptr6)).toBe(false);
+    expect(deepEqual(ptrStorage(f32, 'read'), ptrStorage(f32, 'read'))).toBe(
+      true,
+    );
+  });
+
+  it('compares atomic types', () => {
+    const atomic1 = atomic(u32);
+    const atomic2 = atomic(u32);
+    const atomic3 = atomic(i32);
+
+    expect(deepEqual(atomic1, atomic2)).toBe(true);
+    expect(deepEqual(atomic1, atomic3)).toBe(false);
+  });
+
+  it('compares loose decorated types', () => {
+    const decorated1 = align(16, unstruct({ a: f32 }));
+    const decorated2 = align(16, unstruct({ a: f32 }));
+    const decorated3 = align(8, unstruct({ a: f32 }));
+    const decorated4 = align(16, unstruct({ a: u32 }));
+    const decorated5 = location(0, unstruct({ a: f32 }));
 
     expect(deepEqual(decorated1, decorated2)).toBe(true);
     expect(deepEqual(decorated1, decorated3)).toBe(false);


### PR DESCRIPTION
This PR introduces a new deep comparison utility for TypeGPU data schemas and adds tests to ensure correct behavior. 

---

Closes #1550