### PR TITLE
fix: Jelly Switch onCleanup Fix

### DIFF
--- a/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.ts
@@ -584,6 +584,7 @@ function createBindGroups() {
 
 let bindGroups = createBindGroups();
 
+let animationFrameHandle: number;
 function render(timestamp: number) {
   frameCount++;
   camera.jitter();
@@ -621,7 +622,7 @@ function render(timestamp: number) {
     .with(bindGroups.render[currentFrame])
     .draw(3);
 
-  requestAnimationFrame(render);
+  animationFrameHandle = requestAnimationFrame(render);
 }
 
 function handleResize() {
@@ -643,7 +644,7 @@ const resizeObserver = new ResizeObserver(() => {
 });
 resizeObserver.observe(canvas);
 
-requestAnimationFrame(render);
+animationFrameHandle = requestAnimationFrame(render);
 
 // #region Example controls and cleanup
 
@@ -785,6 +786,7 @@ export const controls = {
 };
 
 export function onCleanup() {
+  cancelAnimationFrame(animationFrameHandle);
   resizeObserver.disconnect();
   root.destroy();
 }


### PR DESCRIPTION
Jelly Switch didn't clean all of its resources properly, thus resulting in gpu crash on some devices