### PR TITLE
impr: Use a more widely supported image source in Jelly Slider number atlas

### DIFF
--- a/apps/typegpu-docs/src/examples/rendering/jelly-slider/numbers.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-slider/numbers.ts
@@ -44,7 +44,7 @@ export class NumberProvider {
     ctx.textBaseline = 'middle';
     ctx.fillStyle = 'white';
 
-    const percentageImages = [];
+    const percentageImages: ImageBitmap[] = [];
 
     for (let i = 0; i <= 100; i++) {
       ctx.clearRect(0, 0, PERCENTAGE_WIDTH, PERCENTAGE_HEIGHT);
@@ -58,9 +58,8 @@ export class NumberProvider {
       ctx.font = percentageFont;
       ctx.fillText(`%`, x, y + 10);
 
-      percentageImages.push(
-        ctx.getImageData(0, 0, PERCENTAGE_WIDTH, PERCENTAGE_HEIGHT),
-      );
+      const bitmap = await createImageBitmap(canvas);
+      percentageImages.push(bitmap);
     }
 
     this.digitTextureAtlas.write(percentageImages);


### PR DESCRIPTION
The `texture.write()` API uses `copyExternalImageToTexture` under the hood. Up until now we were passing `ImageData` into it which is actually not supported in all browsers like Mozilla (Safari seems to support it even tho MDN claims it does not). This PR moves to a more compatible approach using `createImageBitmap` and passing `ImageBitmap` instead.

<img width="766" height="327" alt="image" src="https://github.com/user-attachments/assets/5290c273-f8e4-41d8-9248-7661a118f38b" />

[Source](https://developer.mozilla.org/en-US/docs/Web/API/GPUQueue/copyExternalImageToTexture#browser_compatibility)
