### PR TITLE
feat: Better snippet origin tracking

### DIFF
--- a/packages/typegpu/tests/bufferUsage.test.ts
+++ b/packages/typegpu/tests/bufferUsage.test.ts
@@ -88,6 +88,22 @@ describe('TgpuBufferUniform', () => {
         .as('uniform')
     ).toThrow();
   });
+
+  it('cannot be mutated', ({ root }) => {
+    const Boid = d.struct({
+      pos: d.vec3f,
+      vel: d.vec3u,
+    });
+
+    const boidUniform = root.createUniform(Boid);
+
+    const main = () => {
+      'use gpu';
+      boidUniform.$.pos.x += 1;
+    };
+
+    expect(() => tgpu.resolve([main])).toThrowErrorMatchingInlineSnapshot();
+  });
 });
 
 describe('TgpuBufferMutable', () => {

--- a/packages/typegpu/tests/constant.test.ts
+++ b/packages/typegpu/tests/constant.test.ts
@@ -121,49 +121,4 @@ describe('tgpu.const', () => {
       }"
     `);
   });
-
-  it('cannot be passed directly to shellless functions', () => {
-    const fn1 = (v: d.v3f) => {
-      'use gpu';
-      return v.x * v.y * v.z;
-    };
-
-    const foo = tgpu.const(d.vec3f, d.vec3f(1, 2, 3));
-    const fn2 = () => {
-      'use gpu';
-      return fn1(foo.$);
-    };
-
-    expect(() => tgpu.resolve([fn2])).toThrowErrorMatchingInlineSnapshot(`
-      [Error: Resolution of the following tree failed:
-      - <root>
-      - fn*:fn2
-      - fn*:fn2(): Cannot pass constant references as function arguments. Explicitly copy them by wrapping them in a schema: 'vec3f(...)']
-    `);
-  });
-
-  it('cannot be mutated', () => {
-    const boid = tgpu.const(Boid, {
-      pos: d.vec3f(1, 2, 3),
-      vel: d.vec3u(4, 5, 6),
-    });
-
-    const fn = () => {
-      'use gpu';
-      // @ts-expect-error: Cannot assign to read-only property
-      boid.$.pos = d.vec3f(0, 0, 0);
-    };
-
-    expect(() => tgpu.resolve([fn])).toThrowErrorMatchingInlineSnapshot(`
-      [Error: Resolution of the following tree failed:
-      - <root>
-      - fn*:fn
-      - fn*:fn(): 'boid.pos = vec3f()' is invalid, because boid.pos is a constant.]
-    `);
-
-    // Since we freeze the object, we cannot mutate when running the function in JS either
-    expect(() => fn()).toThrowErrorMatchingInlineSnapshot(
-      `[TypeError: Cannot assign to read only property 'pos' of object '#<Object>']`,
-    );
-  });
 });

--- a/packages/typegpu/tests/utils/parseResolved.ts
+++ b/packages/typegpu/tests/utils/parseResolved.ts
@@ -12,9 +12,7 @@ import { $internal } from '../../src/shared/symbols.ts';
 import { CodegenState } from '../../src/types.ts';
 
 function extractSnippetFromFn(cb: () => unknown): Snippet {
-  const ctx = new ResolutionCtxImpl({
-    namespace: namespace({ names: 'strict' }),
-  });
+  const ctx = new ResolutionCtxImpl({ namespace: namespace() });
 
   return provideCtx(
     ctx,


### PR DESCRIPTION
Changes:
- Not all arguments are automatically considered ephemeral, meaning unnecessary branching is no longer required.
- `blockVariable` is only responsible for generating the variable definition code (easily swappable with a different shader generator)