### PR TITLE
fix: Keyboard popping up in docs on mobile

### DIFF
--- a/apps/typegpu-docs/src/components/CodeEditor.tsx
+++ b/apps/typegpu-docs/src/components/CodeEditor.tsx
@@ -85,6 +85,7 @@ const createCodeEditorComponent = (
             enabled: false,
           },
           readOnly: true,
+          domReadOnly: true,
         }}
       />
     </div>


### PR DESCRIPTION
This is the issue:

https://github.com/user-attachments/assets/16bc3da8-5429-4c8e-b106-31987d2a69bb

I'm not sure about this solution, as now the following message is gone.

<img width="499" height="117" alt="Screenshot 2025-12-22 at 14 17 58" src="https://github.com/user-attachments/assets/55d33a80-ad9e-410e-9886-3b9481a603d3" />
