### PR TITLE
docs: Lazy load thumbnails to improve load time

### DIFF
--- a/apps/typegpu-docs/src/components/ExampleCard.tsx
+++ b/apps/typegpu-docs/src/components/ExampleCard.tsx
@@ -20,6 +20,7 @@ export function ExampleCard({ example }: { example: Example }) {
                 src={example.thumbnails.large}
                 alt={example.metadata.title}
                 className='h-full w-full object-cover'
+                loading='lazy'
               />
             </picture>
           )


### PR DESCRIPTION
Before and after (with preset fast 4G throttling)

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <video src="https://github.com/user-attachments/assets/a7af41df-e285-4828-9bd7-22ae9dd824ef" controls muted width="300"></video>
      </td>
      <td>
        <video src="https://github.com/user-attachments/assets/a0a8f594-923b-4da8-bfcc-c9b92cd25d76" controls muted width="300"></video>
      </td>
    </tr>
  </tbody>
</table>
