### PR TITLE
chore: Simplify tests using inline snapshots

### DIFF
--- a/packages/typegpu/package.json
+++ b/packages/typegpu/package.json
@@ -75,7 +75,6 @@
     "tsup": "catalog:build",
     "typescript": "catalog:types",
     "unplugin-typegpu": "workspace:*",
-    "wesl": "0.6.7",
     "wgpu-matrix": "catalog:example"
   },
   "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",

--- a/packages/typegpu/tests/accessor.test.ts
+++ b/packages/typegpu/tests/accessor.test.ts
@@ -2,7 +2,7 @@ import { describe, expect } from 'vitest';
 import * as d from '../src/data/index.ts';
 import tgpu from '../src/index.ts';
 import { it } from './utils/extendedIt.ts';
-import { asWgsl, parse, parseResolved } from './utils/parseResolved.ts';
+import { asWgsl } from './utils/parseResolved.ts';
 
 const RED = d.vec3f(1, 0, 0);
 const RED_RESOLVED = 'vec3f(1, 0, 0)';
@@ -17,17 +17,11 @@ describe('tgpu.accessor', () => {
       .$uses({ colorAccess })
       .with(colorAccess, red);
 
-    expect(parseResolved({ getColor })).toBe(
-      parse(/* wgsl */ `
-        fn red() -> vec3f {
-          return ${RED_RESOLVED};
-        }
+    expect(asWgsl(getColor)).toMatchInlineSnapshot(`
+      "fn red() -> vec3f{ return vec3f(1, 0, 0); }
 
-        fn getColor() -> vec3f {
-          return red();
-        }
-    `),
-    );
+      fn getColor() -> vec3f{ return red(); }"
+    `);
   });
 
   it('resolves to provided buffer usage', ({ root }) => {
@@ -42,34 +36,27 @@ describe('tgpu.accessor', () => {
       .$uses({ colorAccess })
       .with(colorAccess, redUniform);
 
-    expect(parseResolved({ getColor })).toBe(
-      parse(/* wgsl */ `
-        @group(0) @binding(0) var<uniform> redUniform: vec3f;
+    expect(asWgsl(getColor)).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<uniform> redUniform: vec3f;
 
-        fn getColor() -> vec3f {
-          return redUniform;
-        }
-    `),
-    );
+      fn getColor() -> vec3f{ return redUniform; }"
+    `);
   });
 
   it('resolves to resolved form of provided JS value', () => {
     const colorAccess = tgpu['~unstable'].accessor(d.vec3f);
     const multiplierAccess = tgpu['~unstable'].accessor(d.f32);
 
-    const getColor = tgpu.fn([], d.vec3f)`() {
-        return colorAccess * multiplierAccess;
-      }`
+    const getColor = tgpu.fn(
+      [],
+      d.vec3f,
+    )`() { return colorAccess * multiplierAccess; }`
       .$uses({ colorAccess, multiplierAccess })
       .with(colorAccess, RED)
       .with(multiplierAccess, 2);
 
-    expect(parseResolved({ getColor })).toBe(
-      parse(/* wgsl */ `
-        fn getColor() -> vec3f {
-          return ${RED_RESOLVED} * 2;
-        }
-    `),
+    expect(asWgsl(getColor)).toMatchInlineSnapshot(
+      `"fn getColor() -> vec3f{ return vec3f(1, 0, 0) * 2; }"`,
     );
   });
 
@@ -79,12 +66,8 @@ describe('tgpu.accessor', () => {
     const getColor = tgpu.fn([], d.vec3f)`() { return colorAccess; }`
       .$uses({ colorAccess });
 
-    expect(parseResolved({ getColor })).toBe(
-      parse(/* wgsl */ `
-      fn getColor() -> vec3f {
-        return ${RED_RESOLVED};
-      }
-    `),
+    expect(asWgsl(getColor)).toMatchInlineSnapshot(
+      `"fn getColor() -> vec3f{ return vec3f(1, 0, 0); }"`,
     );
   });
 
@@ -97,22 +80,14 @@ describe('tgpu.accessor', () => {
     // overriding to green
     const getColorWithGreen = getColor.with(colorAccess, d.vec3f(0, 1, 0));
 
-    const main = tgpu.fn([])`() {
-      return getColorWithGreen();
-    }
-    `.$uses({ getColorWithGreen });
+    const main = tgpu.fn([])`() { return getColorWithGreen(); }`
+      .$uses({ getColorWithGreen });
 
-    expect(parseResolved({ main })).toBe(
-      parse(/* wgsl */ `
-        fn getColor() -> vec3f {
-          return vec3f(0, 1, 0);
-        }
+    expect(asWgsl(main)).toMatchInlineSnapshot(`
+      "fn getColor() -> vec3f{ return vec3f(0, 1, 0); }
 
-        fn main() {
-          return getColor();
-        }
-    `),
-    );
+      fn main() { return getColor(); }"
+    `);
   });
 
   it('throws error when no default nor value provided', () => {
@@ -121,7 +96,7 @@ describe('tgpu.accessor', () => {
     const getColor = tgpu.fn([], d.vec3f)`() { return colorAccess; }`
       .$uses({ colorAccess });
 
-    expect(() => tgpu.resolve({ externals: { getColor }, names: 'strict' }))
+    expect(() => asWgsl(getColor))
       .toThrowErrorMatchingInlineSnapshot(`
         [Error: Resolution of the following tree failed:
         - <root>
@@ -152,33 +127,25 @@ describe('tgpu.accessor', () => {
       const color3X = colorAccessorFn.value.x;
     });
 
-    const resolved = tgpu.resolve({
-      externals: { main },
-      names: 'strict',
-    });
+    expect(asWgsl(main)).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<uniform> redUniform: vec3f;
 
-    expect(parse(resolved)).toBe(
-      parse(/* wgsl */ `
-        @group(0) @binding(0) var<uniform> redUniform: vec3f;
+      fn getColor() -> vec3f {
+        return vec3f(1, 0, 0);
+      }
 
-        fn getColor() -> vec3f {
-          return vec3f(1, 0, 0);
-        }
-
-        fn main() {
-          var color = vec3f(1, 0, 0);
-          var color2 = redUniform;
-          var color3 = getColor();
-
-          var colorX = 1;
-          var color2X = redUniform.x;
-          var color3X = getColor().x;
-        }
-    `),
-    );
+      fn main() {
+        var color = vec3f(1, 0, 0);
+        var color2 = redUniform;
+        var color3 = getColor();
+        var colorX = 1;
+        var color2X = redUniform.x;
+        var color3X = getColor().x;
+      }"
+    `);
   });
 
-  it('retains type information', ({ root }) => {
+  it('retains type information', () => {
     // Typed as f32, but literal could be automatically inferred as an i32
     const fooAccess = tgpu['~unstable'].accessor(d.f32, 1);
 

--- a/packages/typegpu/tests/bindGroupLayout.test.ts
+++ b/packages/typegpu/tests/bindGroupLayout.test.ts
@@ -22,7 +22,7 @@ import {
   type UnwrapRuntimeConstructor,
 } from '../src/tgpuBindGroupLayout.ts';
 import { it } from './utils/extendedIt.ts';
-import { parse } from './utils/parseResolved.ts';
+import { asWgsl } from './utils/parseResolved.ts';
 import './utils/webgpuGlobals.ts';
 
 const DEFAULT_READONLY_VISIBILITY_FLAGS = GPUShaderStage.COMPUTE |
@@ -222,19 +222,14 @@ describe('TgpuBindGroupLayout', () => {
 
     const fooTexture = layout.bound.fooTexture;
 
-    const resolved = tgpu.resolve({
-      template: 'fn main () { textureLoad(fooTexture); }',
-      externals: { fooTexture },
-      names: 'strict',
-    });
+    const main = tgpu.fn([])`() { textureLoad(fooTexture); }`
+      .$uses({ fooTexture });
 
-    expect(parse(resolved)).toBe(
-      parse(`
-      @group(0) @binding(0) var fooTexture: texture_1d<f32>;
+    expect(asWgsl(main)).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var fooTexture: texture_1d<f32>;
 
-      fn main() { textureLoad(fooTexture); }
-    `),
-    );
+      fn main() { textureLoad(fooTexture); }"
+    `);
   });
 });
 

--- a/packages/typegpu/tests/bufferUsage.test.ts
+++ b/packages/typegpu/tests/bufferUsage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf } from 'vitest';
-import { parse } from './utils/parseResolved.ts';
+import { asWgsl } from './utils/parseResolved.ts';
 
 import tgpu from '../src/index.ts';
 
@@ -19,23 +19,14 @@ describe('TgpuBufferUniform', () => {
     const buffer = root.createBuffer(d.f32).$usage('uniform').$name('param');
     const uniform = buffer.as('uniform');
 
-    const resolved = tgpu.resolve({
-      template: `
-        fn m() {
-          let y = hello;
-        }`,
-      externals: { hello: uniform },
-      names: 'strict',
-    });
+    const main = tgpu.fn([])`() { let y = hello; }`
+      .$uses({ hello: uniform });
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        @group(0) @binding(0) var<uniform> param: f32;
+    expect(asWgsl(main)).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<uniform> param: f32;
 
-        fn m() {
-          let y = param;
-        }`),
-    );
+      fn main() { let y = param; }"
+    `);
   });
 
   it('resolves to buffer binding in tgsl functions', ({ root }) => {
@@ -46,19 +37,13 @@ describe('TgpuBufferUniform', () => {
       const x = uniform.value;
     });
 
-    const resolved = tgpu.resolve({
-      externals: { func },
-      names: 'strict',
-    });
+    expect(asWgsl(func)).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<uniform> param: f32;
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        @group(0) @binding(0) var<uniform> param: f32;
-
-        fn func() {
-          var x = param;
-        }`),
-    );
+      fn func() {
+        var x = param;
+      }"
+    `);
   });
 
   it('allows accessing fields in a struct stored in its buffer', ({ root }) => {
@@ -75,25 +60,19 @@ describe('TgpuBufferUniform', () => {
       const velX = uniform.value.vel.x;
     });
 
-    const resolved = tgpu.resolve({
-      externals: { func },
-      names: 'strict',
-    });
+    expect(asWgsl(func)).toMatchInlineSnapshot(`
+      "struct Boid {
+        pos: vec3f,
+        vel: vec3u,
+      }
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        struct Boid {
-          pos: vec3f,
-          vel: vec3u,
-        }
+      @group(0) @binding(0) var<uniform> boid: Boid;
 
-        @group(0) @binding(0) var<uniform> boid: Boid;
-
-        fn func() {
-          var pos = boid.pos;
-          var velX = boid.vel.x;
-        }`),
-    );
+      fn func() {
+        var pos = boid.pos;
+        var velX = boid.vel.x;
+      }"
+    `);
   });
 });
 
@@ -109,23 +88,14 @@ describe('TgpuBufferMutable', () => {
     const buffer = root.createBuffer(d.f32).$usage('storage').$name('param');
     const mutable = buffer.as('mutable');
 
-    const resolved = tgpu.resolve({
-      template: `
-        fn m() {
-          let y = hello;
-        }`,
-      externals: { hello: mutable },
-      names: 'strict',
-    });
+    const main = tgpu.fn([])`() { let y = hello; }`
+      .$uses({ hello: mutable });
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        @group(0) @binding(0) var<storage, read_write> param: f32;
+    expect(asWgsl(main)).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<storage, read_write> param: f32;
 
-        fn m() {
-          let y = param;
-        }`),
-    );
+      fn main() { let y = param; }"
+    `);
   });
 
   it('resolves to buffer binding in tgsl functions', ({ root }) => {
@@ -136,19 +106,13 @@ describe('TgpuBufferMutable', () => {
       const x = mutable.value;
     });
 
-    const resolved = tgpu.resolve({
-      externals: { func },
-      names: 'strict',
-    });
+    expect(asWgsl(func)).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<storage, read_write> param: f32;
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        @group(0) @binding(0) var<storage, read_write> param: f32;
-
-        fn func() {
-          var x = param;
-        }`),
-    );
+      fn func() {
+        var x = param;
+      }"
+    `);
   });
 
   it('allows accessing fields in a struct stored in its buffer', ({ root }) => {
@@ -167,25 +131,19 @@ describe('TgpuBufferMutable', () => {
       const velX = mutable.value.vel.x;
     });
 
-    const resolved = tgpu.resolve({
-      externals: { func },
-      names: 'strict',
-    });
+    expect(asWgsl(func)).toMatchInlineSnapshot(`
+      "struct Boid {
+        pos: vec3f,
+        vel: vec3u,
+      }
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        struct Boid {
-          pos: vec3f,
-          vel: vec3u,
-        }
+      @group(0) @binding(0) var<storage, read_write> boid: Boid;
 
-        @group(0) @binding(0) var<storage, read_write> boid: Boid;
-
-        fn func() {
-          var pos = boid.pos;
-          var velX = boid.vel.x;
-        }`),
-    );
+      fn func() {
+        var pos = boid.pos;
+        var velX = boid.vel.x;
+      }"
+    `);
   });
 
   describe('simulate mode', () => {
@@ -220,23 +178,14 @@ describe('TgpuBufferReadonly', () => {
     const buffer = root.createBuffer(d.f32).$usage('storage').$name('param');
     const readonly = buffer.as('readonly');
 
-    const resolved = tgpu.resolve({
-      template: `
-        fn m() {
-          let y = hello;
-        }`,
-      externals: { hello: readonly },
-      names: 'strict',
-    });
+    const main = tgpu.fn([])`() { let y = hello; }`
+      .$uses({ hello: readonly });
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        @group(0) @binding(0) var<storage, read> param: f32;
+    expect(asWgsl(main)).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<storage, read> param: f32;
 
-        fn m() {
-          let y = param;
-        }`),
-    );
+      fn main() { let y = param; }"
+    `);
   });
 
   it('resolves to buffer binding in TGSL functions', ({ root }) => {
@@ -247,19 +196,13 @@ describe('TgpuBufferReadonly', () => {
       const x = paramReadonly.value;
     });
 
-    const resolved = tgpu.resolve({
-      externals: { func },
-      names: 'strict',
-    });
+    expect(asWgsl(func)).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<storage, read> paramBuffer: f32;
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        @group(0) @binding(0) var<storage, read> paramBuffer: f32;
-
-        fn func() {
-          var x = paramBuffer;
-        }`),
-    );
+      fn func() {
+        var x = paramBuffer;
+      }"
+    `);
   });
 
   it('allows accessing fields in a struct stored in its buffer', ({ root }) => {
@@ -277,25 +220,19 @@ describe('TgpuBufferReadonly', () => {
       const velX = boidReadonly.value.vel.x;
     });
 
-    const resolved = tgpu.resolve({
-      externals: { func },
-      names: 'strict',
-    });
+    expect(asWgsl(func)).toMatchInlineSnapshot(`
+      "struct Boid {
+        pos: vec3f,
+        vel: vec3u,
+      }
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        struct Boid {
-          pos: vec3f,
-          vel: vec3u,
-        }
+      @group(0) @binding(0) var<storage, read> boid: Boid;
 
-        @group(0) @binding(0) var<storage, read> boid: Boid;
-
-        fn func() {
-          var pos = boid.pos;
-          var velX = boid.vel.x;
-        }`),
-    );
+      fn func() {
+        var pos = boid.pos;
+        var velX = boid.vel.x;
+      }"
+    `);
   });
 
   it('cannot be accessed via .$ or .value top-level', ({ root }) => {

--- a/packages/typegpu/tests/computePipeline.test.ts
+++ b/packages/typegpu/tests/computePipeline.test.ts
@@ -7,7 +7,7 @@ import tgpu, {
 } from '../src/index.ts';
 import { $internal } from '../src/shared/symbols.ts';
 import { it } from './utils/extendedIt.ts';
-import { parse, parseResolved } from './utils/parseResolved.ts';
+import { asWgsl } from './utils/parseResolved.ts';
 import { extensionEnabled } from '../src/std/extensions.ts';
 
 describe('TgpuComputePipeline', () => {
@@ -62,9 +62,11 @@ describe('TgpuComputePipeline', () => {
       .withCompute(main)
       .createPipeline();
 
-    expect(parseResolved({ computePipeline })).toStrictEqual(parse(`
-      @compute @workgroup_size(32) fn main() {}
-    `));
+    expect(asWgsl(computePipeline)).toMatchInlineSnapshot(`
+      "@compute @workgroup_size(32) fn main() {
+
+      }"
+    `);
   });
 
   describe('Performance Callbacks', () => {

--- a/packages/typegpu/tests/derived.test.ts
+++ b/packages/typegpu/tests/derived.test.ts
@@ -3,7 +3,7 @@ import * as d from '../src/data/index.ts';
 import tgpu, { type TgpuDerived } from '../src/index.ts';
 import { mul } from '../src/std/index.ts';
 import { it } from './utils/extendedIt.ts';
-import { parse, parseResolved } from './utils/parseResolved.ts';
+import { asWgsl } from './utils/parseResolved.ts';
 
 describe('TgpuDerived', () => {
   it('memoizes results of transitive "derived"', () => {
@@ -13,17 +13,16 @@ describe('TgpuDerived', () => {
     const a = tgpu['~unstable'].derived(() => double.$ + 1);
     const b = tgpu['~unstable'].derived(() => double.$ + 2);
 
-    const main = tgpu.fn([], d.f32)(() => {
+    const main = () => {
+      'kernel';
       return a.$ + b.$;
-    });
+    };
 
-    expect(parseResolved({ main })).toBe(
-      parse(`
-      fn main() -> f32 {
+    expect(asWgsl(main)).toMatchInlineSnapshot(`
+      "fn item_0() -> i32 {
         return 7;
-      }
-    `),
-    );
+      }"
+    `);
 
     expect(computeDouble).toHaveBeenCalledTimes(1);
   });
@@ -40,15 +39,15 @@ describe('TgpuDerived', () => {
     const b = getDouble.with(foo, 2); // the same as `a`
     const c = getDouble.with(foo, 4);
 
-    const main = tgpu.fn([])(() => {
+    const main = () => {
+      'kernel';
       a();
       b();
       c();
-    });
+    };
 
-    expect(parseResolved({ main })).toBe(
-      parse(`
-      fn getDouble() -> f32 {
+    expect(asWgsl(main)).toMatchInlineSnapshot(`
+      "fn getDouble() -> f32 {
         return 4;
       }
 
@@ -56,13 +55,12 @@ describe('TgpuDerived', () => {
         return 8;
       }
 
-      fn main() {
+      fn item_0() {
         getDouble();
         getDouble();
         getDouble_1();
-      }
-    `),
-    );
+      }"
+    `);
   });
 
   it('can use slot values from its surrounding context', () => {
@@ -90,19 +88,25 @@ describe('TgpuDerived', () => {
     })
       .with(gridSizeSlot, 1);
 
-    expect(parseResolved({ main })).toBe(
-      parse(/* wgsl */ `
-      fn fill(arr: array<f32, 1>) {}
-      fn fill_1(arr: array<f32, 2>) {}
-      fn fill_2(arr: array<f32, 3>) {}
+    expect(asWgsl(main)).toMatchInlineSnapshot(`
+      "fn fill(arr: array<f32, 1>) {
+
+      }
+
+      fn fill_1(arr: array<f32, 2>) {
+
+      }
+
+      fn fill_2(arr: array<f32, 3>) {
+
+      }
 
       fn main() {
         fill(array<f32, 1>(1));
         fill_1(array<f32, 2>(1, 2));
         fill_2(array<f32, 3>(1, 2, 3));
-      }
-    `),
-    );
+      }"
+    `);
   });
 
   it('allows access to value in tgsl functions through the .value property ', ({ root }) => {
@@ -136,30 +140,23 @@ describe('TgpuDerived', () => {
       const velX_ = derivedDerivedUniformSlot.value.vel.x;
     });
 
-    const resolved = tgpu.resolve({
-      externals: { func },
-      names: 'strict',
-    });
+    expect(asWgsl(func)).toMatchInlineSnapshot(`
+      "struct Boid {
+        pos: vec3f,
+        vel: vec3u,
+      }
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        struct Boid {
-          pos: vec3f,
-          vel: vec3u,
-        }
+      @group(0) @binding(0) var<uniform> boid: Boid;
 
-        @group(0) @binding(0) var<uniform> boid: Boid;
-
-        fn func(){
-          var pos = vec3f(2, 4, 6);
-          var posX = 2;
-          var vel = boid.vel;
-          var velX = boid.vel.x;
-
-          var vel_ = boid.vel;
-          var velX_ = boid.vel.x;
-        }`),
-    );
+      fn func() {
+        var pos = vec3f(2, 4, 6);
+        var posX = 2;
+        var vel = boid.vel;
+        var velX = boid.vel.x;
+        var vel_ = boid.vel;
+        var velX_ = boid.vel.x;
+      }"
+    `);
   });
 
   // TODO: rethink this behavior of derived returning a function,
@@ -181,22 +178,20 @@ describe('TgpuDerived', () => {
       derivedFnWith2.$();
     });
 
-    expect(parseResolved({ main })).toBe(
-      parse(`
-        fn innerFn() -> f32 {
-          return 1;
-        }
+    expect(asWgsl(main)).toMatchInlineSnapshot(`
+      "fn innerFn() -> f32 {
+        return 1;
+      }
 
-        fn innerFn_1() -> f32 {
-          return 2;
-        }
+      fn innerFn_1() -> f32 {
+        return 2;
+      }
 
-        fn main() {
-          innerFn();
-          innerFn_1();
-        }
-      `),
-    );
+      fn main() {
+        innerFn();
+        innerFn_1();
+      }"
+    `);
   });
 
   it('does not allow defining derived values at resolution', () => {
@@ -208,7 +203,7 @@ describe('TgpuDerived', () => {
     );
     const fn = tgpu.fn([], d.u32)(() => absGridSize.$);
 
-    expect(() => parseResolved({ fn })).toThrow(
+    expect(() => asWgsl(fn)).toThrow(
       'Cannot create tgpu.derived objects at the resolution stage.',
     );
   });
@@ -226,30 +221,29 @@ describe('TgpuDerived', () => {
 
     const fooHalf = foo.with(halfPrecisionSlot, true);
 
-    const main = tgpu.fn([])(() => {
+    const main = () => {
+      'kernel';
       foo();
       fooHalf();
-    });
+    };
 
     expectTypeOf(ResultArray).toEqualTypeOf<
       TgpuDerived<d.WgslArray<d.F16 | d.F32>>
     >();
 
-    expect(parseResolved({ main })).toBe(
-      parse(`
-        fn foo() {
-          var array = array<f32, 4>();
-        }
+    expect(asWgsl(main)).toMatchInlineSnapshot(`
+      "fn foo() {
+        var array = array<f32, 4>();
+      }
 
-        fn foo_1() {
-          var array = array<f16, 4>();
-        }
+      fn foo_1() {
+        var array = array<f16, 4>();
+      }
 
-        fn main() {
-          foo();
-          foo_1();
-        }
-      `),
-    );
+      fn item_0() {
+        foo();
+        foo_1();
+      }"
+    `);
   });
 });

--- a/packages/typegpu/tests/entryFnHeaderGen.test.ts
+++ b/packages/typegpu/tests/entryFnHeaderGen.test.ts
@@ -1,47 +1,37 @@
 import { describe, expect, it } from 'vitest';
 import * as d from '../src/data/index.ts';
 import tgpu from '../src/index.ts';
-import { parse, parseResolved } from './utils/parseResolved.ts';
+import { asWgsl } from './utils/parseResolved.ts';
 
 describe('autogenerating wgsl headers for tgpu entry functions with raw string WGSL implementations', () => {
   it('works for fragment entry function with non-decorated non-struct output', () => {
     const mainFragment = tgpu['~unstable'].fragmentFn({
       in: { uv: d.vec2f },
       out: d.vec4f,
-    })(/* wgsl */ `{
-      return vec4f(in.uv[0]);
-    }`);
+    }) /* wgsl */`{ return vec4f(in.uv[0]); }`;
 
-    expect(parseResolved({ mainFragment })).toBe(
-      parse(`
-      struct mainFragment_Input {
-        @location(0) uv : vec2f,
+    expect(asWgsl(mainFragment)).toMatchInlineSnapshot(`
+      "struct mainFragment_Input {
+        @location(0) uv: vec2f,
       }
 
-      @fragment fn mainFragment(in: mainFragment_Input) -> @location(0) vec4f {
-        return vec4f(in.uv[0]);
-      }`),
-    );
+      @fragment fn mainFragment(in: mainFragment_Input) -> @location(0)  vec4f { return vec4f(in.uv[0]); }"
+    `);
   });
 
   it('works for fragment entry function with decorated non-struct output', () => {
     const mainFragment = tgpu['~unstable'].fragmentFn({
       in: { uv: d.vec2f },
       out: d.location(1, d.vec4f),
-    })(/* wgsl */ `{
-      return vec4f(in.uv[0]);
-    }`);
+    }) /* wgsl */`{ return vec4f(in.uv[0]); }`;
 
-    expect(parseResolved({ mainFragment })).toBe(
-      parse(`
-      struct mainFragment_Input {
-        @location(0) uv : vec2f,
+    expect(asWgsl(mainFragment)).toMatchInlineSnapshot(`
+      "struct mainFragment_Input {
+        @location(0) uv: vec2f,
       }
 
-      @fragment fn mainFragment(in: mainFragment_Input) -> @location(1) vec4f {
-        return vec4f(in.uv[0]);
-      }`),
-    );
+      @fragment fn mainFragment(in: mainFragment_Input) -> @location(1)  vec4f { return vec4f(in.uv[0]); }"
+    `);
   });
 
   it('works for fragment entry function with struct output', () => {
@@ -50,44 +40,34 @@ describe('autogenerating wgsl headers for tgpu entry functions with raw string W
       out: {
         primary: d.location(1, d.vec4f),
       },
-    })(/* wgsl */ `{
-      return Out(vec4f(in.uv[0]));
-    }`);
+    }) /* wgsl */`{ return Out(vec4f(in.uv[0])); }`;
 
-    expect(parseResolved({ mainFragment })).toBe(
-      parse(`
-      struct mainFragment_Input { 
-        @location(0) uv : vec2f,
+    expect(asWgsl(mainFragment)).toMatchInlineSnapshot(`
+      "struct mainFragment_Input {
+        @location(0) uv: vec2f,
       }
 
-      struct mainFragment_Output { 
-        @location(1) primary : vec4f,
+      struct mainFragment_Output {
+        @location(1) primary: vec4f,
       }
 
-      @fragment fn mainFragment(in: mainFragment_Input) -> mainFragment_Output { 
-        return mainFragment_Output(vec4f(in.uv[0])); 
-      }`),
-    );
+      @fragment fn mainFragment(in: mainFragment_Input) -> mainFragment_Output { return mainFragment_Output(vec4f(in.uv[0])); }"
+    `);
   });
 
   it('works for compute entry function', () => {
     const mainCompute = tgpu['~unstable'].computeFn({
       in: { index: d.builtin.globalInvocationId },
       workgroupSize: [1],
-    })(/* wgsl */ `{
-      let x = in.index;
-    }`);
+    }) /* wgsl */`{ let x = in.index; }`;
 
-    expect(parseResolved({ mainCompute })).toBe(
-      parse(`
-      struct mainCompute_Input {
-        @builtin(global_invocation_id) index : vec3u,
+    expect(asWgsl(mainCompute)).toMatchInlineSnapshot(`
+      "struct mainCompute_Input {
+        @builtin(global_invocation_id) index: vec3u,
       }
 
-      @compute @workgroup_size(1) fn mainCompute(in: mainCompute_Input) {
-        let x = in.index;
-      }`),
-    );
+      @compute @workgroup_size(1) fn mainCompute(in: mainCompute_Input)  { let x = in.index; }"
+    `);
   });
 
   it('works for vertex entry function', () => {
@@ -110,32 +90,31 @@ describe('autogenerating wgsl headers for tgpu entry functions with raw string W
     return Out(vec4f(pos[in.vertexIndex], 0.0, 1.0), uv[in.vertexIndex]);
   }`);
 
-    expect(parseResolved({ mainVertex })).toBe(
-      parse(`
-      struct mainVertex_Input {
-        @builtin(vertex_index) vertexIndex : u32,
+    expect(asWgsl(mainVertex)).toMatchInlineSnapshot(`
+      "struct mainVertex_Input {
+        @builtin(vertex_index) vertexIndex: u32,
       }
 
       struct mainVertex_Output {
-        @builtin(position) outPos : vec4f,
+        @builtin(position) outPos: vec4f,
         @location(0) uv: vec2f,
       }
 
       @vertex fn mainVertex(in: mainVertex_Input) -> mainVertex_Output {
-        var pos = array<vec2f, 3>(
-          vec2(0.0, 0.5),
-          vec2(-0.5, -0.5),
-          vec2(0.5, -0.5)
-        );
+          var pos = array<vec2f, 3>(
+            vec2(0.0, 0.5),
+            vec2(-0.5, -0.5),
+            vec2(0.5, -0.5)
+          );
 
-        var uv = array<vec2f, 3>(
-          vec2(0.5, 1.0),
-          vec2(0.0, 0.0),
-          vec2(1.0, 0.0),
-        );
+          var uv = array<vec2f, 3>(
+            vec2(0.5, 1.0),
+            vec2(0.0, 0.0),
+            vec2(1.0, 0.0),
+          );
 
-        return mainVertex_Output(vec4f(pos[in.vertexIndex], 0.0, 1.0), uv[in.vertexIndex]);
-      }`),
-    );
+          return mainVertex_Output(vec4f(pos[in.vertexIndex], 0.0, 1.0), uv[in.vertexIndex]);
+        }"
+    `);
   });
 });

--- a/packages/typegpu/tests/rawFn.test.ts
+++ b/packages/typegpu/tests/rawFn.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import * as d from '../src/data/index.ts';
 import tgpu from '../src/index.ts';
 import { getName } from '../src/shared/meta.ts';
-import { parse, parseResolved } from './utils/parseResolved.ts';
+import { asWgsl } from './utils/parseResolved.ts';
 
 describe('tgpu.fn with raw string WGSL implementation', () => {
   it('is namable', () => {
@@ -14,11 +14,9 @@ describe('tgpu.fn with raw string WGSL implementation', () => {
   it('resolves to WGSL', () => {
     const getY = tgpu.fn([], d.f32)`() { return 3.0f; }`;
 
-    expect(parseResolved({ getY })).toBe(parse(`
-      fn getY() -> f32 {
-        return 3.0f;
-      }
-    `));
+    expect(asWgsl(getY)).toMatchInlineSnapshot(
+      `"fn getY() -> f32{ return 3.0f; }"`,
+    );
   });
 
   it('resolves externals and replaces their usages in code', () => {
@@ -39,26 +37,22 @@ describe('tgpu.fn with raw string WGSL implementation', () => {
       }`)
       .$uses({ get_x: getX, color: getColor });
 
-    const actual = parseResolved({ getY });
+    expect(asWgsl(getY)).toMatchInlineSnapshot(`
+      "fn getColor() -> vec3f{
+            let color = vec3f();
+            return color;
+          }
 
-    const expected = parse(`
-      fn getColor() -> vec3f {
-        let color = vec3f();
-        return color;
-      }
+      fn getX() -> f32{
+              let color = getColor();
+              return 3.0f;
+            }
 
-      fn getX() -> f32 {
-        let color = getColor();
-        return 3.0f;
-      }
-
-      fn getY() -> f32 {
-        let c = getColor();
-        return getX();
-      }
+      fn getY() -> f32{
+              let c = getColor();
+              return getX();
+            }"
     `);
-
-    expect(actual).toBe(expected);
   });
 
   it('replaces external usage just for exact identifier matches', () => {
@@ -76,25 +70,19 @@ describe('tgpu.fn with raw string WGSL implementation', () => {
       .$name('get_y')
       .$uses({ getx });
 
-    const actual = parseResolved({ getY });
+    expect(asWgsl(getY)).toMatchInlineSnapshot(`
+      "fn externalFn() -> f32{ return 3.0f; }
 
-    const expected = parse(`
-      fn externalFn() -> f32 {
-        return 3.0f;
-      }
-
-      fn get_y() -> f32 {
-        let x = externalFn();
-        let y = externalFn() + externalFn();
-        let z = hellogetx();
-        externalFn();
-        xgetx();
-        getxx();
-        return externalFn();
-      }
+      fn get_y() -> f32{
+              let x = externalFn();
+              let y = externalFn() + externalFn();
+              let z = hellogetx();
+              externalFn();
+              xgetx();
+              getxx();
+              return externalFn();
+            }"
     `);
-
-    expect(actual).toBe(expected);
   });
 
   it("doesn't replace property access identifiers when replacing externals", () => {
@@ -107,38 +95,28 @@ describe('tgpu.fn with raw string WGSL implementation', () => {
       highlightedCircle: { uniform: HighlightedCircle },
     });
 
-    const shaderCode = tgpu.resolve({
-      template: `
-        fn vs() {
-          out.highlighted = highlighted.index;
+    const vs = tgpu.fn([])`() {
+      out.highlighted = highlighted.index;
 
-          let h = highlighted;
-          let x = a.b.c.highlighted.d;
-        }
-      `,
-      externals: {
-        highlighted: uniformBindGroupLayout.bound.highlightedCircle,
-      },
-      names: 'strict',
-    });
+      let h = highlighted;
+      let x = a.b.c.highlighted.d;
+    }`.$uses({ highlighted: uniformBindGroupLayout.bound.highlightedCircle });
 
-    expect(parse(shaderCode)).toBe(
-      parse(`
-        struct HighlightedCircle {
-          index: u32,
-          color: vec4f,
-        }
+    expect(asWgsl(vs)).toMatchInlineSnapshot(`
+      "struct HighlightedCircle {
+        index: u32,
+        color: vec4f,
+      }
 
-        @group(0) @binding(0) var<uniform> highlightedCircle: HighlightedCircle;
+      @group(0) @binding(0) var<uniform> highlightedCircle: HighlightedCircle;
 
-        fn vs() {
-          out.highlighted = highlightedCircle.index;
+      fn vs() {
+            out.highlighted = highlightedCircle.index;
 
-          let h = highlightedCircle;
-          let x = a.b.c.highlighted.d;
-        }
-      `),
-    );
+            let h = highlightedCircle;
+            let x = a.b.c.highlighted.d;
+          }"
+    `);
   });
 
   it('adds output struct definition when resolving vertex functions', () => {
@@ -159,13 +137,9 @@ describe('tgpu.fn with raw string WGSL implementation', () => {
     var output: Out;
     output.outPos = vec4f(pos[vertexIndex], 0, 1);
     return output;
-  }`)
-      .$name('vertex_fn');
+  }`).$name('vertex_fn');
 
-    const resolved = tgpu.resolve({
-      externals: { vertexFunction },
-      names: 'strict',
-    });
+    const resolved = asWgsl(vertexFunction);
 
     expect(resolved).toContain(`\
 struct vertex_fn_Output {
@@ -188,10 +162,7 @@ struct vertex_fn_Output {
       }`)
       .$name('fragment');
 
-    const resolved = tgpu.resolve({
-      externals: { fragmentFunction },
-      names: 'strict',
-    });
+    const resolved = asWgsl(fragmentFunction);
 
     expect(resolved).toContain(`\
 struct fragment_Output {
@@ -212,17 +183,15 @@ struct fragment_Output {
       }`)
       .$name('fragment');
 
-    expect(parseResolved({ fragmentFunction })).toBe(
-      parse(`
-    struct fragment_Input {
-      @builtin(position) position: vec4f,
-    }
+    expect(asWgsl(fragmentFunction)).toMatchInlineSnapshot(`
+      "struct fragment_Input {
+        @builtin(position) position: vec4f,
+      }
 
-    @fragment
-    fn fragment(in: fragment_Input) -> @location(0) vec4f {
-      return vec4f(1.0f);
-    }`),
-    );
+      @fragment fn fragment(in: fragment_Input) -> @location(0)  vec4f {
+              return vec4f(1.0f);
+            }"
+    `);
   });
 
   it('automatically adds struct definitions of argument types when resolving wgsl-defined functions', () => {
@@ -237,18 +206,17 @@ struct fragment_Output {
       }`)
       .$name('newPointF');
 
-    expect(parseResolved({ func })).toBe(
-      parse(`
-    struct Point {
-      a: u32,
-      b: u32,
-    }
+    expect(asWgsl(func)).toMatchInlineSnapshot(`
+      "struct Point {
+        a: u32,
+        b: u32,
+      }
 
-    fn newPointF(a: vec4f, b: Point) {
-      var newPoint: Point;
-      newPoint = b;
-    }`),
-    );
+      fn newPointF(a: vec4f, b: Point) {
+              var newPoint: Point;
+              newPoint = b;
+            }"
+    `);
   });
 
   it('replaces references when adding struct definitions of argument types when resolving wgsl-defined functions', () => {
@@ -268,18 +236,17 @@ struct fragment_Output {
       }`)
       .$name('newPointF');
 
-    expect(parseResolved({ func })).toBe(
-      parse(`
-    struct P {
-      a: u32,
-      b: u32,
-    }
+    expect(asWgsl(func)).toMatchInlineSnapshot(`
+      "struct P {
+        a: u32,
+        b: u32,
+      }
 
-    fn newPointF(a: vec4f, b: P) -> vec2f {
-      var newPoint: P;
-      newPoint = b;
-    }`),
-    );
+      fn newPointF(a: vec4f, b: P) -> vec2f{
+              var newPoint: P;
+              newPoint = b;
+            }"
+    `);
   });
 
   it('adds return type struct definitions when resolving wgsl-defined functions', () => {
@@ -298,19 +265,18 @@ struct fragment_Output {
       }`,
     ).$name('newPointF');
 
-    expect(parseResolved({ func })).toBe(
-      parse(`
-    struct P {
-      a: u32,
-      b: u32,
-    }
+    expect(asWgsl(func)).toMatchInlineSnapshot(`
+      "struct P {
+        a: u32,
+        b: u32,
+      }
 
-    fn newPointF(a: vec4f) -> P {
-      var newPoint: P;
-      newPoint = b;
-      return newPoint;
-    }`),
-    );
+      fn newPointF(a: vec4f) -> P{
+              var newPoint: P;
+              newPoint = b;
+              return newPoint;
+            }"
+    `);
   });
 
   // TODO: handle nested structs
@@ -349,19 +315,17 @@ struct fragment_Output {
       .$name('main')
       .$uses({ functions: { getColor } });
 
-    expect(parseResolved({ main })).toBe(
-      parse(`
-      fn get_color() -> vec3f {
-        let color = vec3f();
-        return color;
-      }
+    expect(asWgsl(main)).toMatchInlineSnapshot(`
+      "fn get_color() -> vec3f{
+              let color = vec3f();
+              return color;
+            }
 
-      fn main() -> f32 {
-        let c = get_color();
-        return c.x;
-      }
-    `),
-    );
+      fn main() -> f32{
+              let c = get_color();
+              return c.x;
+            }"
+    `);
   });
 
   it('resolves compound types with structs provided in externals', () => {
@@ -376,15 +340,16 @@ struct fragment_Output {
       .$name('get_color')
       .$uses({ MyPoint: Point });
 
-    expect(parseResolved({ getColor })).toBe(
-      parse(`
-      struct P { a: u32, }
-      fn get_color(a: array<P, 4>) -> u32 {
-        var b: P = a[0];
-        return b.a;
+    expect(asWgsl(getColor)).toMatchInlineSnapshot(`
+      "struct P {
+        a: u32,
       }
-    `),
-    );
+
+      fn get_color(a: array<P,4>) -> u32{
+              var b: P = a[0];
+              return b.a;
+            }"
+    `);
   });
 });
 
@@ -398,43 +363,35 @@ describe('tgpu.fn with raw wgsl and missing types', () => {
       }`)
       .$name('get_color');
 
-    expect(parseResolved({ getColor })).toBe(
-      parse(`
-      fn get_color(a: vec3f, b: u32, c: mat2x2f, d: bool, e: vec2<bool>) -> vec4u {
-        return vec4u();
-      }
-    `),
-    );
+    expect(asWgsl(getColor)).toMatchInlineSnapshot(`
+      "fn get_color(a: vec3f, b: u32, c: mat2x2f, d: bool, e: vec2<bool>) -> vec4u{
+              return vec4u();
+            }"
+    `);
   });
 
   it('resolves void functions', () => {
     const getColor = tgpu.fn([])(`() {
-        return;
-      }`)
-      .$name('get_color');
+      return;
+    }`);
 
-    expect(parseResolved({ getColor })).toBe(
-      parse(`
-      fn get_color() {
-        return;
-      }
-    `),
-    );
+    expect(asWgsl(getColor)).toMatchInlineSnapshot(`
+      "fn getColor() {
+            return;
+          }"
+    `);
   });
 
   it('resolves compound types', () => {
     const getColor = tgpu.fn([d.arrayOf(d.u32, 4)], d.u32)(`(a) {
-        return a[0];
-      }`)
-      .$name('get_color');
+      return a[0];
+    }`);
 
-    expect(parseResolved({ getColor })).toBe(
-      parse(`
-      fn get_color(a: array<u32, 4>) -> u32 {
-        return a[0];
-      }
-    `),
-    );
+    expect(asWgsl(getColor)).toMatchInlineSnapshot(`
+      "fn getColor(a: array<u32,4>) -> u32{
+            return a[0];
+          }"
+    `);
   });
 
   it('resolves compound types with structs provided in externals', () => {
@@ -444,18 +401,18 @@ describe('tgpu.fn with raw wgsl and missing types', () => {
         var b: MyPoint = a[0];
         return b.a;
       }`)
-      .$name('get_color')
       .$uses({ MyPoint: Point });
 
-    expect(parseResolved({ getColor })).toBe(
-      parse(`
-      struct P { a: u32, }
-      fn get_color(a: array<P, 4>) -> u32 {
-        var b: P = a[0];
-        return b.a;
+    expect(asWgsl(getColor)).toMatchInlineSnapshot(`
+      "struct P {
+        a: u32,
       }
-    `),
-    );
+
+      fn getColor(a: array<P,4>) -> u32{
+              var b: P = a[0];
+              return b.a;
+            }"
+    `);
   });
 
   it('replaces references when one struct is named in wgsl', () => {
@@ -471,91 +428,84 @@ describe('tgpu.fn with raw wgsl and missing types', () => {
       }`)
       .$name('newPointF');
 
-    expect(parseResolved({ func })).toBe(
-      parse(`
-        struct P {
-          a: u32,
-          b: u32,
-        }
+    expect(asWgsl(func)).toMatchInlineSnapshot(`
+      "struct P {
+        a: u32,
+        b: u32,
+      }
 
-        fn newPointF(a: P, b: P) -> P {
-          return b;
-        }`),
-    );
+      fn newPointF(a: P, b: P) -> P{
+              return b;
+            }"
+    `);
   });
 
   it('throws when parameter type mismatch', () => {
     const getColor = tgpu.fn([d.vec3f])(`(a: vec4f) {
-        return;
-      }`)
-      .$name('get_color');
+      return;
+    }`);
 
-    expect(() => parseResolved({ getColor }))
-      .toThrowErrorMatchingInlineSnapshot(`
-        [Error: Resolution of the following tree failed:
-        - <root>
-        - fn:get_color: Type mismatch between TGPU shell and WGSL code string: parameter a, JS type "vec3f", WGSL type "vec4f".]
-      `);
+    expect(() => asWgsl(getColor)).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn:getColor: Type mismatch between TGPU shell and WGSL code string: parameter a, JS type "vec3f", WGSL type "vec4f".]
+    `);
   });
 
   it('throws when compound parameter type mismatch', () => {
     const Point = d.struct({ a: d.u32 }).$name('P');
 
     const getColor = tgpu.fn([d.arrayOf(Point, 4)])(`(a: arrayOf<MyPoint, 3>) {
-        return;
-      }`)
-      .$name('get_color')
+      return;
+    }`)
       .$uses({ MyPoint: Point });
 
-    expect(() => parseResolved({ getColor }))
-      .toThrowErrorMatchingInlineSnapshot(`
-        [Error: Resolution of the following tree failed:
-        - <root>
-        - fn:get_color: Type mismatch between TGPU shell and WGSL code string: parameter a, JS type "array<P,4>", WGSL type "arrayOf<P,3>".]
-      `);
+    expect(() => asWgsl(getColor)).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn:getColor: Type mismatch between TGPU shell and WGSL code string: parameter a, JS type "array<P,4>", WGSL type "arrayOf<P,3>".]
+    `);
   });
 
   it('throws when return type mismatch', () => {
     const getColor = tgpu.fn([], d.vec4f)(`() -> vec2f {
-        return;
-      }`)
-      .$name('get_color');
+      return;
+    }`);
 
-    expect(() => parseResolved({ getColor }))
-      .toThrowErrorMatchingInlineSnapshot(`
-        [Error: Resolution of the following tree failed:
-        - <root>
-        - fn:get_color: Type mismatch between TGPU shell and WGSL code string: return type, JS type "vec4f", WGSL type "vec2f".]
-      `);
+    expect(() => asWgsl(getColor)).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn:getColor: Type mismatch between TGPU shell and WGSL code string: return type, JS type "vec4f", WGSL type "vec2f".]
+    `);
   });
 
   it('throws when wrong argument count', () => {
     const getColor = tgpu.fn([d.vec3f, d.vec4f])(`(a, b, c) {
-        return;
-      }`)
-      .$name('get_color');
+      return;
+    }`);
 
-    expect(() => parseResolved({ getColor }))
-      .toThrowErrorMatchingInlineSnapshot(`
-        [Error: Resolution of the following tree failed:
-        - <root>
-        - fn:get_color: WGSL implementation has 3 arguments, while the shell has 2 arguments.]
-      `);
+    expect(() => asWgsl(getColor)).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn:getColor: WGSL implementation has 3 arguments, while the shell has 2 arguments.]
+    `);
   });
 
   it('resolves implicitly typed struct without externals', () => {
-    const Point = d.struct({ a: d.i32 }).$name('myStruct');
+    const Point = d.struct({ a: d.i32 });
     const getColor = tgpu.fn([Point])(`(a) {
-        return;
-      }`)
-      .$name('get_color');
+      return;
+    }`);
 
-    expect(parseResolved({ getColor })).toBe(parse(`
-      struct myStruct { a: i32, }
-      fn get_color(a: myStruct) {
-        return;
+    expect(asWgsl(getColor)).toMatchInlineSnapshot(`
+      "struct Point {
+        a: i32,
       }
-      `));
+
+      fn getColor(a: Point) {
+            return;
+          }"
+    `);
   });
 });
 
@@ -570,17 +520,14 @@ describe('tgpu.computeFn with raw string WGSL implementation', () => {
       var result: array<f32, 4>;
     }`);
 
-    expect(parseResolved({ foo })).toBe(
-      parse(`
-      struct foo_Input {
+    expect(asWgsl(foo)).toMatchInlineSnapshot(`
+      "struct foo_Input {
         @builtin(global_invocation_id) gid: vec3u,
       }
 
-      @compute @workgroup_size(1)
-      fn foo(in: foo_Input) {
-        var result: array<f32, 4>;
-      }
-    `),
-    );
+      @compute @workgroup_size(1) fn foo(in: foo_Input)  {
+            var result: array<f32, 4>;
+          }"
+    `);
   });
 });

--- a/packages/typegpu/tests/renderPipeline.test.ts
+++ b/packages/typegpu/tests/renderPipeline.test.ts
@@ -10,7 +10,7 @@ import tgpu, {
 } from '../src/index.ts';
 import { $internal } from '../src/shared/symbols.ts';
 import { it } from './utils/extendedIt.ts';
-import { parse, parseResolved } from './utils/parseResolved.ts';
+import { asWgsl } from './utils/parseResolved.ts';
 
 describe('TgpuRenderPipeline', () => {
   const vert = tgpu['~unstable'].vertexFn({
@@ -142,28 +142,25 @@ describe('TgpuRenderPipeline', () => {
 
   describe('resolve', () => {
     it('allows resolving the entire shader code', ({ root }) => {
-      const pipeline = root['~unstable'].withVertex(
-        vertWithBuiltin.$name('vertex'),
-        {},
-      )
+      const pipeline = root['~unstable']
+        .withVertex(vertWithBuiltin.$name('vertex'), {})
         .withFragment(
           tgpu['~unstable'].fragmentFn({
             in: { a: d.builtin.position },
             out: d.vec4f,
           })(() => d.vec4f(1, 2, 3, 4)).$name('fragment'),
           { format: 'r8unorm' },
-        ).createPipeline();
+        )
+        .createPipeline();
 
-      expect(parseResolved({ pipeline })).toEqual(parse(`
-        struct vertex_Output {
+      expect(asWgsl(pipeline)).toMatchInlineSnapshot(`
+        "struct vertex_Output {
           @location(0) a: vec3f,
           @location(1) b: vec2f,
           @builtin(position) pos: vec4f,
         }
 
-        @vertex fn vertex() -> vertex_Output {
-          return vertex_Output();
-        }
+        @vertex fn vertex() -> vertex_Output { return vertex_Output(); }
 
         struct fragment_Input {
           @builtin(position) a: vec4f,
@@ -171,49 +168,46 @@ describe('TgpuRenderPipeline', () => {
 
         @fragment fn fragment(_arg_0: fragment_Input) -> @location(0) vec4f {
           return vec4f(1, 2, 3, 4);
-        }
-      `));
+        }"
+      `);
     });
 
     it('resolves with correct locations when pairing up a vertex and a fragment function', ({ root }) => {
-      const vertexMain = tgpu['~unstable']
-        .vertexFn({
-          out: {
-            foo: d.vec3f,
-            bar: d.vec3f,
-            baz: d.location(0, d.vec3f),
-            baz2: d.location(5, d.f32),
-            baz3: d.u32,
-            pos: d.builtin.position,
-          },
-        })(() => ({
-          foo: d.vec3f(),
-          bar: d.vec3f(),
-          baz: d.vec3f(),
-          baz2: 0,
-          baz3: 0,
-          pos: d.vec4f(),
-        }))
-        .$name('vertexMain');
+      const vertexMain = tgpu['~unstable'].vertexFn({
+        out: {
+          foo: d.vec3f,
+          bar: d.vec3f,
+          baz: d.location(0, d.vec3f),
+          baz2: d.location(5, d.f32),
+          baz3: d.u32,
+          pos: d.builtin.position,
+        },
+      })(() => ({
+        foo: d.vec3f(),
+        bar: d.vec3f(),
+        baz: d.vec3f(),
+        baz2: 0,
+        baz3: 0,
+        pos: d.vec4f(),
+      }));
 
-      const fragmentMain = tgpu['~unstable']
-        .fragmentFn({
-          in: {
-            baz3: d.u32,
-            bar: d.vec3f,
-            foo: d.location(2, d.vec3f),
-            baz2: d.f32,
-          },
-          out: d.vec4f,
-        })(() => d.vec4f());
+      const fragmentMain = tgpu['~unstable'].fragmentFn({
+        in: {
+          baz3: d.u32,
+          bar: d.vec3f,
+          foo: d.location(2, d.vec3f),
+          baz2: d.f32,
+        },
+        out: d.vec4f,
+      })(() => d.vec4f());
 
       const pipeline = root['~unstable']
         .withVertex(vertexMain, {})
         .withFragment(fragmentMain, { format: 'r8unorm' })
         .createPipeline();
 
-      expect(parseResolved({ pipeline })).toStrictEqual(parse(`
-        struct vertexMain_Output {
+      expect(asWgsl(pipeline)).toMatchInlineSnapshot(`
+        "struct vertexMain_Output {
           @location(2) foo: vec3f,
           @location(1) bar: vec3f,
           @location(0) baz: vec3f,
@@ -235,42 +229,40 @@ describe('TgpuRenderPipeline', () => {
 
         @fragment fn fragmentMain(_arg_0: fragmentMain_Input) -> @location(0) vec4f {
           return vec4f();
-        }
-      `));
+        }"
+      `);
     });
 
     it('resolves with correct locations when pairing up a vertex and a fragment function with rawFn implementation', ({ root }) => {
-      const vertexMain = tgpu['~unstable']
-        .vertexFn({
-          out: {
-            foo: d.vec3f,
-            bar: d.vec3f,
-            position: d.builtin.position,
-            baz: d.location(0, d.vec3f),
-            baz2: d.location(5, d.f32),
-            baz3: d.u32,
-          },
-        })`{ return Out(); }`;
+      const vertexMain = tgpu['~unstable'].vertexFn({
+        out: {
+          foo: d.vec3f,
+          bar: d.vec3f,
+          position: d.builtin.position,
+          baz: d.location(0, d.vec3f),
+          baz2: d.location(5, d.f32),
+          baz3: d.u32,
+        },
+      })`{ return Out(); }`;
 
-      const fragmentMain = tgpu['~unstable']
-        .fragmentFn({
-          in: {
-            position: d.builtin.position,
-            baz3: d.u32,
-            bar: d.vec3f,
-            foo: d.location(2, d.vec3f),
-            baz2: d.f32,
-          },
-          out: d.vec4f,
-        })`{ return vec4f(); }`;
+      const fragmentMain = tgpu['~unstable'].fragmentFn({
+        in: {
+          position: d.builtin.position,
+          baz3: d.u32,
+          bar: d.vec3f,
+          foo: d.location(2, d.vec3f),
+          baz2: d.f32,
+        },
+        out: d.vec4f,
+      })`{ return vec4f(); }`;
 
       const pipeline = root['~unstable']
         .withVertex(vertexMain, {})
         .withFragment(fragmentMain, { format: 'r8unorm' })
         .createPipeline();
 
-      expect(parseResolved({ pipeline })).toStrictEqual(parse(`
-        struct vertexMain_Output {
+      expect(asWgsl(pipeline)).toMatchInlineSnapshot(`
+        "struct vertexMain_Output {
           @location(2) foo: vec3f,
           @location(1) bar: vec3f,
           @builtin(position) position: vec4f,
@@ -279,9 +271,7 @@ describe('TgpuRenderPipeline', () => {
           @location(3) baz3: u32,
         }
 
-        @vertex fn vertexMain() -> vertexMain_Output {
-          return vertexMain_Output();
-        }
+        @vertex fn vertexMain() -> vertexMain_Output { return vertexMain_Output(); }
 
         struct fragmentMain_Input {
           @builtin(position) position: vec4f,
@@ -291,10 +281,8 @@ describe('TgpuRenderPipeline', () => {
           @location(5) baz2: f32,
         }
 
-        @fragment fn fragmentMain(in: fragmentMain_Input) -> @location(0) vec4f {
-          return vec4f();
-        }
-      `));
+        @fragment fn fragmentMain(in: fragmentMain_Input) -> @location(0)  vec4f { return vec4f(); }"
+      `);
     });
 
     it('logs warning when resolving pipeline having vertex and fragment functions with conflicting user-defined locations', ({ root }) => {
@@ -302,24 +290,22 @@ describe('TgpuRenderPipeline', () => {
         () => {},
       );
 
-      const vertexMain = tgpu['~unstable']
-        .vertexFn({
-          out: {
-            foo: d.vec3f,
-            bar: d.location(0, d.vec3f),
-          },
-        })(() => ({
-          foo: d.vec3f(),
-          bar: d.vec3f(),
-        }));
+      const vertexMain = tgpu['~unstable'].vertexFn({
+        out: {
+          foo: d.vec3f,
+          bar: d.location(0, d.vec3f),
+        },
+      })(() => ({
+        foo: d.vec3f(),
+        bar: d.vec3f(),
+      }));
 
-      const fragmentMain = tgpu['~unstable']
-        .fragmentFn({
-          in: {
-            bar: d.location(1, d.vec3f),
-          },
-          out: d.vec4f,
-        })(() => d.vec4f());
+      const fragmentMain = tgpu['~unstable'].fragmentFn({
+        in: {
+          bar: d.location(1, d.vec3f),
+        },
+        out: d.vec4f,
+      })(() => d.vec4f());
 
       const pipeline = root['~unstable']
         .withVertex(vertexMain, {})
@@ -337,24 +323,22 @@ describe('TgpuRenderPipeline', () => {
         () => {},
       );
 
-      const vertexMain = tgpu['~unstable']
-        .vertexFn({
-          out: {
-            foo: d.vec3f,
-            bar: d.location(0, d.vec3f),
-          },
-        })(() => ({
-          foo: d.vec3f(),
-          bar: d.vec3f(),
-        }));
+      const vertexMain = tgpu['~unstable'].vertexFn({
+        out: {
+          foo: d.vec3f,
+          bar: d.location(0, d.vec3f),
+        },
+      })(() => ({
+        foo: d.vec3f(),
+        bar: d.vec3f(),
+      }));
 
-      const fragmentMain = tgpu['~unstable']
-        .fragmentFn({
-          in: {
-            bar: d.location(0, d.vec3f),
-          },
-          out: d.vec4f,
-        })(() => d.vec4f());
+      const fragmentMain = tgpu['~unstable'].fragmentFn({
+        in: {
+          bar: d.location(0, d.vec3f),
+        },
+        out: d.vec4f,
+      })(() => d.vec4f());
 
       const pipeline = root['~unstable']
         .withVertex(vertexMain, {})

--- a/packages/typegpu/tests/resolve.test.ts
+++ b/packages/typegpu/tests/resolve.test.ts
@@ -10,7 +10,6 @@ import {
 } from '../src/shared/symbols.ts';
 import type { ResolutionCtx } from '../src/types.ts';
 import { it } from './utils/extendedIt.ts';
-import { parse } from './utils/parseResolved.ts';
 import { snip } from '../src/data/snippet.ts';
 
 describe('tgpu resolve', () => {
@@ -26,11 +25,12 @@ describe('tgpu resolve', () => {
       },
       names: 'strict',
     });
-    expect(parse(resolved)).toBe(
-      parse(
-        'struct Gradient { start: vec3f, end: vec3f, } fn foo() { var g: Gradient; }',
-      ),
-    );
+    expect(resolved).toMatchInlineSnapshot(`
+      "struct Gradient {
+        start: vec3f,
+        end: vec3f,
+      }fn foo() { var g: Gradient; }"
+    `);
   });
 
   it('should resolve a nested external JS struct', () => {
@@ -87,17 +87,17 @@ describe('tgpu resolve', () => {
       names: 'strict',
     });
 
-    expect(parse(resolved)).toBe(
-      parse(
-        `@group(0) @binding(0) var<uniform> intensity: f32;
-        @fragment fn fragment1() -> @location(0) vec4f {
-          return vec4f(0, intensity, 0, 1);
-        }
-        @fragment fn fragment2() -> @location(0) vec4f {
-          return vec4f(intensity, 0, 0, 1);
-        }`,
-      ),
-    );
+    expect(resolved).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<uniform> intensity: f32;
+
+      @fragment fn fragment1() -> @location(0) vec4f {
+        return vec4f(0, intensity, 0, 1);
+      }
+
+      @fragment fn fragment2() -> @location(0) vec4f {
+        return vec4f(intensity, 0, 0, 1);
+      }"
+    `);
   });
 
   it('properly resolves a combination of functions, structs and strings', () => {
@@ -109,19 +109,17 @@ describe('tgpu resolve', () => {
 
     const getPlayerHealth = tgpu.fn([PlayerData], d.f32)((pInfo) => {
       return pInfo.health;
-    })
-      .$name('getPlayerHealthTest');
-
-    const shaderLogic = `
-      @compute @workgroup_size(1)
-      fn main() {
-        var player: PlayerData;
-        player.health = 100;
-        let health = getPlayerHealth(player);
-      }`;
+    });
 
     const resolved = tgpu.resolve({
-      template: shaderLogic,
+      template: `
+@compute @workgroup_size(1)
+fn main() {
+  var player: PlayerData;
+  player.health = 100;
+  let health = getPlayerHealth(player);
+}
+`,
       externals: {
         PlayerData,
         getPlayerHealth,
@@ -129,26 +127,24 @@ describe('tgpu resolve', () => {
       names: 'strict',
     });
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        struct PlayerData {
-          position: vec3f,
-          velocity: vec3f,
-          health: f32,
-        }
+    expect(resolved).toMatchInlineSnapshot(`
+      "struct PlayerData {
+        position: vec3f,
+        velocity: vec3f,
+        health: f32,
+      }
 
-        fn getPlayerHealthTest(pInfo: PlayerData) -> f32 {
-          return pInfo.health;
-        }
-
-        @compute @workgroup_size(1)
-        fn main() {
-          var player: PlayerData;
-          player.health = 100;
-          let health = getPlayerHealthTest(player);
-        }
-      `),
-    );
+      fn getPlayerHealth(pInfo: PlayerData) -> f32 {
+        return pInfo.health;
+      }
+      @compute @workgroup_size(1)
+      fn main() {
+        var player: PlayerData;
+        player.health = 100;
+        let health = getPlayerHealth(player);
+      }
+      "
+    `);
   });
 
   it('should resolve a function with its dependencies', () => {
@@ -179,28 +175,25 @@ describe('tgpu resolve', () => {
       names: 'strict',
     });
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        struct Random {
-          seed: vec2f,
-          range: vec2f,
-        }
+    expect(resolved).toMatchInlineSnapshot(`
+      "struct Random {
+        seed: vec2f,
+        range: vec2f,
+      }
 
-        fn random() -> f32 {
-          var r: Random;
-          r.seed = vec2<f32>(3.14, 1.59);
-          r.range = vec2<f32>(0.0, 1.0);
-          r.seed.x = fract(cos(dot(r.seed, vec2f(23.14077926, 232.61690225))) * 136.8168);
-          r.seed.y = fract(cos(dot(r.seed, vec2f(54.47856553, 345.84153136))) * 534.7645);
-          return clamp(r.seed.y, r.range.x, r.range.y);
-        }
-
-        @compute @workgroup_size(1)
-        fn main() {
-          var value = random();
-        }
-      `),
-    );
+      fn random() -> f32{
+              var r: Random;
+              r.seed = vec2<f32>(3.14, 1.59);
+              r.range = vec2<f32>(0.0, 1.0);
+              r.seed.x = fract(cos(dot(r.seed, vec2f(23.14077926, 232.61690225))) * 136.8168);
+              r.seed.y = fract(cos(dot(r.seed, vec2f(54.47856553, 345.84153136))) * 534.7645);
+              return clamp(r.seed.y, r.range.x, r.range.y);
+            }
+            @compute @workgroup_size(1)
+            fn main() {
+              var value = random();
+            }"
+    `);
   });
 
   it('should resolve an unstruct to its corresponding struct', () => {
@@ -216,16 +209,14 @@ describe('tgpu resolve', () => {
       names: 'strict',
     });
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        struct VertexInfo {
-          color: vec4f,
-          colorHDR: vec4f,
-          position2d: vec2f,
-        }
-        fn foo() { var v: VertexInfo; }
-      `),
-    );
+    expect(resolved).toMatchInlineSnapshot(`
+      "struct VertexInfo {
+        color: vec4f,
+        colorHDR: vec4f,
+        position2d: vec2f,
+
+      }fn foo() { var v: VertexInfo; }"
+    `);
   });
 
   it('should resolve an unstruct with a disarray to its corresponding struct', () => {
@@ -242,17 +233,15 @@ describe('tgpu resolve', () => {
       names: 'strict',
     });
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        struct VertexInfo {
-          color: vec4f,
-          colorHDR: vec4f,
-          position2d: vec2f,
-          extra: array<vec4f, 16>,
-        }
-        fn foo() { var v: VertexInfo; }
-      `),
-    );
+    expect(resolved).toMatchInlineSnapshot(`
+      "struct VertexInfo {
+        color: vec4f,
+        colorHDR: vec4f,
+        position2d: vec2f,
+        extra: array<vec4f, 16>,
+
+      }fn foo() { var v: VertexInfo; }"
+    `);
   });
 
   it('should resolve an unstruct with a complex nested structure', () => {
@@ -281,30 +270,29 @@ describe('tgpu resolve', () => {
       names: 'strict',
     });
 
-    expect(parse(resolved)).toBe(
-      parse(`
-        struct Extra {
-          a: f32,
-          b: vec4f,
-          c: vec2f,
-        }
+    expect(resolved).toMatchInlineSnapshot(`
+      "struct Extra {
+        a: f32,
+        b: vec4f,
+        c: vec2f,
 
-        struct More {
-          a: f32,
-          b: vec4f,
-        }
+      }
 
-        struct VertexInfo {
-          color: vec4f,
-          colorHDR: vec4f,
-          position2d: vec2f,
-          extra: Extra,
-          more: array<More, 16>,
-        }
+      struct More {
+        a: f32,
+        b: vec4f,
 
-        fn foo() { var v: VertexInfo; }
-      `),
-    );
+      }
+
+      struct VertexInfo {
+        color: vec4f,
+        colorHDR: vec4f,
+        position2d: vec2f,
+        extra: Extra,
+        more: array<More, 16>,
+
+      }fn foo() { var v: VertexInfo; }"
+    `);
   });
 
   it('should resolve object externals and replace their usages in template', () => {
@@ -330,33 +318,28 @@ describe('tgpu resolve', () => {
       names: 'strict',
     });
 
-    expect(parse(resolved)).toBe(
-      parse(`
-      @group(0) @binding(0) var<uniform> intensity: u32;
+    expect(resolved).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<uniform> intensity: u32;
 
-      fn get_color() -> vec3f {
-        let color = vec3f();
-        return color;
-      }
-
-      fn main() {
-        let c = get_color() * intensity;
-      }
-    `),
-    );
+      fn get_color() -> vec3f{
+              let color = vec3f();
+              return color;
+            }
+            fn main () {
+              let c = get_color() * intensity;
+            }"
+    `);
   });
 
   it('should resolve only used object externals and ignore non-existing', () => {
     const getColor = tgpu.fn([], d.vec3f)`() {
       let color = vec3f();
       return color;
-    }
-    `.$name('get_color');
+    }`;
 
     const getIntensity = tgpu.fn([], d.vec3f)`() {
       return 1;
-    }
-    `.$name('get_intensity');
+    }`;
 
     const layout = tgpu.bindGroupLayout({
       intensity: { uniform: d.u32 },
@@ -380,51 +363,43 @@ describe('tgpu resolve', () => {
   });
 
   it('should resolve deeply nested objects', () => {
-    expect(
-      parse(
-        tgpu.resolve({
-          template: 'fn main () { let x = a.b.c.d + a.e; }',
-          externals: {
-            a: {
-              b: {
-                c: {
-                  d: 2,
-                },
-              },
-              e: 3,
+    expect(tgpu.resolve({
+      template: 'fn main () { let x = a.b.c.d + a.e; }',
+      externals: {
+        a: {
+          b: {
+            c: {
+              d: 2,
             },
           },
-          names: 'strict',
-        }),
-      ),
-    ).toBe(parse('fn main() { let x = 2 + 3; }'));
+          e: 3,
+        },
+      },
+      names: 'strict',
+    })).toMatchInlineSnapshot(`"fn main () { let x = 2 + 3; }"`);
   });
 
   it('should treat dot as a regular character in regex when resolving object access externals and not a wildcard', () => {
-    expect(
-      parse(
-        tgpu.resolve({
-          template: `
-        fn main () {
-          let x = a.b;
-          let y = axb;
-        }`,
-          externals: {
-            a: {
-              b: 3,
-            },
-            axb: 2,
-          },
-          names: 'strict',
-        }),
-      ),
-    ).toBe(
-      parse(`
-        fn main () {
-          let x = 3;
-          let y = 2;
-        }`),
-    );
+    expect(tgpu.resolve({
+      template: `
+fn main () {
+  let x = a.b;
+  let y = axb;
+}`,
+      externals: {
+        a: {
+          b: 3,
+        },
+        axb: 2,
+      },
+      names: 'strict',
+    })).toMatchInlineSnapshot(`
+      "
+      fn main () {
+        let x = 3;
+        let y = 2;
+      }"
+    `);
   });
 });
 
@@ -445,17 +420,16 @@ describe('tgpu resolveWithContext', () => {
       names: 'strict',
     });
 
-    expect(parse(code)).toBe(
-      parse(`
-        struct Gradient {
-          start: vec3f,
-          end: vec3f,
-        }
-        fn getGradientAngle(gradient: Gradient) -> f32 {
-          return atan(gradient.end.y - gradient.start.y, gradient.end.x - gradient.start.x);
-        }
-      `),
-    );
+    expect(code).toMatchInlineSnapshot(`
+      "struct Gradient {
+        start: vec3f,
+        end: vec3f,
+      }
+              fn getGradientAngle(gradient: Gradient) -> f32 {
+                return atan(gradient.end.y - gradient.start.y, gradient.end.x - gradient.start.x);
+              }
+            "
+    `);
   });
 
   it('should resolve a template with additional config', () => {
@@ -476,17 +450,16 @@ describe('tgpu resolveWithContext', () => {
       config: (cfg) => cfg.pipe(configSpy),
     });
 
-    expect(parse(code)).toBe(
-      parse(`
-          struct Voxel {
-            position: vec3f,
-            color: vec4f,
-          }
-          fn getVoxelColor(voxel: Voxel) -> vec4f {
-            return voxel.color;
-          }
-        `),
-    );
+    expect(code).toMatchInlineSnapshot(`
+      "struct Voxel {
+        position: vec3f,
+        color: vec4f,
+      }
+                fn getVoxelColor(voxel: Voxel) -> vec4f {
+                  return voxel.color;
+                }
+              "
+    `);
 
     // verify resolveWithContext::config impl is being called
     expect(configSpy.mock.lastCall?.[0]).toBeDefined();
@@ -513,17 +486,16 @@ describe('tgpu resolveWithContext', () => {
       config: (cfg) => cfg.with(colorSlot, v).pipe(configSpy),
     });
 
-    expect(parse(code)).toBe(
-      parse(`
-          struct Voxel {
-            position: vec3f,
-            color: vec4f,
-          }
-          fn getVoxelColor(voxel: Voxel) -> vec4f {
-            return voxel.color * vec4f(1, 0, 1, 0);
-          }
-        `),
-    );
+    expect(code).toMatchInlineSnapshot(`
+      "struct Voxel {
+        position: vec3f,
+        color: vec4f,
+      }
+                fn getVoxelColor(voxel: Voxel) -> vec4f {
+                  return voxel.color * vec4f(1, 0, 1, 0);
+                }
+              "
+    `);
     // verify resolveWithContext::config impl is actually working
     expect(configSpy.mock.lastCall?.[0].bindings).toEqual(
       [[colorSlot, v]],

--- a/packages/typegpu/tests/std/matrix/rotate.test.ts
+++ b/packages/typegpu/tests/std/matrix/rotate.test.ts
@@ -3,7 +3,7 @@ import { mat4x4f, vec4f } from '../../../src/data/index.ts';
 import tgpu from '../../../src/index.ts';
 import { isCloseTo, mul } from '../../../src/std/index.ts';
 import { rotateX4, rotateY4, rotateZ4 } from '../../../src/std/matrix.ts';
-import { parse, parseResolved } from '../../utils/parseResolved.ts';
+import { asWgsl } from '../../utils/parseResolved.ts';
 
 describe('rotate', () => {
   it('generates correct WGSL for rotateX4 with custom matrix', () => {
@@ -14,17 +14,12 @@ describe('rotate', () => {
       const resultExpression = rotateX4(M, angle);
     });
 
-    expect(parseResolved({ rotateFn })).toBe(
-      parse(
-        `fn rotateFn() {
-          var angle = 4;
-          var resultExpression = (
-            mat4x4f(1, 0, 0, 0, 0, cos(angle), sin(angle), 0, 0, -sin(angle), cos(angle), 0, 0, 0, 0, 1) *
-            mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1)
-          );
-        }`,
-      ),
-    );
+    expect(asWgsl(rotateFn)).toMatchInlineSnapshot(`
+      "fn rotateFn() {
+        var angle = 4;
+        var resultExpression = (mat4x4f(1, 0, 0, 0, 0, cos(angle), sin(angle), 0, 0, -sin(angle), cos(angle), 0, 0, 0, 0, 1) * mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1));
+      }"
+    `);
   });
 
   it('generates correct WGSL for rotateY4 with custom matrix', () => {
@@ -35,17 +30,12 @@ describe('rotate', () => {
       const resultExpression = rotateY4(M, angle);
     });
 
-    expect(parseResolved({ rotateFn })).toBe(
-      parse(
-        `fn rotateFn() {
-          var angle = 4;
-          var resultExpression = (
-            mat4x4f(cos(angle), 0, -sin(angle), 0, 0, 1, 0, 0, sin(angle), 0, cos(angle), 0, 0, 0, 0, 1) *
-            mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1)
-          );
-        }`,
-      ),
-    );
+    expect(asWgsl(rotateFn)).toMatchInlineSnapshot(`
+      "fn rotateFn() {
+        var angle = 4;
+        var resultExpression = (mat4x4f(cos(angle), 0, -sin(angle), 0, 0, 1, 0, 0, sin(angle), 0, cos(angle), 0, 0, 0, 0, 1) * mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1));
+      }"
+    `);
   });
 
   it('generates correct WGSL for rotateZ4 with custom matrix', () => {
@@ -56,17 +46,12 @@ describe('rotate', () => {
       const resultExpression = rotateZ4(M, angle);
     });
 
-    expect(parseResolved({ rotateFn })).toBe(
-      parse(
-        `fn rotateFn() {
-          var angle = 4;
-          var resultExpression = (
-            mat4x4f(cos(angle), sin(angle), 0, 0, -sin(angle), cos(angle), 0, 0, 0, 0, 1, 0, 0, 0, 0, 1) *
-            mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1)
-          );
-        }`,
-      ),
-    );
+    expect(asWgsl(rotateFn)).toMatchInlineSnapshot(`
+      "fn rotateFn() {
+        var angle = 4;
+        var resultExpression = (mat4x4f(cos(angle), sin(angle), 0, 0, -sin(angle), cos(angle), 0, 0, 0, 0, 1, 0, 0, 0, 0, 1) * mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1));
+      }"
+    `);
   });
 
   it('rotates around X correctly', () => {

--- a/packages/typegpu/tests/std/matrix/scale.test.ts
+++ b/packages/typegpu/tests/std/matrix/scale.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { mat4x4f, vec3f, vec4f } from '../../../src/data/index.ts';
 import tgpu from '../../../src/index.ts';
 import { isCloseTo, mul, scale4, translate4 } from '../../../src/std/index.ts';
-import { parse, parseResolved } from '../../utils/parseResolved.ts';
+import { asWgsl } from '../../utils/parseResolved.ts';
 
 describe('scale', () => {
   it('scales a matrix by a vec3f vector', () => {
@@ -22,16 +22,11 @@ describe('scale', () => {
       const resultExpression = scale4(M, T);
     });
 
-    expect(parseResolved({ scaleFn })).toBe(
-      parse(
-        `fn scaleFn() {
-          var resultExpression = (
-            mat4x4f(vec3f(2, 2, 4).x, 0, 0, 0, 0, vec3f(2, 2, 4).y, 0, 0, 0, 0, vec3f(2, 2, 4).z, 0, 0, 0, 0, 1) *
-            mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1)
-          );
-        }`,
-      ),
-    );
+    expect(asWgsl(scaleFn)).toMatchInlineSnapshot(`
+      "fn scaleFn() {
+        var resultExpression = (mat4x4f(vec3f(2, 2, 4).x, 0, 0, 0, 0, vec3f(2, 2, 4).y, 0, 0, 0, 0, vec3f(2, 2, 4).z, 0, 0, 0, 0, 1) * mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1));
+      }"
+    `);
   });
 
   it('scales correctly', () => {

--- a/packages/typegpu/tests/std/matrix/translate.test.ts
+++ b/packages/typegpu/tests/std/matrix/translate.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { mat4x4f, vec3f, vec4f } from '../../../src/data/index.ts';
 import tgpu from '../../../src/index.ts';
 import { isCloseTo, mul, scale4, translate4 } from '../../../src/std/index.ts';
-import { parse, parseResolved } from '../../utils/parseResolved.ts';
+import { asWgsl } from '../../utils/parseResolved.ts';
 
 describe('translate', () => {
   it('translates a matrix by a vec3f vector', () => {
@@ -22,16 +22,11 @@ describe('translate', () => {
       const resultExpression = translate4(M, T);
     });
 
-    expect(parseResolved({ translateFn })).toBe(
-      parse(
-        `fn translateFn() { 
-          var resultExpression = (
-            mat4x4f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, vec3f(2, 2, 4).x, vec3f(2, 2, 4).y, vec3f(2, 2, 4).z, 1) *
-            mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1)
-          ); 
-        }`,
-      ),
-    );
+    expect(asWgsl(translateFn)).toMatchInlineSnapshot(`
+      "fn translateFn() {
+        var resultExpression = (mat4x4f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, vec3f(2, 2, 4).x, vec3f(2, 2, 4).y, vec3f(2, 2, 4).z, 1) * mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1));
+      }"
+    `);
   });
 
   it('translates correctly', () => {

--- a/packages/typegpu/tests/std/numeric/mod.test.ts
+++ b/packages/typegpu/tests/std/numeric/mod.test.ts
@@ -30,7 +30,7 @@ import type {
 import { isCloseTo, mod } from '../../../src/std/index.ts';
 import tgpu from '../../../src/index.ts';
 import * as d from '../../../src/data/index.ts';
-import { parseResolved } from '../../utils/parseResolved.ts';
+import { asWgsl } from '../../utils/parseResolved.ts';
 
 describe('mod', () => {
   it('computes modulo of a number and a number', () => {
@@ -331,17 +331,21 @@ describe('mod parseResolved test', () => {
       return mod(a, b);
     });
 
-    expect(parseResolved({ modFunction })).toMatchInlineSnapshot(
-      `"fn modFunction ( a : vec2f , b : vec2f ) -> vec2f { return ( a % b ) ; }"`,
-    );
+    expect(asWgsl(modFunction)).toMatchInlineSnapshot(`
+      "fn modFunction(a: vec2f, b: vec2f) -> vec2f {
+        return (a % b);
+      }"
+    `);
   });
 
   it('resolves scalar-vector mod operation to WGSL correctly', () => {
     const modScalarVec = tgpu.fn([d.f32, d.vec3f], d.vec3f)((scalar, vec) => {
       return mod(scalar, vec);
     });
-    expect(parseResolved({ modScalarVec })).toMatchInlineSnapshot(
-      `"fn modScalarVec ( scalar : f32 , vec : vec3f ) -> vec3f { return ( scalar % vec ) ; }"`,
-    );
+    expect(asWgsl(modScalarVec)).toMatchInlineSnapshot(`
+      "fn modScalarVec(scalar: f32, vec: vec3f) -> vec3f {
+        return (scalar % vec);
+      }"
+    `);
   });
 });

--- a/packages/typegpu/tests/struct.test.ts
+++ b/packages/typegpu/tests/struct.test.ts
@@ -20,7 +20,7 @@ import {
 } from '../src/data/index.ts';
 import tgpu from '../src/index.ts';
 import type { Infer } from '../src/shared/repr.ts';
-import { parse, parseResolved } from './utils/parseResolved.ts';
+import { asWgsl } from './utils/parseResolved.ts';
 import { frexp } from '../src/std/numeric.ts';
 
 describe('struct', () => {
@@ -309,20 +309,20 @@ describe('struct', () => {
       const defaultValue = Outer();
     });
 
-    expect(parseResolved({ testFunction })).toBe(parse(`
-          struct Nested {
-            prop1: vec2f,
-            prop2: u32,
-          }
+    expect(asWgsl(testFunction)).toMatchInlineSnapshot(`
+      "struct Nested {
+        prop1: vec2f,
+        prop2: u32,
+      }
 
-          struct Outer {
-            nested: Nested,
-          }
+      struct Outer {
+        nested: Nested,
+      }
 
-          fn testFunction() {
-            var defaultValue = Outer();
-          }
-        `));
+      fn testFunction() {
+        var defaultValue = Outer();
+      }"
+    `);
   });
 
   it('generates correct code when struct clone is used', () => {
@@ -337,19 +337,18 @@ describe('struct', () => {
       return;
     });
 
-    expect(parseResolved({ testFn })).toBe(
-      parse(`
-        struct TestStruct {
-          x: u32,
-          y: f32,
-        }
+    expect(asWgsl(testFn)).toMatchInlineSnapshot(`
+      "struct TestStruct {
+        x: u32,
+        y: f32,
+      }
 
-        fn testFn() {
-          var myStruct = TestStruct(1, 2);
-          var myClone = myStruct;
-          return;
-        }`),
-    );
+      fn testFn() {
+        var myStruct = TestStruct(1, 2);
+        var myClone = myStruct;
+        return;
+      }"
+    `);
   });
 
   it('generates correct code when complex struct clone is used', () => {
@@ -364,19 +363,18 @@ describe('struct', () => {
       return;
     });
 
-    expect(parseResolved({ testFn })).toBe(
-      parse(`
-        struct TestStruct {
-          x: u32,
-          y: f32,
-        }
+    expect(asWgsl(testFn)).toMatchInlineSnapshot(`
+      "struct TestStruct {
+        x: u32,
+        y: f32,
+      }
 
-        fn testFn() {
-          var myStructs = array<TestStruct, 1>(TestStruct(1, 2));
-          var myClone = myStructs[0];
-          return;
-        }`),
-    );
+      fn testFn() {
+        var myStructs = array<TestStruct, 1>(TestStruct(1, 2));
+        var myClone = myStructs[0];
+        return;
+      }"
+    `);
   });
 });
 
@@ -388,12 +386,11 @@ describe('abstruct', () => {
       return result.exp;
     });
 
-    expect(parseResolved({ testFn })).toBe(
-      parse(`
-        fn testFn(x: f32) -> f32 {
-          var result = frexp(x);
-          return f32(result.exp);
-        }`),
-    );
+    expect(asWgsl(testFn)).toMatchInlineSnapshot(`
+      "fn testFn(x: f32) -> f32 {
+        var result = frexp(x);
+        return f32(result.exp);
+      }"
+    `);
   });
 });

--- a/packages/typegpu/tests/tgsl/codeGen.test.ts
+++ b/packages/typegpu/tests/tgsl/codeGen.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from 'vitest';
 import { it } from '../utils/extendedIt.ts';
-import { parse, parseResolved } from '../utils/parseResolved.ts';
+import { asWgsl } from '../utils/parseResolved.ts';
 
 // Library entrypoints
 import { tgpu } from '../../src/index.ts';
@@ -14,9 +14,11 @@ describe('codeGen', () => {
         return size.x * size.y * size.z;
       });
 
-      expect(parseResolved({ main })).toBe(
-        parse('fn main() -> f32 { return 6; }'),
-      );
+      expect(asWgsl(main)).toMatchInlineSnapshot(`
+        "fn main() -> f32 {
+          return 6;
+        }"
+      `);
     });
 
     it('handles member access for local vectors', () => {
@@ -25,12 +27,12 @@ describe('codeGen', () => {
         return size.x * size.y * size.z;
       });
 
-      expect(parseResolved({ main })).toBe(parse(`
-        fn main() -> f32 {
+      expect(asWgsl(main)).toMatchInlineSnapshot(`
+        "fn main() -> f32 {
           var size = vec3f(1, 2, 3);
           return ((size.x * size.y) * size.z);
-        }
-      `));
+        }"
+      `);
     });
   });
 });

--- a/packages/typegpu/tests/tgsl/infixOperators.test.ts
+++ b/packages/typegpu/tests/tgsl/infixOperators.test.ts
@@ -2,7 +2,7 @@ import { describe, expect } from 'vitest';
 import * as d from '../../src/data/index.ts';
 import tgpu from '../../src/index.ts';
 import { it } from '../utils/extendedIt.ts';
-import { parse, parseResolved } from '../utils/parseResolved.ts';
+import { asWgsl } from '../utils/parseResolved.ts';
 
 describe('wgslGenerator', () => {
   it('resolves add infix operator', () => {
@@ -14,16 +14,15 @@ describe('wgslGenerator', () => {
       const m2 = d.mat3x3f().add(d.mat3x3f()).add(d.mat3x3f());
     });
 
-    expect(parseResolved({ testFn })).toEqual(
-      parse(`
-      fn testFn() {
+    expect(asWgsl(testFn)).toMatchInlineSnapshot(`
+      "fn testFn() {
         var v1 = vec4f(1);
         var v2 = vec3f(3, 4, 5);
         var v3 = vec2f(6);
         var m1 = (mat2x2f() + mat2x2f());
         var m2 = ((mat3x3f() + mat3x3f()) + mat3x3f());
-      }`),
-    );
+      }"
+    `);
   });
 
   it('resolves sub infix operator', () => {
@@ -35,16 +34,15 @@ describe('wgslGenerator', () => {
       const m2 = d.mat3x3f().sub(d.mat3x3f()).sub(d.mat3x3f());
     });
 
-    expect(parseResolved({ testFn })).toEqual(
-      parse(`
-      fn testFn() {
+    expect(asWgsl(testFn)).toMatchInlineSnapshot(`
+      "fn testFn() {
         var v1 = vec4f(-1);
         var v2 = vec3f(-1, -2, -3);
         var v3 = vec2f();
         var m1 = (mat2x2f() - mat2x2f());
         var m2 = ((mat3x3f() - mat3x3f()) - mat3x3f());
-      }`),
-    );
+      }"
+    `);
   });
 
   it('resolves mul infix operator', () => {
@@ -60,20 +58,18 @@ describe('wgslGenerator', () => {
       const m4 = d.mat2x2f().mul(d.mat2x2f()).mul(1);
     });
 
-    expect(parseResolved({ testFn })).toEqual(
-      parse(`
-      fn testFn() {
+    expect(asWgsl(testFn)).toMatchInlineSnapshot(`
+      "fn testFn() {
         var v1 = vec2f(6);
         var v2 = vec3f(4, 6, 8);
         var v3 = (vec4f() * mat4x4f());
         var v4 = ((vec3f() * mat3x3f()) * 1);
-
         var m1 = (mat2x2f() * 1);
         var m2 = (mat3x3f() * vec3f());
         var m3 = (mat4x4f() * mat4x4f());
         var m4 = ((mat2x2f() * mat2x2f()) * 1);
-      }`),
-    );
+      }"
+    `);
   });
 
   it('resolves mul infix operator on a function return value', () => {
@@ -87,16 +83,15 @@ describe('wgslGenerator', () => {
       const v1 = getVec().mul(getVec());
     });
 
-    expect(parseResolved({ testFn })).toEqual(
-      parse(`
-      fn getVec() -> vec3f {
+    expect(asWgsl(testFn)).toMatchInlineSnapshot(`
+      "fn getVec() -> vec3f {
         return vec3f(1, 2, 3);
       }
 
       fn testFn() {
         var v1 = (getVec() * getVec());
-      }`),
-    );
+      }"
+    `);
   });
 
   it('resolves mul infix operator on a struct property', () => {
@@ -108,17 +103,16 @@ describe('wgslGenerator', () => {
       const v1 = s.vec.mul(s.vec);
     });
 
-    expect(parseResolved({ testFn })).toEqual(
-      parse(`
-      struct Struct {
+    expect(asWgsl(testFn)).toMatchInlineSnapshot(`
+      "struct Struct {
         vec: vec3f,
       }
 
       fn testFn() {
         var s = Struct(vec3f());
         var v1 = (s.vec * s.vec);
-      }`),
-    );
+      }"
+    `);
   });
 
   it('resolves div infix operator', () => {
@@ -128,14 +122,13 @@ describe('wgslGenerator', () => {
       const v3 = d.vec2f(1).div(d.vec2f(2)).div(2);
     });
 
-    expect(parseResolved({ testFn })).toEqual(
-      parse(`
-      fn testFn() {
+    expect(asWgsl(testFn)).toMatchInlineSnapshot(`
+      "fn testFn() {
         var v1 = vec4f(0.5);
         var v2 = vec3f(6, 3, 2);
         var v3 = vec2f(0.25);
-      }`),
-    );
+      }"
+    `);
   });
 
   it('resolves add infix operator on uniform vector', ({ root }) => {
@@ -148,17 +141,17 @@ describe('wgslGenerator', () => {
       const v3 = fooUniform.$.add(barUniform.$);
     });
 
-    expect(parseResolved({ testFn })).toEqual(
-      parse(`
-      @group(0) @binding(0) var<uniform> fooUniform: vec3f;
+    expect(asWgsl(testFn)).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<uniform> fooUniform: vec3f;
+
       @group(0) @binding(1) var<uniform> barUniform: vec3f;
 
       fn testFn() {
         var v1 = (fooUniform + 2);
         var v2 = (vec3f(1, 2, 3) + barUniform);
         var v3 = (fooUniform + barUniform);
-      }`),
-    );
+      }"
+    `);
   });
 
   it('precomputes adds on known values', () => {
@@ -167,12 +160,11 @@ describe('wgslGenerator', () => {
       const v2 = d.vec3f(1, 2, 3).add(d.vec3f(3, 2, 1));
     });
 
-    expect(parseResolved({ testFn })).toEqual(
-      parse(`
-      fn testFn() {
+    expect(asWgsl(testFn)).toMatchInlineSnapshot(`
+      "fn testFn() {
         var v1 = vec3f(6, 7, 8);
         var v2 = vec3f(4);
-      }`),
-    );
+      }"
+    `);
   });
 });

--- a/packages/typegpu/tests/utils/parseResolved.ts
+++ b/packages/typegpu/tests/utils/parseResolved.ts
@@ -1,6 +1,4 @@
 import type * as tinyest from 'tinyest';
-import { WeslStream } from 'wesl';
-import type { TgpuResolveOptions } from '../../src/core/resolve/tgpuResolve.ts';
 import tgpu from '../../src/index.ts';
 import { type Assertion, expect } from 'vitest';
 import type { AnyData } from '../../src/data/index.ts';
@@ -11,41 +9,6 @@ import { CodegenState, type Wgsl } from '../../src/types.ts';
 import { getMetaData } from '../../src/shared/meta.ts';
 import wgslGenerator from '../../src/tgsl/wgslGenerator.ts';
 import { namespace } from '../../src/core/resolve/namespace.ts';
-
-export function parse(code: string): string {
-  const stream = new WeslStream(code);
-  const firstToken = stream.nextToken();
-  if (firstToken === null) {
-    return '';
-  }
-
-  let result = firstToken.text;
-  let token = stream.nextToken();
-  while (token !== null) {
-    result += ` ${token.text}`;
-    token = stream.nextToken();
-  }
-  return result;
-}
-
-export function parseResolved(
-  resolvable: TgpuResolveOptions['externals'],
-): string {
-  const resolved = tgpu.resolve({
-    externals: resolvable,
-    names: 'strict',
-  });
-
-  try {
-    return parse(resolved);
-  } catch (e) {
-    throw new Error(
-      `Failed to parse the following: \n${resolved}\n\nCause:${
-        String(e).substring(0, 128)
-      }`,
-    );
-  }
-}
 
 /**
  * Just a shorthand for tgpu.resolve

--- a/packages/typegpu/tests/vector.test.ts
+++ b/packages/typegpu/tests/vector.test.ts
@@ -4,7 +4,7 @@ import { readData, writeData } from '../src/data/dataIO.ts';
 import * as d from '../src/data/index.ts';
 import { sizeOf } from '../src/data/sizeOf.ts';
 import tgpu from '../src/index.ts';
-import { asWgsl, parse, parseResolved } from './utils/parseResolved.ts';
+import { asWgsl } from './utils/parseResolved.ts';
 
 describe('constructors', () => {
   it('casts floats to signed integers', () => {
@@ -833,17 +833,14 @@ describe('v3f', () => {
         const three = d.vec3f(d.vec2f(1, 2), 12); // literal
       });
 
-      expect(parseResolved({ main })).toBe(
-        parse(`
-          fn main() {
-            var planarPosLocal = vec2f(1, 2);
-
-            var one = vec3f(1, 2, 12);
-            var two = vec3f(planarPosLocal, 12);
-            var three = vec3f(1, 2, 12);
-          }
-        `),
-      );
+      expect(asWgsl(main)).toMatchInlineSnapshot(`
+        "fn main() {
+          var planarPosLocal = vec2f(1, 2);
+          var one = vec3f(1, 2, 12);
+          var two = vec3f(planarPosLocal, 12);
+          var three = vec3f(1, 2, 12);
+        }"
+      `);
     });
   });
 
@@ -883,17 +880,14 @@ describe('v4f', () => {
         const three = d.vec4f(d.vec3f(0, 0, 1), 1); // literal
       });
 
-      expect(parseResolved({ main })).toBe(
-        parse(`
-          fn main() {
-            var green = vec3f(0, 1, 0);
-
-            var one = vec4f(0.125, 0.25, 0.375, 1);
-            var two = vec4f(green, 1);
-            var three = vec4f(0, 0, 1, 1);
-          }
-        `),
-      );
+      expect(asWgsl(main)).toMatchInlineSnapshot(`
+        "fn main() {
+          var green = vec3f(0, 1, 0);
+          var one = vec4f(0.125, 0.25, 0.375, 1);
+          var two = vec4f(green, 1);
+          var three = vec4f(0, 0, 1, 1);
+        }"
+      `);
     });
   });
 
@@ -915,17 +909,14 @@ describe('v4f', () => {
         const three = d.vec4f(0.125, d.vec3f(0.25, 0.5, 0.75)); // literal
       });
 
-      expect(parseResolved({ main })).toBe(
-        parse(`
-        fn main() {
+      expect(asWgsl(main)).toMatchInlineSnapshot(`
+        "fn main() {
           var fooLocal = vec3f(0.25, 0.5, 0.75);
-
           var one = vec4f(0.25, 0.25, 0.5, 0.75);
           var two = vec4f(0.1, fooLocal);
           var three = vec4f(0.125, 0.25, 0.5, 0.75);
-        }
-      `),
-      );
+        }"
+      `);
     });
   });
 
@@ -935,11 +926,11 @@ describe('v4f', () => {
         return d.vec4f(1, 2, 3, 4).zyx;
       });
 
-      expect(parseResolved({ foo })).toEqual(parse(`
-        fn foo() -> vec3f {
+      expect(asWgsl(foo)).toMatchInlineSnapshot(`
+        "fn foo() -> vec3f {
           return vec3f(3, 2, 1);
-        }
-      `));
+        }"
+      `);
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,9 +466,6 @@ importers:
       unplugin-typegpu:
         specifier: workspace:*
         version: link:../unplugin-typegpu
-      wesl:
-        specifier: 0.6.7
-        version: 0.6.7
       wgpu-matrix:
         specifier: catalog:example
         version: 3.4.0
@@ -4596,9 +4593,6 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  mini-parse@0.6.7:
-    resolution: {integrity: sha512-rxyTgJNp4GwmE0JGFx8DKLuJfdiMV7TRP/aonobpIdL0Fp4RxkEX16A/rFpGhD5B3UzEYJZ7S8EtbQbdJPWQew==}
-
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
     engines: {node: 20 || >=22}
@@ -6281,9 +6275,6 @@ packages:
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
-
-  wesl@0.6.7:
-    resolution: {integrity: sha512-/T8KvIscZZnya1Xa6RoGM4RicgGNFrUIOzubz95Sz2ZhTJmJrV+jsdQNqvH3nBghR3yCIvA/H32GOjG1HG8XKA==}
 
   wgpu-matrix@3.4.0:
     resolution: {integrity: sha512-kXHrbAPKEn9A32Wf4wVldyx9MmnzwhuB5p8GCqoJP3ItU5+iDT4J3aTQwPZWkfb153hwGtqZtUwR2M+ipJKadg==}
@@ -10924,8 +10915,6 @@ snapshots:
   mimic-response@3.1.0:
     optional: true
 
-  mini-parse@0.6.7: {}
-
   minimatch@10.0.3:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
@@ -12767,10 +12756,6 @@ snapshots:
   webidl-conversions@8.0.0: {}
 
   webpack-virtual-modules@0.6.2: {}
-
-  wesl@0.6.7:
-    dependencies:
-      mini-parse: 0.6.7
 
   wgpu-matrix@3.4.0: {}
 


### PR DESCRIPTION
Why?
- Easier to update expected output when a part of how shaders are generated changes
- We can track the visual quality of the produced WGSL code