### PR TITLE
refactor: Double down on BaseData

### DIFF
--- a/packages/typegpu/src/builtin.ts
+++ b/packages/typegpu/src/builtin.ts
@@ -4,7 +4,6 @@ import type { LooseDecorated } from './data/dataTypes.ts';
 import { bool, f32, u32 } from './data/numeric.ts';
 import { vec3u, vec4f } from './data/vector.ts';
 import type {
-  AnyWgslData,
   BaseData,
   Bool,
   Builtin,
@@ -62,7 +61,7 @@ export type BuiltinSubgroupId = Decorated<U32, [Builtin<'subgroup_id'>]>;
 export type BuiltinNumSubgroups = Decorated<U32, [Builtin<'num_subgroups'>]>;
 
 function defineBuiltin<T extends Decorated | LooseDecorated>(
-  dataType: AnyWgslData,
+  dataType: BaseData,
   value: T['attribs'][0] extends { params: [infer TValue] } ? TValue : never,
 ): T {
   return attribute(dataType, {

--- a/packages/typegpu/src/core/buffer/buffer.ts
+++ b/packages/typegpu/src/core/buffer/buffer.ts
@@ -144,22 +144,22 @@ export function INTERNAL_createBuffer<TData extends AnyData>(
   return new TgpuBufferImpl(group, typeSchema, initialOrBuffer);
 }
 
-export function isBuffer<T extends TgpuBuffer<AnyData>>(
+export function isBuffer<T extends TgpuBuffer<BaseData>>(
   value: T | unknown,
 ): value is T {
-  return (value as TgpuBuffer<AnyData>).resourceType === 'buffer';
+  return (value as T).resourceType === 'buffer';
 }
 
-export function isUsableAsVertex<T extends TgpuBuffer<AnyData>>(
+export function isUsableAsVertex<T extends TgpuBuffer<BaseData>>(
   buffer: T,
 ): buffer is T & VertexFlag {
-  return !!(buffer as unknown as VertexFlag).usableAsVertex;
+  return !!(buffer as T).usableAsVertex;
 }
 
-export function isUsableAsIndex<T extends TgpuBuffer<AnyData>>(
+export function isUsableAsIndex<T extends TgpuBuffer<BaseData>>(
   buffer: T,
 ): buffer is T & IndexFlag {
-  return !!(buffer as unknown as IndexFlag).usableAsIndex;
+  return !!(buffer as T).usableAsIndex;
 }
 
 // --------------
@@ -167,7 +167,7 @@ export function isUsableAsIndex<T extends TgpuBuffer<AnyData>>(
 // --------------
 const endianness = getSystemEndianness();
 
-class TgpuBufferImpl<TData extends AnyData> implements TgpuBuffer<TData> {
+class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
   public readonly [$internal] = true;
   public readonly resourceType = 'buffer';
   public flags: GPUBufferUsageFlags = GPUBufferUsage.COPY_DST |

--- a/packages/typegpu/src/core/buffer/bufferUsage.ts
+++ b/packages/typegpu/src/core/buffer/bufferUsage.ts
@@ -1,4 +1,3 @@
-import type { AnyData } from '../../data/dataTypes.ts';
 import { schemaCallWrapper } from '../../data/schemaCallWrapper.ts';
 import { type ResolvedSnippet, snip } from '../../data/snippet.ts';
 import {
@@ -80,10 +79,10 @@ export interface TgpuFixedBufferUsage<TData extends BaseData>
 export interface TgpuBufferMutable<TData extends BaseData>
   extends TgpuBufferUsage<TData, 'mutable'> {}
 
-export function isUsableAsUniform<T extends TgpuBuffer<AnyData>>(
+export function isUsableAsUniform<T extends TgpuBuffer<BaseData>>(
   buffer: T,
 ): buffer is T & UniformFlag {
-  return !!(buffer as unknown as UniformFlag).usableAsUniform;
+  return !!(buffer as T).usableAsUniform;
 }
 
 // --------------
@@ -97,7 +96,7 @@ const usageToVarTemplateMap: Record<BindableBufferUsage, string> = {
 };
 
 class TgpuFixedBufferImpl<
-  TData extends AnyWgslData,
+  TData extends BaseData,
   TUsage extends BindableBufferUsage,
 > implements
   TgpuBufferUsage<TData, TUsage>,
@@ -237,7 +236,7 @@ class TgpuFixedBufferImpl<
 }
 
 export class TgpuLaidOutBufferImpl<
-  TData extends AnyWgslData,
+  TData extends BaseData,
   TUsage extends BindableBufferUsage,
 > implements TgpuBufferUsage<TData, TUsage>, SelfResolvable {
   /** Type-token, not available at runtime */
@@ -312,8 +311,8 @@ export class TgpuLaidOutBufferImpl<
 }
 
 const mutableUsageMap = new WeakMap<
-  TgpuBuffer<AnyWgslData>,
-  TgpuFixedBufferImpl<AnyWgslData, 'mutable'>
+  TgpuBuffer<BaseData>,
+  TgpuFixedBufferImpl<BaseData, 'mutable'>
 >();
 
 export function mutable<TData extends AnyWgslData>(
@@ -336,8 +335,8 @@ export function mutable<TData extends AnyWgslData>(
 }
 
 const readonlyUsageMap = new WeakMap<
-  TgpuBuffer<AnyWgslData>,
-  TgpuFixedBufferImpl<AnyWgslData, 'readonly'>
+  TgpuBuffer<BaseData>,
+  TgpuFixedBufferImpl<BaseData, 'readonly'>
 >();
 
 export function readonly<TData extends AnyWgslData>(
@@ -360,8 +359,8 @@ export function readonly<TData extends AnyWgslData>(
 }
 
 const uniformUsageMap = new WeakMap<
-  TgpuBuffer<AnyWgslData>,
-  TgpuFixedBufferImpl<AnyWgslData, 'uniform'>
+  TgpuBuffer<BaseData>,
+  TgpuFixedBufferImpl<BaseData, 'uniform'>
 >();
 
 export function uniform<TData extends AnyWgslData>(

--- a/packages/typegpu/src/core/constant/tgpuConstant.ts
+++ b/packages/typegpu/src/core/constant/tgpuConstant.ts
@@ -1,6 +1,6 @@
 import type { AnyData } from '../../data/dataTypes.ts';
 import { type ResolvedSnippet, snip } from '../../data/snippet.ts';
-import { isNaturallyEphemeral } from '../../data/wgslTypes.ts';
+import { type BaseData, isNaturallyEphemeral } from '../../data/wgslTypes.ts';
 import { inCodegenMode } from '../../execMode.ts';
 import type { TgpuNamable } from '../../shared/meta.ts';
 import { getName, setName } from '../../shared/meta.ts';
@@ -24,7 +24,7 @@ type DeepReadonly<T> = T extends { [$internal]: unknown } ? T
     ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
   : T;
 
-export interface TgpuConst<TDataType extends AnyData = AnyData>
+export interface TgpuConst<TDataType extends BaseData = BaseData>
   extends TgpuNamable {
   readonly resourceType: 'const';
   readonly [$gpuValueOf]: DeepReadonly<InferGPU<TDataType>>;
@@ -71,7 +71,7 @@ function deepFreeze<T extends object>(object: T): T {
   return Object.freeze(object);
 }
 
-class TgpuConstImpl<TDataType extends AnyData>
+class TgpuConstImpl<TDataType extends BaseData>
   implements TgpuConst<TDataType>, SelfResolvable {
   readonly [$internal] = {};
   readonly resourceType: 'const';

--- a/packages/typegpu/src/core/function/dualImpl.ts
+++ b/packages/typegpu/src/core/function/dualImpl.ts
@@ -1,4 +1,3 @@
-import type { AnyData } from '../../data/dataTypes.ts';
 import { type MapValueToSnippet, snip } from '../../data/snippet.ts';
 import { setName } from '../../shared/meta.ts';
 import { $gpuCallable } from '../../shared/symbols.ts';
@@ -9,8 +8,9 @@ import {
   NormalState,
   type ResolutionCtx,
 } from '../../types.ts';
+import { type BaseData, isPtr } from '../../data/wgslTypes.ts';
 
-type MapValueToDataType<T> = { [K in keyof T]: AnyData };
+type MapValueToDataType<T> = { [K in keyof T]: BaseData };
 type AnyFn = (...args: never[]) => unknown;
 
 interface DualImplOptions<T extends AnyFn> {
@@ -21,10 +21,10 @@ interface DualImplOptions<T extends AnyFn> {
     args: MapValueToSnippet<Parameters<T>>,
   ) => string;
   readonly signature:
-    | { argTypes: AnyData[]; returnType: AnyData }
+    | { argTypes: BaseData[]; returnType: BaseData }
     | ((
       ...inArgTypes: MapValueToDataType<Parameters<T>>
-    ) => { argTypes: AnyData[]; returnType: AnyData });
+    ) => { argTypes: BaseData[]; returnType: BaseData });
   /**
    * Whether the function should skip trying to execute the "normal" implementation if
    * all arguments are known at compile time.
@@ -64,7 +64,7 @@ export function dualImpl<T extends AnyFn>(
         ? options.signature(
           ...args.map((s) => {
             // Dereference implicit pointers
-            if (s.dataType.type === 'ptr' && s.dataType.implicit) {
+            if (isPtr(s.dataType) && s.dataType.implicit) {
               return s.dataType.inner;
             }
             return s.dataType;

--- a/packages/typegpu/src/core/function/fnCore.ts
+++ b/packages/typegpu/src/core/function/fnCore.ts
@@ -1,7 +1,12 @@
 import { getAttributesString } from '../../data/attributes.ts';
-import { type AnyData, undecorate } from '../../data/dataTypes.ts';
+import { undecorate } from '../../data/dataTypes.ts';
 import { type ResolvedSnippet, snip } from '../../data/snippet.ts';
-import { isWgslData, isWgslStruct, Void } from '../../data/wgslTypes.ts';
+import {
+  type BaseData,
+  isWgslData,
+  isWgslStruct,
+  Void,
+} from '../../data/wgslTypes.ts';
 import { MissingLinksError } from '../../errors.ts';
 import { getMetaData, getName, setName } from '../../shared/meta.ts';
 import type { ResolutionCtx } from '../../types.ts';
@@ -17,12 +22,12 @@ export interface FnCore {
   applyExternals(newExternals: ExternalMap): void;
   resolve(
     ctx: ResolutionCtx,
-    argTypes: AnyData[],
+    argTypes: BaseData[],
     /**
      * The return type of the function. If undefined, the type should be inferred
      * from the implementation (relevant for shellless functions).
      */
-    returnType: AnyData | undefined,
+    returnType: BaseData | undefined,
   ): ResolvedSnippet;
 }
 
@@ -45,8 +50,8 @@ export function createFnCore(
 
     resolve(
       ctx: ResolutionCtx,
-      argTypes: AnyData[],
-      returnType: AnyData | undefined,
+      argTypes: BaseData[],
+      returnType: BaseData | undefined,
     ): ResolvedSnippet {
       const externalMap: ExternalMap = {};
 

--- a/packages/typegpu/src/core/function/shelllessImpl.ts
+++ b/packages/typegpu/src/core/function/shelllessImpl.ts
@@ -1,5 +1,5 @@
-import type { AnyData } from '../../data/dataTypes.ts';
 import type { ResolvedSnippet } from '../../data/snippet.ts';
+import type { BaseData } from '../../data/wgslTypes.ts';
 import { getName } from '../../shared/meta.ts';
 import { $getNameForward, $internal, $resolve } from '../../shared/symbols.ts';
 import type { ResolutionCtx, SelfResolvable } from '../../types.ts';
@@ -23,12 +23,12 @@ import { createFnCore } from './fnCore.ts';
  */
 export interface ShelllessImpl extends SelfResolvable {
   readonly resourceType: 'shellless-impl';
-  readonly argTypes: AnyData[];
+  readonly argTypes: BaseData[];
   readonly [$getNameForward]: unknown;
 }
 
 export function createShelllessImpl(
-  argTypes: AnyData[],
+  argTypes: BaseData[],
   implementation: (...args: never[]) => unknown,
 ): ShelllessImpl {
   const core = createFnCore(implementation, '');

--- a/packages/typegpu/src/core/pipeline/renderPipeline.ts
+++ b/packages/typegpu/src/core/pipeline/renderPipeline.ts
@@ -14,7 +14,7 @@ import type {
   WgslTextureDepthMultisampled2d,
 } from '../../data/texture.ts';
 import {
-  type AnyWgslData,
+  type BaseData,
   type Decorated,
   isWgslData,
   type U16,
@@ -132,7 +132,7 @@ export interface TgpuRenderPipeline<Output extends IOLayout = IOLayout>
   ): this;
 
   withIndexBuffer(
-    buffer: TgpuBuffer<AnyWgslData> & IndexFlag,
+    buffer: TgpuBuffer<BaseData> & IndexFlag,
     offsetElements?: number,
     sizeElements?: number,
   ): this & HasIndexBuffer;
@@ -329,7 +329,7 @@ export function INTERNAL_createRenderPipeline(
 
 type TgpuRenderPipelinePriors = {
   readonly vertexLayoutMap?:
-    | Map<TgpuVertexLayout, TgpuBuffer<AnyWgslData> & VertexFlag>
+    | Map<TgpuVertexLayout, TgpuBuffer<BaseData> & VertexFlag>
     | undefined;
   readonly bindGroupLayoutMap?:
     | Map<TgpuBindGroupLayout, TgpuBindGroup>
@@ -339,7 +339,7 @@ type TgpuRenderPipelinePriors = {
   readonly stencilReference?: GPUStencilValue | undefined;
   readonly indexBuffer?:
     | {
-      buffer: TgpuBuffer<AnyWgslData> & IndexFlag | GPUBuffer;
+      buffer: TgpuBuffer<BaseData> & IndexFlag | GPUBuffer;
       indexFormat: GPUIndexFormat;
       offsetBytes?: number | undefined;
       sizeBytes?: number | undefined;
@@ -382,7 +382,7 @@ class TgpuRenderPipelineImpl implements TgpuRenderPipeline {
     return this;
   }
 
-  with<TData extends WgslArray<AnyWgslData>>(
+  with<TData extends WgslArray>(
     vertexLayout: TgpuVertexLayout<TData>,
     buffer: TgpuBuffer<TData> & VertexFlag,
   ): this;
@@ -396,7 +396,7 @@ class TgpuRenderPipelineImpl implements TgpuRenderPipeline {
       | TgpuVertexLayout
       | TgpuBindGroupLayout
       | TgpuBindGroup,
-    resource?: (TgpuBuffer<AnyWgslData> & VertexFlag) | TgpuBindGroup,
+    resource?: (TgpuBuffer<BaseData> & VertexFlag) | TgpuBindGroup,
   ): this {
     const internals = this[$internal];
 
@@ -427,7 +427,7 @@ class TgpuRenderPipelineImpl implements TgpuRenderPipeline {
           ...(internals.priors.vertexLayoutMap ?? []),
           [
             layoutOrBindGroup,
-            resource as TgpuBuffer<AnyWgslData> & VertexFlag,
+            resource as TgpuBuffer<BaseData> & VertexFlag,
           ],
         ]),
       }) as this;
@@ -496,7 +496,7 @@ class TgpuRenderPipelineImpl implements TgpuRenderPipeline {
   }
 
   withIndexBuffer(
-    buffer: TgpuBuffer<AnyWgslData> & IndexFlag,
+    buffer: TgpuBuffer<BaseData> & IndexFlag,
     offsetElements?: number,
     sizeElements?: number,
   ): this & HasIndexBuffer;
@@ -507,7 +507,7 @@ class TgpuRenderPipelineImpl implements TgpuRenderPipeline {
     sizeBytes?: number,
   ): this & HasIndexBuffer;
   withIndexBuffer(
-    buffer: TgpuBuffer<AnyWgslData> & IndexFlag | GPUBuffer,
+    buffer: TgpuBuffer<BaseData> & IndexFlag | GPUBuffer,
     indexFormatOrOffset?: GPUIndexFormat | number,
     offsetElementsOrSizeBytes?: number,
     sizeElementsOrUndefined?: number,

--- a/packages/typegpu/src/core/rawCodeSnippet/tgpuRawCodeSnippet.ts
+++ b/packages/typegpu/src/core/rawCodeSnippet/tgpuRawCodeSnippet.ts
@@ -1,5 +1,6 @@
 import type { AnyData } from '../../data/dataTypes.ts';
 import { type Origin, type ResolvedSnippet, snip } from '../../data/snippet.ts';
+import type { BaseData } from '../../data/wgslTypes.ts';
 import { inCodegenMode } from '../../execMode.ts';
 import type { InferGPU } from '../../shared/repr.ts';
 import {
@@ -24,7 +25,7 @@ import { valueProxyHandler } from '../valueProxyUtils.ts';
  * Extra declaration that will be included in final WGSL code
  * when resolving objects that use it.
  */
-export interface TgpuRawCodeSnippet<TDataType extends AnyData> {
+export interface TgpuRawCodeSnippet<TDataType extends BaseData> {
   $: InferGPU<TDataType>;
   value: InferGPU<TDataType>;
   readonly [$gpuValueOf]: InferGPU<TDataType>;
@@ -92,7 +93,7 @@ export function rawCodeSnippet<TDataType extends AnyData>(
 // Implementation
 // --------------
 
-class TgpuRawCodeSnippetImpl<TDataType extends AnyData>
+class TgpuRawCodeSnippetImpl<TDataType extends BaseData>
   implements TgpuRawCodeSnippet<TDataType>, SelfResolvable {
   readonly [$internal]: true;
   readonly dataType: TDataType;

--- a/packages/typegpu/src/core/resolve/resolveData.ts
+++ b/packages/typegpu/src/core/resolve/resolveData.ts
@@ -16,6 +16,7 @@ import {
 import { formatToWGSLType } from '../../data/vertexFormatData.ts';
 import type {
   AnyWgslData,
+  BaseData,
   Bool,
   F16,
   F32,
@@ -104,7 +105,7 @@ type IdentityType =
   | Mat4x4f
   | WgslExternalTexture;
 
-function isIdentityType(data: AnyWgslData): data is IdentityType {
+function isIdentityType(data: BaseData): data is IdentityType {
   return identityTypes.includes(data.type);
 }
 
@@ -118,7 +119,7 @@ function isIdentityType(data: AnyWgslData): data is IdentityType {
  */
 function resolveStructProperty(
   ctx: ResolutionCtx,
-  [key, property]: [string, AnyData],
+  [key, property]: [string, BaseData],
 ) {
   return `  ${getAttributesString(property)}${key}: ${
     ctx.resolve(property).value
@@ -245,7 +246,9 @@ export function resolveData(ctx: ResolutionCtx, data: AnyData): string {
       ).value;
     }
 
-    return ctx.resolve(formatToWGSLType[data.type]).value;
+    return ctx.resolve(
+      formatToWGSLType[data.type as keyof typeof formatToWGSLType],
+    ).value;
   }
 
   if (isIdentityType(data)) {

--- a/packages/typegpu/src/core/root/configurableImpl.ts
+++ b/packages/typegpu/src/core/root/configurableImpl.ts
@@ -1,4 +1,4 @@
-import type { AnyData } from '../../data/dataTypes.ts';
+import type { BaseData } from '../../data/wgslTypes.ts';
 import type { Infer } from '../../shared/repr.ts';
 import {
   isAccessor,
@@ -12,7 +12,7 @@ import type { Configurable } from './rootTypes.ts';
 export class ConfigurableImpl implements Configurable {
   constructor(readonly bindings: [TgpuSlot<unknown>, unknown][]) {}
 
-  with<T extends AnyData>(
+  with<T extends BaseData>(
     slot: TgpuSlot<T> | TgpuAccessor<T> | TgpuMutableAccessor<T>,
     value: TgpuAccessor.In<T> | TgpuMutableAccessor.In<T> | Infer<T>,
   ): Configurable {

--- a/packages/typegpu/src/core/root/init.ts
+++ b/packages/typegpu/src/core/root/init.ts
@@ -11,6 +11,7 @@ import {
 import type { AnyData, Disarray } from '../../data/dataTypes.ts';
 import type {
   AnyWgslData,
+  BaseData,
   U16,
   U32,
   v3u,
@@ -211,7 +212,7 @@ class WithBindingImpl implements WithBinding {
     private readonly _slotBindings: [TgpuSlot<unknown>, unknown][],
   ) {}
 
-  with<T extends AnyData>(
+  with<T extends BaseData>(
     slot: TgpuSlot<T> | TgpuAccessor<T> | TgpuMutableAccessor<T>,
     value: TgpuAccessor.In<T> | TgpuMutableAccessor.In<T>,
   ): WithBinding {
@@ -557,7 +558,7 @@ class TgpuRootImpl extends WithBindingImpl
   unwrap(resource: TgpuRenderPipeline): GPURenderPipeline;
   unwrap(resource: TgpuBindGroupLayout): GPUBindGroupLayout;
   unwrap(resource: TgpuBindGroup): GPUBindGroup;
-  unwrap(resource: TgpuBuffer<AnyData>): GPUBuffer;
+  unwrap(resource: TgpuBuffer<BaseData>): GPUBuffer;
   unwrap(resource: TgpuTexture): GPUTexture;
   unwrap(resource: TgpuTextureView): GPUTextureView;
   unwrap(resource: TgpuVertexLayout): GPUVertexBufferLayout;
@@ -570,7 +571,7 @@ class TgpuRootImpl extends WithBindingImpl
       | TgpuRenderPipeline
       | TgpuBindGroupLayout
       | TgpuBindGroup
-      | TgpuBuffer<AnyData>
+      | TgpuBuffer<BaseData>
       | TgpuTexture
       | TgpuTextureView
       | TgpuVertexLayout

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../data/sampler.ts';
 import type {
   AnyWgslData,
+  BaseData,
   U16,
   U32,
   Vec3u,
@@ -208,11 +209,11 @@ export interface WithFragment<
 
 export interface Withable<TSelf> {
   with<T>(slot: TgpuSlot<T>, value: Eventual<T>): TSelf;
-  with<T extends AnyData>(
+  with<T extends BaseData>(
     accessor: TgpuAccessor<T>,
     value: TgpuAccessor.In<NoInfer<T>>,
   ): TSelf;
-  with<T extends AnyData>(
+  with<T extends BaseData>(
     accessor: TgpuMutableAccessor<T>,
     value: TgpuMutableAccessor.In<NoInfer<T>>,
   ): TSelf;
@@ -552,17 +553,17 @@ export interface RenderPass {
   ): undefined;
 }
 
-export type ValidateBufferSchema<TData extends AnyData> =
+export type ValidateBufferSchema<TData extends BaseData> =
   IsValidBufferSchema<TData> extends false
     ? ExtractInvalidSchemaError<TData, '(Error) '>
     : TData;
 
-export type ValidateStorageSchema<TData extends AnyData> =
+export type ValidateStorageSchema<TData extends BaseData> =
   IsValidStorageSchema<TData> extends false
     ? ExtractInvalidSchemaError<TData, '(Error) '>
     : TData;
 
-export type ValidateUniformSchema<TData extends AnyData> =
+export type ValidateUniformSchema<TData extends BaseData> =
   IsValidUniformSchema<TData> extends false
     ? ExtractInvalidSchemaError<TData, '(Error) '>
     : TData;

--- a/packages/typegpu/src/core/simulate/tgpuSimulate.ts
+++ b/packages/typegpu/src/core/simulate/tgpuSimulate.ts
@@ -1,4 +1,4 @@
-import type { AnyData } from '../../data/dataTypes.ts';
+import type { BaseData } from '../../data/wgslTypes.ts';
 import { getResolutionCtx, provideCtx } from '../../execMode.ts';
 import { ResolutionCtxImpl } from '../../resolutionCtx.ts';
 import wgslGenerator from '../../tgsl/wgslGenerator.ts';
@@ -10,9 +10,9 @@ import type { TgpuVar } from '../variable/tgpuVariable.ts';
 interface SimulationResult<T> {
   value: T;
 
-  buffers: Map<TgpuBuffer<AnyData>, unknown>;
-  privateVars: Map<TgpuVar<'private', AnyData>, unknown>[][][];
-  workgroupVars: Map<TgpuVar<'workgroup', AnyData>, unknown>[][][];
+  buffers: Map<TgpuBuffer<BaseData>, unknown>;
+  privateVars: Map<TgpuVar<'private', BaseData>, unknown>[][][];
+  workgroupVars: Map<TgpuVar<'workgroup', BaseData>, unknown>[][][];
 }
 
 /**
@@ -56,7 +56,7 @@ export function simulate<T>(callback: () => T): SimulationResult<T> {
     workgroups[2] * workgroupSize[2],
   ] as const;
 
-  const buffers = new Map<TgpuBuffer<AnyData>, unknown>();
+  const buffers = new Map<TgpuBuffer<BaseData>, unknown>();
 
   const workgroupVars = Array.from(
     { length: workgroups[0] },

--- a/packages/typegpu/src/core/slot/accessor.ts
+++ b/packages/typegpu/src/core/slot/accessor.ts
@@ -1,6 +1,7 @@
 import { type AnyData, isData } from '../../data/dataTypes.ts';
 import { schemaCallWrapper } from '../../data/schemaCallWrapper.ts';
 import { isSnippet, type ResolvedSnippet, snip } from '../../data/snippet.ts';
+import type { BaseData } from '../../data/wgslTypes.ts';
 import { getResolutionCtx, inCodegenMode } from '../../execMode.ts';
 import { getName, hasTinyestMetadata, setName } from '../../shared/meta.ts';
 import type { InferGPU } from '../../shared/repr.ts';
@@ -51,7 +52,7 @@ export function mutableAccessor<
 ): TgpuMutableAccessor<UnwrapRuntimeConstructor<T>> {
   return new TgpuMutableAccessorImpl(
     schemaOrConstructor,
-    defaultValue as TgpuMutableAccessor.In<AnyData>,
+    defaultValue as TgpuMutableAccessor.In<BaseData>,
   ) as unknown as TgpuMutableAccessor<UnwrapRuntimeConstructor<T>>;
 }
 
@@ -60,7 +61,7 @@ export function mutableAccessor<
 // --------------
 
 abstract class AccessorBase<
-  T extends AnyData,
+  T extends BaseData,
   TValue extends TgpuAccessor.In<T> | TgpuMutableAccessor.In<T>,
 > implements SelfResolvable {
   readonly [$internal] = true;
@@ -77,7 +78,7 @@ abstract class AccessorBase<
   ) {
     this.schema = isData(schemaOrConstructor)
       ? schemaOrConstructor
-      : schemaOrConstructor(0);
+      : (schemaOrConstructor as ((count: number) => T))(0);
     this.defaultValue = defaultValue;
 
     // NOTE: in certain setups, unplugin can run on package typegpu, so we have to avoid auto-naming triggering here
@@ -173,7 +174,7 @@ abstract class AccessorBase<
   }
 }
 
-export class TgpuAccessorImpl<T extends AnyData>
+export class TgpuAccessorImpl<T extends BaseData>
   extends AccessorBase<T, TgpuAccessor.In<T>>
   implements TgpuAccessor<T> {
   readonly resourceType = 'accessor';
@@ -196,7 +197,7 @@ export class TgpuAccessorImpl<T extends AnyData>
   }
 }
 
-export class TgpuMutableAccessorImpl<T extends AnyData>
+export class TgpuMutableAccessorImpl<T extends BaseData>
   extends AccessorBase<T, TgpuMutableAccessor.In<T>>
   implements TgpuMutableAccessor<T> {
   readonly resourceType = 'mutable-accessor';

--- a/packages/typegpu/src/core/slot/slotTypes.ts
+++ b/packages/typegpu/src/core/slot/slotTypes.ts
@@ -1,5 +1,5 @@
-import type { AnyData } from '../../data/dataTypes.ts';
 import type { WgslStorageTexture, WgslTexture } from '../../data/texture.ts';
+import type { BaseData } from '../../data/wgslTypes.ts';
 import type { TgpuNamable } from '../../shared/meta.ts';
 import type { GPUValueOf, Infer, InferGPU } from '../../shared/repr.ts';
 import { $gpuValueOf, $internal, $providing } from '../../shared/symbols.ts';
@@ -49,7 +49,8 @@ export interface TgpuLazy<out T> extends Withable<TgpuLazy<T>> {
   // ---
 }
 
-export interface TgpuAccessor<T extends AnyData = AnyData> extends TgpuNamable {
+export interface TgpuAccessor<T extends BaseData = BaseData>
+  extends TgpuNamable {
   readonly [$internal]: true;
   readonly resourceType: 'accessor';
 
@@ -65,7 +66,7 @@ export interface TgpuAccessor<T extends AnyData = AnyData> extends TgpuNamable {
   readonly $: InferGPU<T>;
 }
 
-type DataAccessorIn<T extends AnyData> =
+type DataAccessorIn<T extends BaseData> =
   | (() => DataAccessorIn<T>)
   | TgpuBufferUsage<T>
   | TgpuBufferShorthand<T>
@@ -79,13 +80,13 @@ type TextureAccessorIn<T extends WgslTexture | WgslStorageTexture> =
   | TgpuTextureView<T>;
 
 export declare namespace TgpuAccessor {
-  type In<T extends AnyData | ((count: number) => AnyData)> =
+  type In<T extends BaseData | ((count: number) => BaseData)> =
     UnwrapRuntimeConstructor<T> extends WgslTexture | WgslStorageTexture
       ? TextureAccessorIn<UnwrapRuntimeConstructor<T>>
       : DataAccessorIn<UnwrapRuntimeConstructor<T>>;
 }
 
-export interface TgpuMutableAccessor<T extends AnyData = AnyData>
+export interface TgpuMutableAccessor<T extends BaseData = BaseData>
   extends TgpuNamable {
   readonly [$internal]: true;
   readonly resourceType: 'mutable-accessor';
@@ -99,7 +100,7 @@ export interface TgpuMutableAccessor<T extends AnyData = AnyData>
   $: InferGPU<T>;
 }
 
-type MutableDataAccessorIn<T extends AnyData> =
+type MutableDataAccessorIn<T extends BaseData> =
   | (() => Infer<T> | MutableDataAccessorIn<T>)
   | TgpuBufferUsage<T>
   | TgpuBufferShorthand<T>
@@ -110,7 +111,7 @@ type MutableTextureAccessorIn<T extends WgslTexture | WgslStorageTexture> =
   | TgpuTextureView<T>;
 
 export declare namespace TgpuMutableAccessor {
-  type In<T extends AnyData | ((count: number) => AnyData)> =
+  type In<T extends BaseData | ((count: number) => BaseData)> =
     UnwrapRuntimeConstructor<T> extends WgslTexture | WgslStorageTexture
       ? MutableTextureAccessorIn<UnwrapRuntimeConstructor<T>>
       : MutableDataAccessorIn<UnwrapRuntimeConstructor<T>>;
@@ -144,13 +145,13 @@ export function isProviding(
   return (value as { [$providing]: Providing })?.[$providing] !== undefined;
 }
 
-export function isAccessor<T extends AnyData>(
+export function isAccessor<T extends BaseData>(
   value: unknown | TgpuAccessor<T>,
 ): value is TgpuAccessor<T> {
   return (value as TgpuAccessor<T>)?.resourceType === 'accessor';
 }
 
-export function isMutableAccessor<T extends AnyData>(
+export function isMutableAccessor<T extends BaseData>(
   value: unknown | TgpuMutableAccessor<T>,
 ): value is TgpuMutableAccessor<T> {
   return (value as TgpuMutableAccessor<T>)?.resourceType === 'mutable-accessor';

--- a/packages/typegpu/src/core/variable/tgpuVariable.ts
+++ b/packages/typegpu/src/core/variable/tgpuVariable.ts
@@ -1,6 +1,6 @@
 import type { AnyData } from '../../data/dataTypes.ts';
 import { type ResolvedSnippet, snip } from '../../data/snippet.ts';
-import { isNaturallyEphemeral } from '../../data/wgslTypes.ts';
+import { type BaseData, isNaturallyEphemeral } from '../../data/wgslTypes.ts';
 import { IllegalVarAccessError } from '../../errors.ts';
 import { getExecMode, isInsideTgpuFn } from '../../execMode.ts';
 import type { TgpuNamable } from '../../shared/meta.ts';
@@ -24,7 +24,7 @@ export type VariableScope = 'private' | 'workgroup';
 
 export interface TgpuVar<
   TScope extends VariableScope = VariableScope,
-  TDataType extends AnyData = AnyData,
+  TDataType extends BaseData = BaseData,
 > extends TgpuNamable {
   readonly resourceType: 'var';
   readonly [$gpuValueOf]: InferGPU<TDataType>;
@@ -77,7 +77,7 @@ export function isVariable<T extends TgpuVar>(
 // Implementation
 // --------------
 
-class TgpuVarImpl<TScope extends VariableScope, TDataType extends AnyData>
+class TgpuVarImpl<TScope extends VariableScope, TDataType extends BaseData>
   implements TgpuVar<TScope, TDataType>, SelfResolvable {
   readonly [$internal] = {};
   readonly resourceType: 'var';

--- a/packages/typegpu/src/core/vertexLayout/vertexLayout.ts
+++ b/packages/typegpu/src/core/vertexLayout/vertexLayout.ts
@@ -228,8 +228,8 @@ class TgpuVertexLayoutImpl<TData extends WgslArray | Disarray>
       stepMode: this.stepMode,
       attributes: [
         ...Object.entries(this.attrib).map(([key, attrib]) => ({
-          format: attrib.format,
-          offset: attrib.offset,
+          format: (attrib as TgpuVertexAttrib).format,
+          offset: (attrib as TgpuVertexAttrib).offset,
           shaderLocation: this._customLocationMap[key],
         })),
       ] as GPUVertexAttribute[],

--- a/packages/typegpu/src/data/attributes.ts
+++ b/packages/typegpu/src/data/attributes.ts
@@ -22,6 +22,7 @@ import { alignmentOf } from './alignmentOf.ts';
 import {
   type AnyData,
   type AnyLooseData,
+  type IsLooseData,
   isLooseData,
   isLooseDecorated,
   type LooseDecorated,
@@ -43,6 +44,7 @@ import {
   isBuiltinAttrib,
   isDecorated,
   isSizeAttrib,
+  type IsWgslData,
   isWgslData,
   type Location,
   type PerspectiveOrLinearInterpolatableData,
@@ -111,9 +113,9 @@ export type ExtractAttributes<T> = T extends {
 export type Decorate<
   TData extends BaseData,
   TAttrib extends AnyAttribute,
-> = TData extends AnyWgslData
+> = IsWgslData<TData> extends true
   ? Decorated<Undecorate<TData>, [TAttrib, ...ExtractAttributes<TData>]>
-  : TData extends AnyLooseData
+  : IsLooseData<TData> extends true
     ? LooseDecorated<Undecorate<TData>, [TAttrib, ...ExtractAttributes<TData>]>
   : never;
 
@@ -126,22 +128,16 @@ export type HasCustomLocation<T> = ExtractAttributes<T>[number] extends []
   : ExtractAttributes<T>[number] extends Location ? true
   : false;
 
-export function attribute<TData extends BaseData, TAttrib extends AnyAttribute>(
-  data: TData,
-  attrib: TAttrib,
+export function attribute(
+  data: BaseData,
+  attrib: AnyAttribute,
 ): Decorated | LooseDecorated {
   if (isDecorated(data)) {
-    return new DecoratedImpl(data.inner, [
-      attrib,
-      ...data.attribs,
-    ]) as Decorated;
+    return new DecoratedImpl(data.inner, [attrib, ...data.attribs]);
   }
 
   if (isLooseDecorated(data)) {
-    return new LooseDecoratedImpl(data.inner, [
-      attrib,
-      ...data.attribs,
-    ]) as LooseDecorated;
+    return new LooseDecoratedImpl(data.inner, [attrib, ...data.attribs]);
   }
 
   if (isLooseData(data)) {

--- a/packages/typegpu/src/data/deepEqual.ts
+++ b/packages/typegpu/src/data/deepEqual.ts
@@ -55,8 +55,7 @@ export function deepEqual(a: AnyData, b: AnyData): boolean {
       const keyB = bKeys[i];
       if (
         keyA !== keyB || !keyA || !keyB ||
-        // biome-ignore lint/style/noNonNullAssertion: they exist
-        !deepEqual(aProps[keyA]!, bProps[keyB]!)
+        !deepEqual(aProps[keyA] as AnyData, bProps[keyB] as AnyData)
       ) {
         return false;
       }
@@ -75,7 +74,7 @@ export function deepEqual(a: AnyData, b: AnyData): boolean {
     return (
       a.addressSpace === b.addressSpace &&
       a.access === b.access &&
-      deepEqual(a.inner, b.inner)
+      deepEqual(a.inner as AnyData, b.inner as AnyData)
     );
   }
 

--- a/packages/typegpu/src/data/matrix.ts
+++ b/packages/typegpu/src/data/matrix.ts
@@ -4,11 +4,11 @@ import { stitch } from '../core/resolve/stitch.ts';
 import { $repr } from '../shared/symbols.ts';
 import { $internal, $resolve } from '../shared/symbols.ts';
 import type { SelfResolvable } from '../types.ts';
-import type { AnyData } from './dataTypes.ts';
 import { f32 } from './numeric.ts';
 import { type ResolvedSnippet, snip } from './snippet.ts';
 import { vec2f, vec3f, vec4f } from './vector.ts';
 import {
+  type BaseData,
   isVec,
   type m2x2f,
   type m3x3f,
@@ -97,7 +97,7 @@ function createMatSchema<
     ignoreImplicitCastWarning: true,
     signature: (...args) => ({
       argTypes: args.map((arg) => (isVec(arg) ? arg : f32)),
-      returnType: schema as unknown as AnyData,
+      returnType: schema as unknown as BaseData,
     }),
     codegenImpl: (_ctx, args) => stitch`${options.type}(${args})`,
   });

--- a/packages/typegpu/src/data/numeric.ts
+++ b/packages/typegpu/src/data/numeric.ts
@@ -41,7 +41,7 @@ const boolCast = dualImpl({
     return !!v;
   },
   codegenImpl: (_ctx, [arg]) =>
-    arg?.dataType.type === 'bool'
+    arg?.dataType === bool
       // Already of type bool
       ? stitch`${arg}`
       : stitch`bool(${arg})`,
@@ -79,7 +79,7 @@ const u32Cast = dualImpl({
     return (v & 0xffffffff) >>> 0;
   },
   codegenImpl: (_ctx, [arg]) =>
-    arg?.dataType.type === 'u32'
+    arg?.dataType === u32
       // Already of type u32
       ? stitch`${arg}`
       : stitch`u32(${arg})`,
@@ -119,7 +119,7 @@ const i32Cast = dualImpl({
     return v | 0;
   },
   codegenImpl: (_ctx, [arg]) =>
-    arg?.dataType.type === 'i32'
+    arg?.dataType === i32
       // Already of type i32
       ? stitch`${arg}`
       : stitch`i32(${arg})`,
@@ -162,7 +162,7 @@ const f32Cast = dualImpl({
     return Math.fround(v);
   },
   codegenImpl: (_ctx, [arg]) =>
-    arg?.dataType.type === 'f32'
+    arg?.dataType === f32
       // Already of type f32
       ? stitch`${arg}`
       : stitch`f32(${arg})`,
@@ -289,7 +289,7 @@ const f16Cast = dualImpl({
   },
   // TODO: make usage of f16() in GPU mode check for feature availability and throw if not available
   codegenImpl: (_ctx, [arg]) =>
-    arg?.dataType.type === 'f16'
+    arg?.dataType === f16
       // Already of type f16
       ? stitch`${arg}`
       : stitch`f16(${arg})`,

--- a/packages/typegpu/src/data/ptr.ts
+++ b/packages/typegpu/src/data/ptr.ts
@@ -4,7 +4,13 @@ import {
   type OriginToPtrParams,
   originToPtrParams,
 } from './snippet.ts';
-import type { Access, AddressSpace, Ptr, StorableData } from './wgslTypes.ts';
+import type {
+  Access,
+  AddressSpace,
+  BaseData,
+  Ptr,
+  StorableData,
+} from './wgslTypes.ts';
 
 export function ptrFn<T extends StorableData>(
   inner: T,
@@ -45,7 +51,7 @@ export function ptrHandle<T extends StorableData>(
 
 export function INTERNAL_createPtr<
   TAddressSpace extends AddressSpace,
-  TInner extends StorableData,
+  TInner extends BaseData,
   TAccess extends Access,
 >(
   addressSpace: TAddressSpace,

--- a/packages/typegpu/src/data/ref.ts
+++ b/packages/typegpu/src/data/ref.ts
@@ -63,7 +63,7 @@ export const ref = (() => {
         );
       }
 
-      if (value.dataType.type === 'ptr') {
+      if (isPtr(value.dataType)) {
         // This can happen if we take a reference of an *implicit* pointer, one
         // made by assigning a reference to a `const`.
         return snip(value.value, explicitFrom(value.dataType), value.origin);

--- a/packages/typegpu/src/data/schemaCallWrapper.ts
+++ b/packages/typegpu/src/data/schemaCallWrapper.ts
@@ -5,8 +5,8 @@ import {
   isGPUCallable,
   type ResolutionCtx,
 } from '../types.ts';
-import type { AnyData } from './dataTypes.ts';
 import type { Snippet } from './snippet.ts';
+import type { BaseData } from './wgslTypes.ts';
 
 /**
  * A wrapper for `schema(item)` or `schema()` call on JS side.
@@ -15,7 +15,7 @@ import type { Snippet } from './snippet.ts';
  * If the schema is not callable, throws an error.
  * Otherwise, returns `schema(item)` or `schema()`.
  */
-export function schemaCallWrapper<T>(schema: AnyData, item?: T): T {
+export function schemaCallWrapper<T>(schema: BaseData, item?: T): T {
   const callSchema = schema as unknown as ((item?: T) => T);
 
   if (hasCast(callSchema)) {
@@ -39,7 +39,7 @@ export function schemaCallWrapper<T>(schema: AnyData, item?: T): T {
  */
 export function schemaCallWrapperGPU(
   ctx: ResolutionCtx,
-  schema: AnyData,
+  schema: BaseData,
   item?: Snippet | undefined,
 ): Snippet {
   if (!isGPUCallable(schema)) {

--- a/packages/typegpu/src/data/sizeOf.ts
+++ b/packages/typegpu/src/data/sizeOf.ts
@@ -81,8 +81,7 @@ const knownSizesMap: Record<string, number> = {
 
 function sizeOfStruct(struct: WgslStruct) {
   let size = 0;
-  const propTypes = struct.propTypes as Record<string, BaseData>;
-  for (const property of Object.values(propTypes)) {
+  for (const property of Object.values(struct.propTypes)) {
     if (Number.isNaN(size)) {
       throw new Error('Only the last property of a struct can be unbounded');
     }
@@ -101,8 +100,7 @@ function sizeOfStruct(struct: WgslStruct) {
 function sizeOfUnstruct(data: Unstruct) {
   let size = 0;
 
-  const propTypes = data.propTypes as Record<string, BaseData>;
-  for (const property of Object.values(propTypes)) {
+  for (const property of Object.values(data.propTypes)) {
     const alignment = customAlignmentOf(property);
     size = roundUp(size, alignment);
     size += sizeOf(property);
@@ -111,8 +109,8 @@ function sizeOfUnstruct(data: Unstruct) {
   return size;
 }
 
-function computeSize(data: object): number {
-  const knownSize = knownSizesMap[(data as BaseData)?.type];
+function computeSize(data: BaseData): number {
+  const knownSize = knownSizesMap[data.type];
 
   if (knownSize !== undefined) {
     return knownSize;

--- a/packages/typegpu/src/data/snippet.ts
+++ b/packages/typegpu/src/data/snippet.ts
@@ -1,7 +1,7 @@
 import { undecorate } from './dataTypes.ts';
-import type { AnyData, UnknownData } from './dataTypes.ts';
+import type { UnknownData } from './dataTypes.ts';
 import { DEV } from '../shared/env.ts';
-import { isNumericSchema } from './wgslTypes.ts';
+import { type BaseData, isNumericSchema } from './wgslTypes.ts';
 
 export type Origin =
   | 'uniform'
@@ -54,7 +54,7 @@ export interface Snippet {
    * The type that `value` is assignable to (not necessary exactly inferred as).
    * E.g. `1.1` is assignable to `f32`, but `1.1` itself is an abstract float
    */
-  readonly dataType: AnyData | UnknownData;
+  readonly dataType: BaseData | UnknownData;
   readonly origin: Origin;
 }
 
@@ -64,7 +64,7 @@ export interface ResolvedSnippet {
    * The type that `value` is assignable to (not necessary exactly inferred as).
    * E.g. `1.1` is assignable to `f32`, but `1.1` itself is an abstract float
    */
-  readonly dataType: AnyData;
+  readonly dataType: BaseData;
   readonly origin: Origin;
 }
 
@@ -73,7 +73,7 @@ export type MapValueToSnippet<T> = { [K in keyof T]: Snippet };
 class SnippetImpl implements Snippet {
   constructor(
     readonly value: unknown,
-    readonly dataType: AnyData | UnknownData,
+    readonly dataType: BaseData | UnknownData,
     readonly origin: Origin,
   ) {}
 }
@@ -88,17 +88,17 @@ export function isSnippetNumeric(snippet: Snippet) {
 
 export function snip(
   value: string,
-  dataType: AnyData,
+  dataType: BaseData,
   origin: Origin,
 ): ResolvedSnippet;
 export function snip(
   value: unknown,
-  dataType: AnyData | UnknownData,
+  dataType: BaseData | UnknownData,
   origin: Origin,
 ): Snippet;
 export function snip(
   value: unknown,
-  dataType: AnyData | UnknownData,
+  dataType: BaseData | UnknownData,
   origin: Origin,
 ): Snippet | ResolvedSnippet {
   if (DEV && isSnippet(value)) {
@@ -109,7 +109,7 @@ export function snip(
   return new SnippetImpl(
     value,
     // We don't care about attributes in snippet land, so we discard that information.
-    undecorate(dataType as AnyData),
+    undecorate(dataType as BaseData),
     origin,
   );
 }

--- a/packages/typegpu/src/data/vector.ts
+++ b/packages/typegpu/src/data/vector.ts
@@ -1,7 +1,6 @@
 import { dualImpl } from '../core/function/dualImpl.ts';
 import { stitch } from '../core/resolve/stitch.ts';
 import { $internal, $repr } from '../shared/symbols.ts';
-import type { AnyData } from './dataTypes.ts';
 import { bool, f16, f32, i32, u32 } from './numeric.ts';
 import {
   Vec2bImpl,
@@ -23,6 +22,7 @@ import {
 } from './vectorImpl.ts';
 import type {
   AnyVecInstance,
+  BaseData,
   Bool,
   F16,
   F32,
@@ -311,12 +311,14 @@ function makeVecSchema<TValue, S extends number | boolean>(
     name: type,
     signature: (...args) => ({
       argTypes: args.map((arg) => isVec(arg) ? arg : primitive),
-      returnType: schema as AnyData,
+      returnType: schema as unknown as BaseData,
     }),
     normalImpl: cpuConstruct,
     ignoreImplicitCastWarning: true,
     codegenImpl: (_ctx, args) => {
-      if (args.length === 1 && args[0]?.dataType === schema) {
+      if (
+        args.length === 1 && args[0]?.dataType === schema as unknown as BaseData
+      ) {
         // Already typed as the schema
         return stitch`${args[0]}`;
       }

--- a/packages/typegpu/src/data/vectorImpl.ts
+++ b/packages/typegpu/src/data/vectorImpl.ts
@@ -1,11 +1,10 @@
 import { $internal, $resolve } from '../shared/symbols.ts';
 import type { SelfResolvable } from '../types.ts';
-import type { AnyData } from './dataTypes.ts';
 import { bool, f16, f32, i32, u32 } from './numeric.ts';
 import { type ResolvedSnippet, snip } from './snippet.ts';
-import type { VecKind } from './wgslTypes.ts';
+import type { BaseData, VecKind } from './wgslTypes.ts';
 
-type VecSchema<S> = AnyData & ((v?: S) => S);
+type VecSchema<S> = BaseData & ((v?: S) => S);
 
 // deno-fmt-ignore
 export abstract class VecBase<S> extends Array implements SelfResolvable {

--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -1303,6 +1303,9 @@ export interface Mat4x4f extends BaseData {
  * between binary and JS representation. Takes into account
  * the `byteAlignment` requirement of its elementType.
  */
+// We restrict the element type to being BaseData, which is the widest type
+// we can use internally to work with generic arrays. The default type of
+// `AnyWgslData` is the best choice for end-users.
 export interface WgslArray<out TElement extends BaseData = BaseData>
   extends BaseData {
   <T extends TElement>(elements: Infer<T>[]): Infer<T>[];
@@ -1334,8 +1337,10 @@ export interface WgslArray<out TElement extends BaseData = BaseData>
  * the `byteAlignment` requirement of its members.
  */
 export interface WgslStruct<
+  // We restrict the type to being Record<string, BaseData>, which is the widest type
+  // we can use internally to work with generic structs.
   // @ts-expect-error: Override variance, as we want structs to behave like objects
-  out TProps extends Record<string, AnyWgslData> = Record<string, AnyWgslData>,
+  out TProps extends Record<string, BaseData> = Record<string, BaseData>,
 > extends BaseData, TgpuNamable {
   readonly [$internal]: {
     isAbstruct: boolean;
@@ -1388,7 +1393,7 @@ export type Access = 'read' | 'write' | 'read-write';
 
 export interface Ptr<
   TAddr extends AddressSpace = AddressSpace,
-  TInner extends StorableData = StorableData,
+  TInner extends BaseData = BaseData,
   TAccess extends Access = Access,
 > extends BaseData {
   readonly type: 'ptr';
@@ -1551,6 +1556,8 @@ export const wgslTypeLiterals = [
 ] as const;
 
 export type WgslTypeLiteral = (typeof wgslTypeLiterals)[number];
+export type IsWgslData<T> = T extends { readonly type: WgslTypeLiteral } ? true
+  : false;
 
 export type PerspectiveOrLinearInterpolatableBaseType =
   | F32

--- a/packages/typegpu/src/errors.ts
+++ b/packages/typegpu/src/errors.ts
@@ -1,8 +1,8 @@
 import type { TgpuBuffer } from './core/buffer/buffer.ts';
 import type { TgpuSlot } from './core/slot/slotTypes.ts';
 import type { TgpuVertexLayout } from './core/vertexLayout/vertexLayout.ts';
-import type { AnyData, Disarray } from './data/dataTypes.ts';
-import type { WgslArray } from './data/wgslTypes.ts';
+import type { Disarray } from './data/dataTypes.ts';
+import type { BaseData, WgslArray } from './data/wgslTypes.ts';
 import { getName, hasTinyestMetadata } from './shared/meta.ts';
 import { DEV, TEST } from './shared/env.ts';
 import type { TgpuBindGroupLayout } from './tgpuBindGroupLayout.ts';
@@ -133,7 +133,7 @@ export class MissingSlotValueError extends Error {
  * @category Errors
  */
 export class NotUniformError extends Error {
-  constructor(value: TgpuBuffer<AnyData>) {
+  constructor(value: TgpuBuffer<BaseData>) {
     super(
       `Buffer '${
         getName(value) ?? '<unnamed>'

--- a/packages/typegpu/src/shared/repr.ts
+++ b/packages/typegpu/src/shared/repr.ts
@@ -1,7 +1,7 @@
 import type { TgpuTexture } from '../core/texture/texture.ts';
 import type { Disarray, Undecorate } from '../data/dataTypes.ts';
 import type { WgslStorageTexture, WgslTexture } from '../data/texture.ts';
-import type { U16, U32, WgslArray } from '../data/wgslTypes.ts';
+import type { BaseData, U16, U32, WgslArray } from '../data/wgslTypes.ts';
 import type {
   $gpuRepr,
   $gpuValueOf,
@@ -109,7 +109,8 @@ export type IsValidVertexSchema<T> =
 /**
  * Accepts only arrays (or disarrays) of u32 or u16.
  */
-export type IsValidIndexSchema<T> = Undecorate<T> extends WgslArray | Disarray
+export type IsValidIndexSchema<T> = Undecorate<T> extends
+  WgslArray<BaseData> | Disarray<BaseData>
   ? (Undecorate<Undecorate<T>['elementType']>) extends U32 | U16 ? true : false
   : false;
 

--- a/packages/typegpu/src/std/atomic.ts
+++ b/packages/typegpu/src/std/atomic.ts
@@ -1,8 +1,13 @@
 import { dualImpl } from '../core/function/dualImpl.ts';
 import { stitch } from '../core/resolve/stitch.ts';
-import type { AnyData } from '../data/dataTypes.ts';
 import { i32, u32 } from '../data/numeric.ts';
-import { type atomicI32, type atomicU32, Void } from '../data/wgslTypes.ts';
+import {
+  type atomicI32,
+  type atomicU32,
+  type BaseData,
+  isAtomic,
+  Void,
+} from '../data/wgslTypes.ts';
 import { safeStringify } from '../shared/stringify.ts';
 type AnyAtomic = atomicI32 | atomicU32;
 
@@ -34,7 +39,7 @@ export const atomicLoad = dualImpl<<T extends AnyAtomic>(a: T) => number>({
   name: 'atomicLoad',
   normalImpl: atomicNormalError,
   signature: (a) => {
-    if (a.type !== 'atomic') {
+    if (!isAtomic(a)) {
       throw new Error(`Invalid atomic type: ${safeStringify(a)}`);
     }
     return { argTypes: [a], returnType: a.inner };
@@ -42,8 +47,8 @@ export const atomicLoad = dualImpl<<T extends AnyAtomic>(a: T) => number>({
   codegenImpl: (_ctx, [a]) => stitch`atomicLoad(&${a})`,
 });
 
-const atomicActionSignature = (a: AnyData, param: AnyData) => {
-  if (a.type !== 'atomic') {
+const atomicActionSignature = (a: BaseData, param: BaseData) => {
+  if (!isAtomic(a)) {
     throw new Error(`Invalid atomic type: ${safeStringify(a)}`);
   }
   return {
@@ -52,8 +57,8 @@ const atomicActionSignature = (a: AnyData, param: AnyData) => {
   };
 };
 
-const atomicOpSignature = (a: AnyData, param: AnyData) => {
-  if (a.type !== 'atomic') {
+const atomicOpSignature = (a: BaseData, param: BaseData) => {
+  if (!isAtomic(a)) {
     throw new Error(`Invalid atomic type: ${safeStringify(a)}`);
   }
   const paramType = a.inner.type === 'u32' ? u32 : i32;

--- a/packages/typegpu/src/std/boolean.ts
+++ b/packages/typegpu/src/std/boolean.ts
@@ -1,6 +1,5 @@
 import { dualImpl } from '../core/function/dualImpl.ts';
 import { stitch } from '../core/resolve/stitch.ts';
-import type { AnyData } from '../data/dataTypes.ts';
 import { bool, f32 } from '../data/numeric.ts';
 import { isSnippetNumeric, snip } from '../data/snippet.ts';
 import { vec2b, vec3b, vec4b } from '../data/vector.ts';
@@ -13,6 +12,7 @@ import {
   type AnyVec3Instance,
   type AnyVecInstance,
   type AnyWgslData,
+  type BaseData,
   isVecInstance,
   type v2b,
   type v3b,
@@ -21,7 +21,7 @@ import {
 import { unify } from '../tgsl/conversion.ts';
 import { sub } from './operators.ts';
 
-function correspondingBooleanVectorSchema(dataType: AnyData) {
+function correspondingBooleanVectorSchema(dataType: BaseData) {
   if (dataType.type.includes('2')) {
     return vec2b;
   }

--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -1,6 +1,5 @@
 import { dualImpl, MissingCpuImplError } from '../core/function/dualImpl.ts';
 import { stitch } from '../core/resolve/stitch.ts';
-import type { AnyData } from '../data/dataTypes.ts';
 import { smoothstepScalar } from '../data/numberOps.ts';
 import {
   abstractFloat,
@@ -32,6 +31,7 @@ import {
   type AnyNumericVecInstance,
   type AnySignedVecInstance,
   type AnyWgslData,
+  type BaseData,
   isHalfPrecisionSchema,
   isNumericSchema,
   isVecInstance,
@@ -55,18 +55,18 @@ type NumVec = AnyNumericVecInstance;
 
 // helpers
 
-const unaryIdentitySignature = (arg: AnyData) => {
+const unaryIdentitySignature = (arg: BaseData) => {
   return {
     argTypes: [arg],
     returnType: arg,
   };
 };
 
-const variadicUnifySignature = (...args: AnyData[]) => {
+const variadicUnifySignature = (...args: BaseData[]) => {
   const uargs = unify(args) ?? args;
   return ({
     argTypes: uargs,
-    returnType: uargs[0] as AnyData,
+    returnType: uargs[0] as BaseData,
   });
 };
 

--- a/packages/typegpu/src/std/texture.ts
+++ b/packages/typegpu/src/std/texture.ts
@@ -10,6 +10,7 @@ import { dualImpl, MissingCpuImplError } from '../core/function/dualImpl.ts';
 import { f32, u32 } from '../data/numeric.ts';
 import { vec2u, vec3u, vec4f, vec4i, vec4u } from '../data/vector.ts';
 import {
+  type BaseData,
   type v2f,
   type v2i,
   type v2u,
@@ -46,7 +47,6 @@ import type {
   textureStorage3d,
 } from '../data/texture.ts';
 
-import type { AnyData } from '../data/dataTypes.ts';
 import type { comparisonSampler, sampler } from '../data/sampler.ts';
 
 function sampleCpu<T extends texture1d>(
@@ -122,7 +122,7 @@ export const textureSample = dualImpl({
   signature: (...args) => {
     const isDepth = (args[0] as WgslTexture).type.startsWith('texture_depth');
     return {
-      argTypes: args as AnyData[],
+      argTypes: args as BaseData[],
       returnType: isDepth ? f32 : vec4f,
     };
   },
@@ -181,7 +181,7 @@ export const textureSampleBias = dualImpl({
   normalImpl: sampleBiasCpu,
   codegenImpl: (_ctx, args) => stitch`textureSampleBias(${args})`,
   signature: (...args) => ({
-    argTypes: args as AnyData[],
+    argTypes: args as BaseData[],
     returnType: vec4f,
   }),
 });

--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -38,7 +38,6 @@ import {
   NotSampledError,
   type SampledFlag,
 } from './core/texture/usageExtension.ts';
-import type { AnyData } from './data/dataTypes.ts';
 import { f32, i32, u32 } from './data/numeric.ts';
 import {
   type StorageTextureDimension,
@@ -94,11 +93,11 @@ export type TgpuLayoutEntryBase = {
 };
 
 export type TgpuLayoutUniform = TgpuLayoutEntryBase & {
-  uniform: AnyWgslData;
+  uniform: BaseData;
 };
 
 export type TgpuLayoutStorage = TgpuLayoutEntryBase & {
-  storage: AnyWgslData | ((arrayLength: number) => AnyWgslData);
+  storage: BaseData | ((arrayLength: number) => BaseData);
   /** @default 'readonly' */
   access?: 'mutable' | 'readonly';
 };
@@ -287,7 +286,7 @@ type UnwrapRuntimeConstructorInner<
 > = T extends (_: number) => BaseData ? ReturnType<T> : T;
 
 export type UnwrapRuntimeConstructor<
-  T extends AnyData | ((_: number) => AnyData),
+  T extends BaseData | ((_: number) => BaseData),
 > = T extends unknown ? UnwrapRuntimeConstructorInner<T> : never;
 
 interface BindGroupLayoutInternals<

--- a/packages/typegpu/src/tgsl/accessProp.ts
+++ b/packages/typegpu/src/tgsl/accessProp.ts
@@ -1,6 +1,5 @@
 import { stitch } from '../core/resolve/stitch.ts';
 import {
-  type AnyData,
   InfixDispatch,
   isUnstruct,
   MatrixColumnsAccess,
@@ -28,6 +27,7 @@ import {
   vec4u,
 } from '../data/vector.ts';
 import {
+  type BaseData,
   isMat,
   isNaturallyEphemeral,
   isPtr,
@@ -72,7 +72,7 @@ type SwizzleLength = 1 | 2 | 3 | 4;
 
 const swizzleLenToType: Record<
   SwizzleableType,
-  Record<SwizzleLength, AnyData>
+  Record<SwizzleLength, BaseData>
 > = {
   f: {
     1: f32,
@@ -110,7 +110,10 @@ export function accessProp(
   target: Snippet,
   propName: string,
 ): Snippet | undefined {
-  if (infixKinds.includes(target.dataType.type) && propName in infixOperators) {
+  if (
+    infixKinds.includes((target.dataType as BaseData).type) &&
+    propName in infixOperators
+  ) {
     return snip(
       new InfixDispatch(
         propName,
@@ -211,7 +214,7 @@ export function accessProp(
     );
   }
 
-  if (isKnownAtComptime(target) || target.dataType.type === 'unknown') {
+  if (isKnownAtComptime(target) || target.dataType === UnknownData) {
     // biome-ignore lint/suspicious/noExplicitAny: we either know exactly what it is, or have no idea at all
     return coerceToSnippet((target.value as any)[propName]);
   }

--- a/packages/typegpu/src/tgsl/consoleLog/deserializers.ts
+++ b/packages/typegpu/src/tgsl/consoleLog/deserializers.ts
@@ -19,6 +19,7 @@ import {
 } from '../../data/vector.ts';
 import {
   type AnyWgslData,
+  type BaseData,
   isWgslArray,
   isWgslData,
   isWgslStruct,
@@ -106,9 +107,10 @@ const deserializerMap: DeserializerMap = {
  */
 function deserialize(
   data: Uint32Array,
-  dataType: AnyWgslData,
+  dataType: BaseData,
 ): unknown {
-  const maybeDeserializer = deserializerMap[dataType.type];
+  const maybeDeserializer =
+    deserializerMap[dataType.type as AnyWgslData['type']];
   if (maybeDeserializer) {
     return maybeDeserializer(data);
   }
@@ -142,7 +144,7 @@ function deserialize(
  */
 function deserializeCompound(
   data: Uint32Array,
-  dataTypes: (AnyWgslData | string)[],
+  dataTypes: (BaseData | string)[],
 ): unknown[] {
   let index = 0;
   return dataTypes.map((info) => {

--- a/packages/typegpu/src/tgsl/consoleLog/serializers.ts
+++ b/packages/typegpu/src/tgsl/consoleLog/serializers.ts
@@ -2,6 +2,7 @@ import type { TgpuMutable } from '../../core/buffer/bufferShorthand.ts';
 import { fn, type TgpuFn } from '../../core/function/tgpuFn.ts';
 import { slot } from '../../core/slot/slot.ts';
 import { privateVar } from '../../core/variable/tgpuVariable.ts';
+import type { AnyData } from '../../data/dataTypes.ts';
 import { mat2x2f, mat3x3f, mat4x4f } from '../../data/matrix.ts';
 import { bool, f16, f32, i32, u32 } from '../../data/numeric.ts';
 import { sizeOf } from '../../data/sizeOf.ts';
@@ -25,6 +26,7 @@ import {
 import {
   type AnyWgslData,
   type Atomic,
+  type BaseData,
   isWgslArray,
   isWgslStruct,
   type U32,
@@ -196,7 +198,7 @@ for (const [name, serializer] of Object.entries(serializerMap)) {
 // Helpers
 // -------
 
-function generateHeader(argTypes: AnyWgslData[]): string {
+function generateHeader(argTypes: BaseData[]): string {
   return `(${argTypes.map((_, i) => `_arg_${i}`).join(', ')})`;
 }
 
@@ -208,11 +210,11 @@ function generateHeader(argTypes: AnyWgslData[]): string {
  * @param dataType - The WGSL data type descriptor to return a serializer for
  * @param dataBuffer - A buffer to store serialized log call data (a necessary external for the returned function)
  */
-function getSerializer<T extends AnyWgslData>(
+function getSerializer<T extends BaseData>(
   dataType: T,
   dataBuffer: TgpuMutable<WgslArray<SerializedLogCallData>>,
 ): TgpuFn<(args_0: T) => Void> {
-  const maybeSerializer = serializerMap[dataType.type];
+  const maybeSerializer = serializerMap[dataType.type as AnyWgslData['type']];
   if (maybeSerializer) {
     return (maybeSerializer as TgpuFn<(args_0: T) => Void>).with(
       dataBufferSlot,
@@ -251,12 +253,12 @@ function getSerializer<T extends AnyWgslData>(
  * @param dataBuffer - A buffer to store serialized log call data (a necessary external for the returned function)
  */
 function createCompoundSerializer(
-  dataTypes: AnyWgslData[],
+  dataTypes: BaseData[],
   dataBuffer: TgpuMutable<WgslArray<SerializedLogCallData>>,
 ) {
   const usedSerializers: Record<string, unknown> = {};
 
-  const shell = fn(dataTypes);
+  const shell = fn(dataTypes as AnyData[]);
   const header = generateHeader(dataTypes);
   const body = dataTypes.map((arg, i) => {
     usedSerializers[`serializer${i}`] = getSerializer(arg, dataBuffer);

--- a/packages/typegpu/src/tgsl/conversion.ts
+++ b/packages/typegpu/src/tgsl/conversion.ts
@@ -1,15 +1,16 @@
 import { stitch } from '../core/resolve/stitch.ts';
-import type { AnyData, UnknownData } from '../data/dataTypes.ts';
+import { UnknownData } from '../data/dataTypes.ts';
 import { undecorate } from '../data/dataTypes.ts';
 import { derefSnippet, RefOperator } from '../data/ref.ts';
 import { schemaCallWrapperGPU } from '../data/schemaCallWrapper.ts';
 import { snip, type Snippet } from '../data/snippet.ts';
 import {
-  type AnyWgslData,
+  type BaseData,
   type F16,
   type F32,
   type I32,
   isMat,
+  isPtr,
   isVec,
   type Ptr,
   type U32,
@@ -17,13 +18,14 @@ import {
 } from '../data/wgslTypes.ts';
 import { invariant, WgslTypeError } from '../errors.ts';
 import { DEV, TEST } from '../shared/env.ts';
+import { safeStringify } from '../shared/stringify.ts';
 import { assertExhaustive } from '../shared/utilityTypes.ts';
 import type { ResolutionCtx } from '../types.ts';
 
 type ConversionAction = 'ref' | 'deref' | 'cast' | 'none';
 
 type ConversionRankInfo =
-  | { rank: number; action: 'cast'; targetType: AnyData }
+  | { rank: number; action: 'cast'; targetType: BaseData }
   | { rank: number; action: Exclude<ConversionAction, 'cast'> };
 
 const INFINITE_RANK: ConversionRankInfo = {
@@ -32,8 +34,8 @@ const INFINITE_RANK: ConversionRankInfo = {
 };
 
 function getAutoConversionRank(
-  src: AnyData,
-  dest: AnyData,
+  src: BaseData,
+  dest: BaseData,
 ): ConversionRankInfo {
   const trueSrc = undecorate(src);
   const trueDst = undecorate(dest);
@@ -68,14 +70,14 @@ function getAutoConversionRank(
 }
 
 function getImplicitConversionRank(
-  src: AnyData,
-  dest: AnyData,
+  src: BaseData,
+  dest: BaseData,
 ): ConversionRankInfo {
   const trueSrc = undecorate(src);
   const trueDst = undecorate(dest);
 
   if (
-    trueSrc.type === 'ptr' &&
+    isPtr(trueSrc) &&
     // Only dereferencing implicit pointers, otherwise we'd have a types mismatch between TS and WGSL
     trueSrc.implicit &&
     getAutoConversionRank(trueSrc.inner, trueDst).rank <
@@ -85,7 +87,7 @@ function getImplicitConversionRank(
   }
 
   if (
-    trueDst.type === 'ptr' &&
+    isPtr(trueDst) &&
     getAutoConversionRank(trueSrc, trueDst.inner).rank <
       Number.POSITIVE_INFINITY
   ) {
@@ -131,8 +133,8 @@ function getImplicitConversionRank(
 }
 
 function getConversionRank(
-  src: AnyData,
-  dest: AnyData,
+  src: BaseData,
+  dest: BaseData,
   allowImplicit: boolean,
 ): ConversionRankInfo {
   const autoRank = getAutoConversionRank(src, dest);
@@ -152,18 +154,18 @@ export type ConversionResultAction = {
 };
 
 export type ConversionResult = {
-  targetType: AnyData;
+  targetType: BaseData;
   actions: ConversionResultAction[];
   hasImplicitConversions?: boolean;
 };
 
 function findBestType(
-  types: AnyData[],
-  uniqueTypes: AnyData[],
+  types: BaseData[],
+  uniqueTypes: BaseData[],
   allowImplicit: boolean,
 ): ConversionResult | undefined {
   let bestResult:
-    | { type: AnyData; details: ConversionRankInfo[]; sum: number }
+    | { type: BaseData; details: ConversionRankInfo[]; sum: number }
     | undefined;
 
   for (const targetType of uniqueTypes) {
@@ -206,8 +208,8 @@ function findBestType(
 }
 
 export function getBestConversion(
-  types: AnyData[],
-  targetTypes?: AnyData[],
+  types: BaseData[],
+  targetTypes?: BaseData[],
 ): ConversionResult | undefined {
   if (types.length === 0) return undefined;
 
@@ -232,7 +234,7 @@ function applyActionToSnippet(
   ctx: ResolutionCtx,
   snippet: Snippet,
   action: ConversionResultAction,
-  targetType: AnyData,
+  targetType: BaseData,
 ): Snippet {
   if (action.action === 'none') {
     return snip(
@@ -262,33 +264,33 @@ function applyActionToSnippet(
   }
 }
 
-export function unify<T extends (AnyData | UnknownData)[]>(
+export function unify<T extends (BaseData | UnknownData)[] | []>(
   inTypes: T,
-  restrictTo?: AnyData[] | undefined,
-): { [K in keyof T]: AnyWgslData } | undefined {
-  if (inTypes.some((type) => type.type === 'unknown')) {
+  restrictTo?: BaseData[] | undefined,
+): { [K in keyof T]: BaseData } | undefined {
+  if (inTypes.some((type) => type === UnknownData)) {
     return undefined;
   }
 
-  const conversion = getBestConversion(inTypes as AnyData[], restrictTo);
+  const conversion = getBestConversion(inTypes as BaseData[], restrictTo);
   if (!conversion) {
     return undefined;
   }
 
   return inTypes.map(() => conversion.targetType) as {
-    [K in keyof T]: AnyWgslData;
+    [K in keyof T]: BaseData;
   };
 }
 
 export function convertToCommonType<T extends Snippet[]>(
   ctx: ResolutionCtx,
   values: T,
-  restrictTo?: AnyData[] | undefined,
+  restrictTo?: BaseData[] | undefined,
   verbose = true,
 ): T | undefined {
   const types = values.map((value) => value.dataType);
 
-  if (types.some((type) => type.type === 'unknown')) {
+  if (types.some((type) => type === UnknownData)) {
     return undefined;
   }
 
@@ -298,7 +300,7 @@ export function convertToCommonType<T extends Snippet[]>(
     );
   }
 
-  const conversion = getBestConversion(types as AnyData[], restrictTo);
+  const conversion = getBestConversion(types as BaseData[], restrictTo);
   if (!conversion) {
     return undefined;
   }
@@ -307,7 +309,7 @@ export function convertToCommonType<T extends Snippet[]>(
     console.warn(
       `Implicit conversions from [\n${
         values
-          .map((v) => `  ${v.value}: ${v.dataType.type}`)
+          .map((v) => `  ${v.value}: ${safeStringify(v.dataType)}`)
           .join(
             ',\n',
           )
@@ -326,14 +328,14 @@ Consider using explicit conversions instead.`,
 export function tryConvertSnippet(
   ctx: ResolutionCtx,
   snippet: Snippet,
-  targetDataType: AnyData,
+  targetDataType: BaseData,
   verbose = true,
 ): Snippet {
   if (targetDataType === snippet.dataType) {
     return snip(snippet.value, targetDataType, snippet.origin);
   }
 
-  if (snippet.dataType.type === 'unknown') {
+  if (snippet.dataType === UnknownData) {
     // This is it, it's now or never. We expect a specific type, and we're going to get it
     return snip(
       stitch`${snip(snippet.value, targetDataType, snippet.origin)}`,

--- a/packages/typegpu/src/tgsl/generationHelpers.ts
+++ b/packages/typegpu/src/tgsl/generationHelpers.ts
@@ -1,9 +1,10 @@
-import { type AnyData, UnknownData } from '../data/dataTypes.ts';
+import { UnknownData } from '../data/dataTypes.ts';
 import { abstractFloat, abstractInt, bool, f32, i32 } from '../data/numeric.ts';
 import { isRef } from '../data/ref.ts';
 import { isSnippet, snip, type Snippet } from '../data/snippet.ts';
 import {
   type AnyWgslData,
+  type BaseData,
   type F32,
   type I32,
   isMatInstance,
@@ -34,7 +35,7 @@ export function numericLiteralToSnippet(value: number): Snippet {
   return snip(value, abstractFloat, /* origin */ 'constant');
 }
 
-export function concretize<T extends AnyData>(type: T): T | F32 | I32 {
+export function concretize<T extends BaseData>(type: T): T | F32 | I32 {
   if (type.type === 'abstractFloat') {
     return f32;
   }
@@ -65,10 +66,10 @@ export type GenerationCtx = ResolutionCtx & {
    * It is used exclusively for inferring the types of structs and arrays.
    * It is modified exclusively by `typedExpression` function.
    */
-  expectedType: AnyData | undefined;
+  expectedType: BaseData | undefined;
 
   readonly topFunctionScope: FunctionScopeLayer | undefined;
-  readonly topFunctionReturnType: AnyData | undefined;
+  readonly topFunctionReturnType: BaseData | undefined;
 
   indent(): string;
   dedent(): string;
@@ -83,7 +84,7 @@ export type GenerationCtx = ResolutionCtx & {
    * reported using this function, and used to infer
    * the return type of the owning function.
    */
-  reportReturnType(dataType: AnyData): void;
+  reportReturnType(dataType: BaseData): void;
 
   readonly shelllessRepo: ShelllessRepository;
 };

--- a/packages/typegpu/src/tgsl/shaderGenerator.ts
+++ b/packages/typegpu/src/tgsl/shaderGenerator.ts
@@ -1,13 +1,13 @@
 import type { Block, Expression, Statement } from 'tinyest';
-import type { AnyData } from '../data/dataTypes.ts';
 import type { Snippet } from '../data/snippet.ts';
 import type { GenerationCtx } from './generationHelpers.ts';
+import type { BaseData } from '../data/wgslTypes.ts';
 
 export interface ShaderGenerator {
   initGenerator(ctx: GenerationCtx): void;
   block(body: Block): string;
   identifier(id: string): Snippet;
-  typedExpression(expression: Expression, expectedType: AnyData): Snippet;
+  typedExpression(expression: Expression, expectedType: BaseData): Snippet;
   expression(expression: Expression): Snippet;
   statement(statement: Statement): string;
   functionDefinition(body: Block): string;

--- a/packages/typegpu/src/tgsl/shellless.ts
+++ b/packages/typegpu/src/tgsl/shellless.ts
@@ -2,10 +2,15 @@ import {
   createShelllessImpl,
   type ShelllessImpl,
 } from '../core/function/shelllessImpl.ts';
-import type { AnyData } from '../data/dataTypes.ts';
+import { UnknownData } from '../data/dataTypes.ts';
 import { RefOperator } from '../data/ref.ts';
 import type { Snippet } from '../data/snippet.ts';
-import { isPtr } from '../data/wgslTypes.ts';
+import {
+  type BaseData,
+  isPtr,
+  isWgslArray,
+  isWgslStruct,
+} from '../data/wgslTypes.ts';
 import { WgslTypeError } from '../errors.ts';
 import { getResolutionCtx } from '../execMode.ts';
 import { getMetaData, getName } from '../shared/meta.ts';
@@ -13,19 +18,21 @@ import { concretize } from './generationHelpers.ts';
 
 type AnyFn = (...args: never[]) => unknown;
 
-function shallowEqualSchemas(a: AnyData, b: AnyData): boolean {
+function shallowEqualSchemas(a: BaseData, b: BaseData): boolean {
   if (a.type !== b.type) return false;
-  if (a.type === 'ptr' && b.type === 'ptr') {
-    return a.access === b.access &&
+  if (isPtr(a) && isPtr(b)) {
+    return (
+      a.access === b.access &&
       a.addressSpace === b.addressSpace &&
       a.implicit === b.implicit &&
-      shallowEqualSchemas(a.inner, b.inner);
+      shallowEqualSchemas(a.inner, b.inner)
+    );
   }
-  if (a.type === 'array' && b.type === 'array') {
+  if (isWgslArray(a) && isWgslArray(b)) {
     return a.elementCount === b.elementCount &&
-      shallowEqualSchemas(a.elementType as AnyData, b.elementType as AnyData);
+      shallowEqualSchemas(a.elementType as BaseData, b.elementType as BaseData);
   }
-  if (a.type === 'struct' && b.type === 'struct') {
+  if (isWgslStruct(a) && isWgslStruct(b)) {
     // Only structs with the same identity are considered equal
     return a === b;
   }
@@ -51,7 +58,7 @@ export class ShelllessRepository {
 
     const argTypes = (argSnippets ?? []).map((s, index) => {
       if (s.value instanceof RefOperator) {
-        if (s.dataType.type === 'unknown') {
+        if (s.dataType === UnknownData) {
           throw new WgslTypeError(
             `d.ref() created with primitive types must be stored in a variable before use`,
           );
@@ -59,7 +66,7 @@ export class ShelllessRepository {
         return s.dataType;
       }
 
-      if (s.dataType.type === 'unknown') {
+      if (s.dataType === UnknownData) {
         throw new Error(
           `Passed illegal value ${s.value} as the #${index} argument to ${meta.name}(...)`,
         );
@@ -101,7 +108,7 @@ export class ShelllessRepository {
       const variant = cache.find((v) =>
         v.argTypes.length === argTypes.length &&
         v.argTypes.every((t, i) =>
-          shallowEqualSchemas(t, argTypes[i] as AnyData)
+          shallowEqualSchemas(t, argTypes[i] as BaseData)
         )
       );
       if (variant) {

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -2,7 +2,6 @@ import * as tinyest from 'tinyest';
 import { stitch } from '../core/resolve/stitch.ts';
 import { arrayOf } from '../data/array.ts';
 import {
-  type AnyData,
   ConsoleLog,
   InfixDispatch,
   isLooseData,
@@ -133,8 +132,8 @@ type Operator =
   | tinyest.UnaryOperator;
 
 function operatorToType<
-  TL extends AnyData | UnknownData,
-  TR extends AnyData | UnknownData,
+  TL extends wgsl.BaseData | UnknownData,
+  TR extends wgsl.BaseData | UnknownData,
 >(lhs: TL, op: Operator, rhs?: TR): TL | TR | wgsl.Bool {
   if (!rhs) {
     if (op === '!' || op === '~') {
@@ -223,7 +222,7 @@ ${this.ctx.pre}}`;
   public blockVariable(
     varType: 'var' | 'let' | 'const',
     id: string,
-    dataType: wgsl.AnyWgslData | UnknownData,
+    dataType: wgsl.BaseData | UnknownData,
     origin: Origin,
   ): Snippet {
     const naturallyEphemeral = wgsl.isNaturallyEphemeral(dataType);
@@ -278,7 +277,7 @@ ${this.ctx.pre}}`;
    */
   public typedExpression(
     expression: tinyest.Expression,
-    expectedType: AnyData,
+    expectedType: wgsl.BaseData,
   ) {
     const prevExpectedType = this.ctx.expectedType;
     this.ctx.expectedType = expectedType;
@@ -328,11 +327,11 @@ ${this.ctx.pre}}`;
         return snip(lhsExpr.value === rhsExpr.value, bool, 'constant');
       }
 
-      if (lhsExpr.dataType.type === 'unknown') {
+      if (lhsExpr.dataType === UnknownData) {
         throw new WgslTypeError(`Left-hand side of '${op}' is of unknown type`);
       }
 
-      if (rhsExpr.dataType.type === 'unknown') {
+      if (rhsExpr.dataType === UnknownData) {
         throw new WgslTypeError(
           `Right-hand side of '${op}' is of unknown type`,
         );
@@ -599,7 +598,7 @@ ${this.ctx.pre}}`;
         );
         if (shellless) {
           const converted = args.map((s, idx) => {
-            const argType = shellless.argTypes[idx] as AnyData;
+            const argType = shellless.argTypes[idx] as wgsl.BaseData;
             return tryConvertSnippet(
               this.ctx,
               s,
@@ -670,11 +669,11 @@ ${this.ctx.pre}}`;
       const [_, valueNodes] = expression;
       // Array Expression
       const arrType = this.ctx.expectedType;
-      let elemType: AnyData;
+      let elemType: wgsl.BaseData;
       let values: Snippet[];
 
       if (wgsl.isWgslArray(arrType)) {
-        elemType = arrType.elementType as AnyData;
+        elemType = arrType.elementType;
         // The array is typed, so its elements should be as well.
         values = valueNodes.map((value) =>
           this.typedExpression(value, elemType)
@@ -698,7 +697,8 @@ ${this.ctx.pre}}`;
             const snippetStr =
               this.ctx.resolve(snippet.value, snippet.dataType).value;
             const snippetType =
-              this.ctx.resolve(concretize(snippet.dataType as AnyData)).value;
+              this.ctx.resolve(concretize(snippet.dataType as wgsl.BaseData))
+                .value;
             throw new WgslTypeError(
               `'${snippetStr}' reference cannot be used in an array constructor.\n-----\nTry '${snippetType}(${snippetStr})' or 'arrayOf(${snippetType}, count)([...])' to copy the value instead.\n-----`,
             );
@@ -845,7 +845,7 @@ Try 'return ${typeStr}(${str});' instead.
         );
 
         invariant(
-          returnSnippet.dataType.type !== 'unknown',
+          returnSnippet.dataType !== UnknownData,
           'Return type should be known',
         );
 
@@ -896,7 +896,7 @@ ${this.ctx.pre}else ${alternate}`;
       }
 
       const ephemeral = isEphemeralSnippet(eq);
-      let dataType = eq.dataType as wgsl.AnyWgslData;
+      let dataType = eq.dataType as wgsl.BaseData;
       const naturallyEphemeral = wgsl.isNaturallyEphemeral(dataType);
 
       if (isLooseData(eq.dataType)) {
@@ -907,7 +907,7 @@ ${this.ctx.pre}else ${alternate}`;
 
       if (eq.value instanceof RefOperator) {
         // We're assigning a newly created `d.ref()`
-        if (eq.dataType.type !== 'unknown') {
+        if (eq.dataType !== UnknownData) {
           throw new WgslTypeError(
             `Cannot store d.ref() in a variable if it references another value. Copy the value passed into d.ref() instead.`,
           );
@@ -915,7 +915,7 @@ ${this.ctx.pre}else ${alternate}`;
         const refSnippet = eq.value.snippet;
         const varName = this.refVariable(
           rawId,
-          concretize(refSnippet.dataType as AnyData) as wgsl.StorableData,
+          concretize(refSnippet.dataType as wgsl.BaseData) as wgsl.StorableData,
         );
         return stitch`${this.ctx.pre}var ${varName} = ${
           tryConvertSnippet(
@@ -965,7 +965,7 @@ ${this.ctx.pre}else ${alternate}`;
           if (!(eq.value instanceof RefOperator)) {
             // If what we're assigning is something preceded by `&`, then it's a value
             // created using `d.ref()`. Otherwise, it's an implicit pointer
-            dataType = implicitFrom(dataType);
+            dataType = implicitFrom(dataType as wgsl.Ptr);
           }
         }
       } else {

--- a/packages/typegpu/src/unwrapper.ts
+++ b/packages/typegpu/src/unwrapper.ts
@@ -8,11 +8,11 @@ import type {
 } from './core/sampler/sampler.ts';
 import type { TgpuTexture, TgpuTextureView } from './core/texture/texture.ts';
 import type { TgpuVertexLayout } from './core/vertexLayout/vertexLayout.ts';
-import type { AnyData } from './data/dataTypes.ts';
 import type {
   TgpuBindGroup,
   TgpuBindGroupLayout,
 } from './tgpuBindGroupLayout.ts';
+import type { BaseData } from './data/wgslTypes.ts';
 
 export interface Unwrapper {
   readonly device: GPUDevice;
@@ -20,7 +20,7 @@ export interface Unwrapper {
   unwrap(resource: TgpuRenderPipeline): GPURenderPipeline;
   unwrap(resource: TgpuBindGroupLayout): GPUBindGroupLayout;
   unwrap(resource: TgpuBindGroup): GPUBindGroup;
-  unwrap(resource: TgpuBuffer<AnyData>): GPUBuffer;
+  unwrap(resource: TgpuBuffer<BaseData>): GPUBuffer;
   unwrap(resource: TgpuTextureView): GPUTextureView;
   unwrap(resource: TgpuVertexLayout): GPUVertexBufferLayout;
   unwrap(resource: TgpuSampler): GPUSampler;

--- a/packages/typegpu/tests/struct.test.ts
+++ b/packages/typegpu/tests/struct.test.ts
@@ -412,7 +412,7 @@ describe('WgslStruct', () => {
     const foo = d.struct({}) as d.WgslStruct;
 
     expectTypeOf(foo.type).toEqualTypeOf<'struct'>();
-    expectTypeOf(foo.propTypes).toEqualTypeOf<Record<string, d.AnyWgslData>>();
+    expectTypeOf(foo.propTypes).toEqualTypeOf<Record<string, d.BaseData>>();
   });
 
   it('accepts every struct by default', () => {

--- a/packages/typegpu/tests/tgsl/generationHelpers.test.ts
+++ b/packages/typegpu/tests/tgsl/generationHelpers.test.ts
@@ -207,10 +207,10 @@ describe('generationHelpers', () => {
 
     it('coerces arrays to unknown', () => {
       const resInt = coerceToSnippet([1, 2, 3]);
-      expect(resInt.dataType.type).toBe('unknown');
+      expect(resInt.dataType).toBe(UnknownData);
 
       const resFloat = coerceToSnippet([1.0, 2.5, -0.5]);
-      expect(resFloat.dataType.type).toBe('unknown');
+      expect(resFloat.dataType).toBe(UnknownData);
     });
 
     it('returns UnknownData for arrays of incompatible types', () => {

--- a/packages/typegpu/tests/utils/parseResolved.ts
+++ b/packages/typegpu/tests/utils/parseResolved.ts
@@ -1,6 +1,6 @@
 import type * as tinyest from 'tinyest';
 import { type Assertion, expect } from 'vitest';
-import type { AnyData } from '../../src/data/index.ts';
+import type { BaseData } from '../../src/data/index.ts';
 import type { UnknownData } from '../../src/data/dataTypes.ts';
 import { ResolutionCtxImpl } from '../../src/resolutionCtx.ts';
 import { provideCtx } from '../../src/execMode.ts';
@@ -75,6 +75,6 @@ export function expectSnippetOf(
 
 export function expectDataTypeOf(
   cb: () => unknown,
-): Assertion<AnyData | UnknownData> {
-  return expect<AnyData | UnknownData>(extractSnippetFromFn(cb).dataType);
+): Assertion<BaseData | UnknownData> {
+  return expect<BaseData | UnknownData>(extractSnippetFromFn(cb).dataType);
 }


### PR DESCRIPTION
Using `AnyData` and `AnyWgslData` internally complicates our types, causing the TypeScript server to chug in generic use-cases, and occasionally crash with "Type instantiation was excessively deep". This PR makes more use of `BaseData` internally, which is a subtype of all schemas.