### PR TITLE
fix: Big int handling

### DIFF
--- a/packages/typegpu-color/src/oklab.ts
+++ b/packages/typegpu-color/src/oklab.ts
@@ -170,7 +170,7 @@ const findGamutIntersection = tgpu.fn(
   [f32, f32, f32, f32, f32, LC],
   f32,
 )((a, b, L1, C1, L0, cusp) => {
-  const FLT_MAX = f32(3.40282346e38);
+  const FLT_MAX = 3.40282346e38;
 
   // Find the intersection for upper and lower half separately
   let t = f32(0);

--- a/packages/typegpu/src/tgsl/generationHelpers.ts
+++ b/packages/typegpu/src/tgsl/generationHelpers.ts
@@ -168,6 +168,9 @@ export function getTypeForIndexAccess(
 }
 
 export function numericLiteralToSnippet(value: number): Snippet {
+  if (Math.abs(value) >= 2 ** 63) {
+    return snip(value, abstractFloat);
+  }
   // WGSL AbstractInt uses 64-bit precision, but JS numbers are only safe up to 2^53 - 1.
   // Warn when values exceed this range to prevent precision loss.
   if (Number.isInteger(value)) {

--- a/packages/typegpu/tests/examples/individual/oklab.test.ts
+++ b/packages/typegpu/tests/examples/individual/oklab.test.ts
@@ -136,7 +136,7 @@ describe('oklab example', () => {
       }
 
       fn findGamutIntersection_13(a: f32, b: f32, L1: f32, C1: f32, L0: f32, cusp: LC_12) -> f32 {
-        var FLT_MAX = 3.4028234663852886e+38f;
+        var FLT_MAX = 3.40282346e+38;
         var t = 0f;
         if (((((L1 - L0) * cusp.C) - ((cusp.L - L0) * C1)) <= 0)) {
           t = ((cusp.C * L0) / ((C1 * cusp.L) + (cusp.C * (L0 - L1))));


### PR DESCRIPTION
Now the following does not warn, and the cast is unnecessary.
`const FLT_MAX = f32(3.40282346e38);`
