### PR TITLE
docs: Keeping the popup's open state in the hash of the url

### DIFF
--- a/apps/typegpu-docs/src/components/shaderhunt/ChallengesSignupPopover.astro
+++ b/apps/typegpu-docs/src/components/shaderhunt/ChallengesSignupPopover.astro
@@ -47,10 +47,9 @@
       dialogElement?.showModal();
      });
 
-    // Handle dialog close to go back in history
     dialogElement.addEventListener('close', () => {
       if (window.location.hash === '#challenges-signup') {
-        history.back();
+        window.location.hash = '';
       }
     });
 


### PR DESCRIPTION
It's something the marketing team asked for so we can link directly to the pop-over