### PR TITLE
fix(@typegpu/three): Let Three.js infer type of new THREE.Color() passed into t3.uniform()

### DIFF
--- a/packages/typegpu-three/src/uniform.ts
+++ b/packages/typegpu-three/src/uniform.ts
@@ -3,7 +3,13 @@ import {
   uniform as uniformImpl,
   uniformArray as uniformArrayImpl,
 } from 'three/tsl';
-import type { Node, TSL, UniformArrayNode, UniformNode } from 'three/webgpu';
+import type {
+  Color,
+  Node,
+  TSL,
+  UniformArrayNode,
+  UniformNode,
+} from 'three/webgpu';
 import * as d from 'typegpu/data';
 import { wgslTypeToGlslType } from './common.ts';
 import { fromTSL, type TSLAccessor } from './typegpu-node.ts';
@@ -28,7 +34,7 @@ export function uniform<TValue, TDataType extends d.AnyWgslData>(
   let glslType: string | undefined =
     wgslTypeToGlslType[dataType.type as keyof typeof wgslTypeToGlslType];
 
-  if ((value as TSL.NodeObject<Node>).isNode) {
+  if ((value as TSL.NodeObject<Node>).isNode || (value as Color).isColor) {
     // The type sometimes interferes with the node's inherent type
     glslType = undefined;
   }


### PR DESCRIPTION
This makes `t3.uniform(new THREE.Color('white'), d.vec3f)` work.