### PR TITLE
fix: Improve perlin noise internals and API with accessors

### DIFF
--- a/packages/typegpu-noise/src/perlin-2d/dynamic-cache.ts
+++ b/packages/typegpu-noise/src/perlin-2d/dynamic-cache.ts
@@ -1,10 +1,10 @@
 import tgpu, {
   type Configurable,
   type StorageFlag,
+  type TgpuAccessor,
   type TgpuBuffer,
   type TgpuFn,
   type TgpuRoot,
-  type TgpuSlot,
   type UniformFlag,
 } from 'typegpu';
 import * as d from 'typegpu/data';
@@ -27,10 +27,13 @@ type Layout<Prefix extends string> = Prettify<
   }>
 >;
 
+type SizeIn = TgpuAccessor.In<d.Vec2u>;
+type MemoryIn = TgpuAccessor.In<typeof MemorySchema>;
+
 type LayoutValue<Prefix extends string> = Prettify<
   PrefixKeys<Prefix, {
-    readonly size: d.v2u;
-    readonly memory: d.v2f[];
+    readonly size: SizeIn;
+    readonly memory: MemoryIn;
   }>
 >;
 
@@ -43,7 +46,6 @@ type Bindings<Prefix extends string> = Prettify<
 
 export interface DynamicPerlin2DCacheConfig<Prefix extends string> {
   readonly layout: Layout<Prefix>;
-  readonly valuesSlot: TgpuSlot<LayoutValue<Prefix>>;
   readonly getJunctionGradient: TgpuFn<(pos: d.Vec2i) => d.Vec2f>;
 
   instance(
@@ -130,29 +132,15 @@ export function dynamicCacheConfig<Prefix extends string>(
 ): DynamicPerlin2DCacheConfig<Prefix> {
   const { prefix = DefaultPerlin2DLayoutPrefix as Prefix } = options ?? {};
 
-  const valuesSlot = tgpu.slot<LayoutValue<Prefix>>();
-
-  const cleanValuesSlot = tgpu.lazy(() => {
-    return {
-      get size() {
-        return (valuesSlot.$ as Record<`${Prefix}size`, d.v2u>)[
-          `${prefix}size`
-        ] as d.v2u;
-      },
-      get memory() {
-        return (valuesSlot.$ as Record<`${Prefix}memory`, d.v2f[]>)[
-          `${prefix}memory`
-        ] as d.v2f[];
-      },
-    };
-  });
+  const sizeAccess = tgpu['~unstable'].accessor(d.vec2u);
+  const memoryAccess = tgpu['~unstable'].accessor(MemorySchema);
 
   const getJunctionGradient = tgpu.fn([d.vec2i], d.vec2f)((pos) => {
-    const size = d.vec2i(cleanValuesSlot.$.size);
+    const size = d.vec2i(sizeAccess.$);
     const x = (pos.x % size.x + size.x) % size.x;
     const y = (pos.y % size.y + size.y) % size.y;
 
-    return cleanValuesSlot.$.memory[x + y * size.x] as d.v2f;
+    return memoryAccess.$[x + y * size.x] as d.v2f;
   });
 
   const computeLayout = tgpu.bindGroupLayout({
@@ -239,13 +227,13 @@ export function dynamicCacheConfig<Prefix extends string>(
       [`${prefix}size`]: { uniform: d.vec2u },
       [`${prefix}memory`]: { storage: MemorySchema, access: 'readonly' },
     } as Layout<Prefix>,
-    valuesSlot,
     getJunctionGradient,
     instance,
 
     inject: (layoutValue) => (cfg) =>
       cfg
         .with(getJunctionGradientSlot, getJunctionGradient)
-        .with(valuesSlot, layoutValue),
+        .with(sizeAccess, () => layoutValue[`${prefix}size`] as SizeIn)
+        .with(memoryAccess, () => layoutValue[`${prefix}memory`] as MemoryIn),
   };
 }

--- a/packages/typegpu-noise/src/perlin-3d/dynamic-cache.ts
+++ b/packages/typegpu-noise/src/perlin-3d/dynamic-cache.ts
@@ -1,10 +1,10 @@
 import tgpu, {
   type Configurable,
   type StorageFlag,
+  type TgpuAccessor,
   type TgpuBuffer,
   type TgpuFn,
   type TgpuRoot,
-  type TgpuSlot,
   type UniformFlag,
 } from 'typegpu';
 import * as d from 'typegpu/data';
@@ -27,10 +27,13 @@ type Layout<Prefix extends string> = Prettify<
   }>
 >;
 
+type SizeIn = TgpuAccessor.In<d.Vec4u>;
+type MemoryIn = TgpuAccessor.In<typeof MemorySchema>;
+
 type LayoutValue<Prefix extends string> = Prettify<
   PrefixKeys<Prefix, {
-    readonly size: d.v4u;
-    readonly memory: d.v3f[];
+    readonly size: SizeIn;
+    readonly memory: MemoryIn;
   }>
 >;
 
@@ -43,7 +46,6 @@ type Bindings<Prefix extends string> = Prettify<
 
 export interface DynamicPerlin3DCacheConfig<Prefix extends string> {
   readonly layout: Layout<Prefix>;
-  readonly valuesSlot: TgpuSlot<LayoutValue<Prefix>>;
   readonly getJunctionGradient: TgpuFn<(pos: d.Vec3i) => d.Vec3f>;
 
   instance(
@@ -130,31 +132,16 @@ export function dynamicCacheConfig<Prefix extends string>(
 ): DynamicPerlin3DCacheConfig<Prefix> {
   const { prefix = DefaultPerlin3DLayoutPrefix as Prefix } = options ?? {};
 
-  const valuesSlot = tgpu.slot<LayoutValue<Prefix>>();
-
-  const cleanValuesSlot = tgpu.lazy(() => {
-    return {
-      get size() {
-        return (valuesSlot.$ as Record<`${Prefix}size`, d.v4u>)[
-          `${prefix}size`
-        ] as d.v4u;
-      },
-      get memory() {
-        return (valuesSlot.$ as Record<`${Prefix}memory`, d.v3f[]>)[
-          `${prefix}memory`
-        ] as d.v3f[];
-      },
-    };
-  });
+  const sizeAccess = tgpu['~unstable'].accessor(d.vec4u);
+  const memoryAccess = tgpu['~unstable'].accessor(MemorySchema);
 
   const getJunctionGradient = tgpu.fn([d.vec3i], d.vec3f)((pos) => {
-    const size = d.vec3i(cleanValuesSlot.$.size.xyz);
+    const size = d.vec3i(sizeAccess.$.xyz);
     const x = (pos.x % size.x + size.x) % size.x;
     const y = (pos.y % size.y + size.y) % size.y;
     const z = (pos.z % size.z + size.z) % size.z;
 
-    return cleanValuesSlot.$
-      .memory[x + y * size.x + z * size.x * size.y] as d.v3f;
+    return memoryAccess.$[x + y * size.x + z * size.x * size.y] as d.v3f;
   });
 
   const computeLayout = tgpu.bindGroupLayout({
@@ -242,13 +229,13 @@ export function dynamicCacheConfig<Prefix extends string>(
       [`${prefix}size`]: { uniform: d.vec4u },
       [`${prefix}memory`]: { storage: MemorySchema, access: 'readonly' },
     } as Layout<Prefix>,
-    valuesSlot,
     getJunctionGradient,
     instance,
 
     inject: (layoutValue) => (cfg) =>
       cfg
         .with(getJunctionGradientSlot, getJunctionGradient)
-        .with(valuesSlot, layoutValue),
+        .with(sizeAccess, () => layoutValue[`${prefix}size`] as SizeIn)
+        .with(memoryAccess, () => layoutValue[`${prefix}memory`] as MemoryIn),
   };
 }

--- a/packages/typegpu/src/core/root/configurableImpl.ts
+++ b/packages/typegpu/src/core/root/configurableImpl.ts
@@ -1,10 +1,8 @@
 import type { AnyData } from '../../data/dataTypes.ts';
 import type { Infer } from '../../shared/repr.ts';
 import {
-  type AccessorIn,
   isAccessor,
   isMutableAccessor,
-  type MutableAccessorIn,
   type TgpuAccessor,
   type TgpuMutableAccessor,
   type TgpuSlot,
@@ -16,7 +14,7 @@ export class ConfigurableImpl implements Configurable {
 
   with<T extends AnyData>(
     slot: TgpuSlot<T> | TgpuAccessor<T> | TgpuMutableAccessor<T>,
-    value: AccessorIn<T> | MutableAccessorIn<T> | Infer<T>,
+    value: TgpuAccessor.In<T> | TgpuMutableAccessor.In<T> | Infer<T>,
   ): Configurable {
     return new ConfigurableImpl([
       ...this.bindings,

--- a/packages/typegpu/src/core/root/init.ts
+++ b/packages/typegpu/src/core/root/init.ts
@@ -83,10 +83,8 @@ import type {
   WgslSamplerProps,
 } from '../../data/sampler.ts';
 import {
-  type AccessorIn,
   isAccessor,
   isMutableAccessor,
-  type MutableAccessorIn,
   type TgpuAccessor,
   type TgpuMutableAccessor,
   type TgpuSlot,
@@ -215,7 +213,7 @@ class WithBindingImpl implements WithBinding {
 
   with<T extends AnyData>(
     slot: TgpuSlot<T> | TgpuAccessor<T> | TgpuMutableAccessor<T>,
-    value: AccessorIn<T> | MutableAccessorIn<T>,
+    value: TgpuAccessor.In<T> | TgpuMutableAccessor.In<T>,
   ): WithBinding {
     return new WithBindingImpl(this._getRoot, [
       ...this._slotBindings,

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -66,9 +66,7 @@ import type {
   TgpuRenderPipeline,
 } from '../pipeline/renderPipeline.ts';
 import type {
-  AccessorIn,
   Eventual,
-  MutableAccessorIn,
   TgpuAccessor,
   TgpuMutableAccessor,
   TgpuSlot,
@@ -212,26 +210,16 @@ export interface Withable<TSelf> {
   with<T>(slot: TgpuSlot<T>, value: Eventual<T>): TSelf;
   with<T extends AnyData>(
     accessor: TgpuAccessor<T>,
-    value: AccessorIn<NoInfer<T>>,
+    value: TgpuAccessor.In<NoInfer<T>>,
   ): TSelf;
   with<T extends AnyData>(
     accessor: TgpuMutableAccessor<T>,
-    value: MutableAccessorIn<NoInfer<T>>,
+    value: TgpuMutableAccessor.In<NoInfer<T>>,
   ): TSelf;
 }
 
-export interface Configurable {
+export interface Configurable extends Withable<Configurable> {
   readonly bindings: [slot: TgpuSlot<unknown>, value: unknown][];
-
-  with<T>(slot: TgpuSlot<T>, value: Eventual<T>): Configurable;
-  with<T extends AnyData>(
-    accessor: TgpuAccessor<T>,
-    value: AccessorIn<NoInfer<T>>,
-  ): Configurable;
-  with<T extends AnyData>(
-    accessor: TgpuMutableAccessor<T>,
-    value: MutableAccessorIn<NoInfer<T>>,
-  ): Configurable;
 
   pipe(transform: (cfg: Configurable) => Configurable): Configurable;
 }

--- a/packages/typegpu/src/core/slot/accessor.ts
+++ b/packages/typegpu/src/core/slot/accessor.ts
@@ -1,6 +1,6 @@
 import { type AnyData, isData } from '../../data/dataTypes.ts';
 import { schemaCallWrapper } from '../../data/schemaCallWrapper.ts';
-import { type ResolvedSnippet, snip } from '../../data/snippet.ts';
+import { isSnippet, type ResolvedSnippet, snip } from '../../data/snippet.ts';
 import { getResolutionCtx, inCodegenMode } from '../../execMode.ts';
 import { getName, hasTinyestMetadata, setName } from '../../shared/meta.ts';
 import type { InferGPU } from '../../shared/repr.ts';
@@ -12,14 +12,12 @@ import {
   $resolve,
 } from '../../shared/symbols.ts';
 import type { UnwrapRuntimeConstructor } from '../../tgpuBindGroupLayout.ts';
-import { coerceToSnippet } from '../../tgsl/generationHelpers.ts';
 import {
   getOwnSnippet,
   NormalState,
   type ResolutionCtx,
   type SelfResolvable,
 } from '../../types.ts';
-import { isComptimeFn } from '../function/comptime.ts';
 import { isTgpuFn } from '../function/tgpuFn.ts';
 import {
   getGpuValueRecursively,
@@ -27,8 +25,6 @@ import {
 } from '../valueProxyUtils.ts';
 import { slot as slotConstructor } from './slot.ts';
 import type {
-  AccessorIn,
-  MutableAccessorIn,
   TgpuAccessor,
   TgpuMutableAccessor,
   TgpuSlot,
@@ -37,10 +33,9 @@ import type {
 // ----------
 // Public API
 // ----------
-
 export function accessor<T extends AnyData | ((count: number) => AnyData)>(
   schemaOrConstructor: T,
-  defaultValue?: AccessorIn<UnwrapRuntimeConstructor<NoInfer<T>>>,
+  defaultValue?: TgpuAccessor.In<NoInfer<T>> | undefined,
 ): TgpuAccessor<UnwrapRuntimeConstructor<T>> {
   return new TgpuAccessorImpl(
     schemaOrConstructor,
@@ -52,11 +47,11 @@ export function mutableAccessor<
   T extends AnyData | ((count: number) => AnyData),
 >(
   schemaOrConstructor: T,
-  defaultValue?: MutableAccessorIn<UnwrapRuntimeConstructor<NoInfer<T>>>,
+  defaultValue?: TgpuMutableAccessor.In<NoInfer<T>> | undefined,
 ): TgpuMutableAccessor<UnwrapRuntimeConstructor<T>> {
   return new TgpuMutableAccessorImpl(
     schemaOrConstructor,
-    defaultValue,
+    defaultValue as TgpuMutableAccessor.In<AnyData>,
   ) as unknown as TgpuMutableAccessor<UnwrapRuntimeConstructor<T>>;
 }
 
@@ -66,7 +61,7 @@ export function mutableAccessor<
 
 abstract class AccessorBase<
   T extends AnyData,
-  TValue extends AccessorIn<T> | MutableAccessorIn<T>,
+  TValue extends TgpuAccessor.In<T> | TgpuMutableAccessor.In<T>,
 > implements SelfResolvable {
   readonly [$internal] = true;
   readonly [$getNameForward]: unknown;
@@ -107,6 +102,23 @@ abstract class AccessorBase<
     const ctx = getResolutionCtx()!;
     let value = getGpuValueRecursively(ctx.unwrap(this.slot));
 
+    while (
+      typeof value === 'function' &&
+      !isTgpuFn(value) &&
+      !hasTinyestMetadata(value)
+    ) {
+      // Not a GPU function, so has to be a resource accessor (ran in codegen mode) or comptime
+      value = value();
+      if (isSnippet(value)) {
+        value = value.value;
+      }
+    }
+
+    const ownSnippet = getOwnSnippet(value);
+    if (ownSnippet) {
+      return ownSnippet;
+    }
+
     if (isTgpuFn(value) || hasTinyestMetadata(value)) {
       return ctx.withResetIndentLevel(() =>
         snip(
@@ -117,24 +129,8 @@ abstract class AccessorBase<
       );
     }
 
-    const ownSnippet = getOwnSnippet(value);
-    if (ownSnippet) {
-      return ownSnippet;
-    }
-
-    if (typeof value === 'function' && !isComptimeFn(value)) {
-      // Not a comptime or GPU function, so has to be a resource accessor
-      // Running the function in codegen mode
-      return coerceToSnippet(value());
-    }
-
     ctx.pushMode(new NormalState());
     try {
-      if (typeof value === 'function') {
-        // Has to be comptime
-        value = value();
-      }
-
       // Doing a deep copy each time so that we don't have to deal with refs
       const cloned = schemaCallWrapper(this.schema, value);
       return snip(cloned, this.schema, 'constant');
@@ -178,13 +174,13 @@ abstract class AccessorBase<
 }
 
 export class TgpuAccessorImpl<T extends AnyData>
-  extends AccessorBase<T, AccessorIn<T>>
+  extends AccessorBase<T, TgpuAccessor.In<T>>
   implements TgpuAccessor<T> {
   readonly resourceType = 'accessor';
 
   constructor(
     schemaOrConstructor: T | ((count: number) => T),
-    defaultValue: AccessorIn<T> | undefined = undefined,
+    defaultValue: TgpuAccessor.In<T> | undefined = undefined,
   ) {
     super(schemaOrConstructor, defaultValue);
   }
@@ -201,13 +197,13 @@ export class TgpuAccessorImpl<T extends AnyData>
 }
 
 export class TgpuMutableAccessorImpl<T extends AnyData>
-  extends AccessorBase<T, MutableAccessorIn<T>>
+  extends AccessorBase<T, TgpuMutableAccessor.In<T>>
   implements TgpuMutableAccessor<T> {
   readonly resourceType = 'mutable-accessor';
 
   constructor(
     schemaOrConstructor: T | ((count: number) => T),
-    defaultValue: MutableAccessorIn<T> | undefined = undefined,
+    defaultValue: TgpuMutableAccessor.In<T> | undefined = undefined,
   ) {
     super(schemaOrConstructor, defaultValue);
   }

--- a/packages/typegpu/src/core/slot/lazy.ts
+++ b/packages/typegpu/src/core/slot/lazy.ts
@@ -4,10 +4,8 @@ import type { GPUValueOf } from '../../shared/repr.ts';
 import { $gpuValueOf, $internal, $providing } from '../../shared/symbols.ts';
 import { getGpuValueRecursively } from '../valueProxyUtils.ts';
 import {
-  type AccessorIn,
   isAccessor,
   isMutableAccessor,
-  type MutableAccessorIn,
   type Providing,
   type TgpuAccessor,
   type TgpuLazy,
@@ -71,7 +69,7 @@ class TgpuLazyImpl<out T> implements TgpuLazy<T> {
 
   with<TData extends AnyData>(
     slot: TgpuSlot<TData> | TgpuAccessor<TData> | TgpuMutableAccessor<TData>,
-    value: AccessorIn<TData> | MutableAccessorIn<TData>,
+    value: TgpuAccessor.In<TData> | TgpuMutableAccessor.In<TData>,
   ): TgpuLazy<T> {
     return new TgpuLazyImpl(this[$internal].compute, {
       inner: this[$providing]?.inner ?? this,

--- a/packages/typegpu/src/index.ts
+++ b/packages/typegpu/src/index.ts
@@ -77,9 +77,7 @@ export type {
   TgpuUniform,
 } from './core/buffer/bufferShorthand.ts';
 export type {
-  AccessorIn,
   Eventual,
-  MutableAccessorIn,
   TgpuAccessor,
   TgpuLazy,
   TgpuMutableAccessor,

--- a/packages/typegpu/tests/accessor.test.ts
+++ b/packages/typegpu/tests/accessor.test.ts
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/style/noNonNullAssertion: it's useful for array access */
-import { describe, expect } from 'vitest';
-import { d, std, tgpu } from '../src/index.ts';
+import { describe, expect, expectTypeOf } from 'vitest';
+import tgpu, { d, std, type TgpuAccessor } from '../src/index.ts';
 import { it } from './utils/extendedIt.ts';
 
 const RED = d.vec3f(1, 0, 0);
@@ -514,6 +514,31 @@ describe('tgpu.accessor', () => {
 
       fn main() {
         let hello = image.pixels[4].x;
+      }"
+    `);
+  });
+
+  it('allows for arbitrarily nested access functions', ({ root }) => {
+    const counterMutable = root.createMutable(d.u32);
+
+    const counterAccess = tgpu['~unstable'].accessor(
+      d.u32,
+      () => () => () => counterMutable.$,
+    );
+
+    const main = () => {
+      'use gpu';
+      return counterAccess.$ / 2;
+    };
+
+    expectTypeOf(counterAccess).toEqualTypeOf<TgpuAccessor<d.U32>>();
+    expectTypeOf<typeof counterAccess.$>().toEqualTypeOf<number>();
+
+    expect(tgpu.resolve([main])).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<storage, read_write> counterMutable: u32;
+
+      fn main() -> f32 {
+        return (f32(counterMutable) / 2f);
       }"
     `);
   });


### PR DESCRIPTION
Apart from changing the perlin noise internals and API, there were a few changes to accessors:
- The `AccessorIn` and `MutableAccessorIn` types now live as `TgpuAccessor.In` and `TgpuMutableAccessor.In` respectively. This can help reduce unnecessary top-level export polution.
- Accessors can accept recursively indirect access functions (e.g. `() => () => () => layout.$.foo`). This is helpful when writing a library, and we're unsure whether we can safely access a property in "normal" mode.