### PR TITLE
fix: Better no color attachment handling

### DIFF
--- a/packages/typegpu/src/core/pipeline/renderPipeline.ts
+++ b/packages/typegpu/src/core/pipeline/renderPipeline.ts
@@ -626,7 +626,7 @@ class TgpuRenderPipelineImpl implements TgpuRenderPipeline {
 
         return attachment;
       }) as GPURenderPassColorAttachment[])
-      : [null];
+      : [];
 
     const renderPassDescriptor: GPURenderPassDescriptor = {
       label: getName(internals.core) ?? '<unnamed>',


### PR DESCRIPTION
Some runtimes do not handle `[null]` as no color attachment which leads to stencil example breaking