### PR TITLE
feat: Export the Withable type

### DIFF
--- a/packages/typegpu/src/index.ts
+++ b/packages/typegpu/src/index.ts
@@ -51,6 +51,7 @@ export type {
   ValidateBufferSchema,
   ValidateStorageSchema,
   ValidateUniformSchema,
+  Withable,
   WithBinding,
   WithCompute,
   WithFragment,


### PR DESCRIPTION
## Summary
- Exports the `Withable` type from the typegpu package to allow library creators to accept user bind groups without exposing the pipeline.

Closes #2114