### PR TITLE
impr: Show some love to concurrent sum (maintenance)

### DIFF
--- a/packages/typegpu-concurrent-scan/src/compute/applySums.ts
+++ b/packages/typegpu-concurrent-scan/src/compute/applySums.ts
@@ -1,29 +1,23 @@
 import tgpu from 'typegpu';
 import * as d from 'typegpu/data';
-import {
-  calculateIndex,
-  operatorSlot,
-  uniformAddLayout as uniformOpLayout,
-  workgroupSize,
-} from '../schemas.ts';
+import { operatorSlot, uniformAddLayout, WORKGROUP_SIZE } from '../schemas.ts';
 
 export const uniformOp = tgpu['~unstable'].computeFn({
-  workgroupSize: [workgroupSize],
+  workgroupSize: [WORKGROUP_SIZE],
   in: {
     gid: d.builtin.globalInvocationId,
-    nwg: d.builtin.numWorkgroups,
     wid: d.builtin.workgroupId,
   },
-})(({ gid, nwg, wid }) => {
-  const globalIdx = calculateIndex(gid, nwg);
-  const workgroupId = calculateIndex(wid, nwg);
+})(({ gid, wid }) => {
+  const globalIdx = gid.x;
+  const workgroupId = wid.x;
   const baseIdx = globalIdx * 8;
-  const sumValue = uniformOpLayout.$.sums[workgroupId];
+  const sumValue = uniformAddLayout.$.sums[workgroupId];
 
   for (let i = d.u32(0); i < 8; i++) {
-    if (baseIdx + i < uniformOpLayout.$.input.length) {
-      (uniformOpLayout.$.input[baseIdx + i] as number) = operatorSlot.$(
-        uniformOpLayout.$.input[baseIdx + i] as number,
+    if (baseIdx + i < uniformAddLayout.$.input.length) {
+      (uniformAddLayout.$.input[baseIdx + i] as number) = operatorSlot.$(
+        uniformAddLayout.$.input[baseIdx + i] as number,
         sumValue as number,
       );
     }

--- a/packages/typegpu-concurrent-scan/src/compute/singleScan.ts
+++ b/packages/typegpu-concurrent-scan/src/compute/singleScan.ts
@@ -1,29 +1,27 @@
 import tgpu from 'typegpu';
 import {
-  calculateIndex,
   identitySlot,
   operatorSlot,
   scanLayout,
-  workgroupSize,
+  WORKGROUP_SIZE,
 } from '../schemas.ts';
 import * as d from 'typegpu/data';
 import * as std from 'typegpu/std';
 
-const workgroupMemory = tgpu['~unstable'].workgroupVar(
-  d.arrayOf(d.f32, workgroupSize),
+const workgroupMemory = tgpu.workgroupVar(
+  d.arrayOf(d.f32, WORKGROUP_SIZE),
 );
 
 export const scanGreatestBlock = tgpu['~unstable'].computeFn({
-  workgroupSize: [workgroupSize],
+  workgroupSize: [WORKGROUP_SIZE],
   in: {
     gid: d.builtin.globalInvocationId,
     lid: d.builtin.localInvocationId,
-    nwg: d.builtin.numWorkgroups,
     wid: d.builtin.workgroupId,
   },
-})(({ gid, lid, nwg, wid }) => {
-  const globalIdx = calculateIndex(gid, nwg);
-  const globalWid = calculateIndex(wid, nwg);
+})(({ gid, lid, wid }) => {
+  const globalIdx = gid.x;
+  const workgroupId = wid.x;
   const localIdx = lid.x;
   const arrayLength = scanLayout.$.input.length;
   let offset = d.u32(1);
@@ -54,13 +52,13 @@ export const scanGreatestBlock = tgpu['~unstable'].computeFn({
   workgroupMemory.$[localIdx] = partialSums[lastIdx] as number;
 
   // Upsweep
-  for (let d_val = d.u32(workgroupSize / 2); d_val > 0; d_val >>= 1) {
+  for (let d_val = d.u32(WORKGROUP_SIZE / 2); d_val > 0; d_val >>= 1) {
     std.workgroupBarrier();
     if (localIdx < d_val) {
       const ai = offset * (2 * localIdx + 1) - 1;
       const bi = offset * (2 * localIdx + 2) - 1;
       workgroupMemory.$[bi] = operatorSlot.$(
-        workgroupMemory.$[ai],
+        workgroupMemory.$[ai] as number,
         workgroupMemory.$[bi] as number,
       );
     }
@@ -68,7 +66,7 @@ export const scanGreatestBlock = tgpu['~unstable'].computeFn({
   }
 
   if (localIdx === 0) {
-    scanLayout.$.sums[globalWid] = workgroupMemory
-      .$[workgroupSize - 1] as number;
+    scanLayout.$.sums[workgroupId] = workgroupMemory
+      .$[WORKGROUP_SIZE - 1] as number;
   }
 });

--- a/packages/typegpu-concurrent-scan/src/schemas.ts
+++ b/packages/typegpu-concurrent-scan/src/schemas.ts
@@ -1,15 +1,12 @@
-import tgpu, { type TgpuFn } from 'typegpu';
+import tgpu from 'typegpu';
 import * as d from 'typegpu/data';
 
-export const workgroupSize = 256;
+export const WORKGROUP_SIZE = 256;
 export interface BinaryOp {
-  operation: TgpuFn<(a: d.F32, b: d.F32) => d.F32>;
+  operation: (a: number, b: number) => number;
   identityElement: number;
 }
 
-export const calculateIndex = tgpu.fn([d.vec3u, d.vec3u], d.u32)((id, nwg) =>
-  id.x + id.y * nwg.x + id.z * nwg.x * nwg.y
-);
 export const scanLayout = tgpu.bindGroupLayout({
   input: { storage: d.arrayOf(d.f32), access: 'mutable' },
   sums: { storage: d.arrayOf(d.f32), access: 'mutable' },
@@ -19,5 +16,5 @@ export const uniformAddLayout = tgpu.bindGroupLayout({
   input: { storage: d.arrayOf(d.f32), access: 'mutable' },
   sums: { storage: d.arrayOf(d.f32), access: 'readonly' },
 });
-export const operatorSlot = tgpu.slot<TgpuFn>();
+export const operatorSlot = tgpu.slot<(a: number, b: number) => number>();
 export const identitySlot = tgpu.slot<number>();


### PR DESCRIPTION
This PR:
- **fixes caching bug (no caching happened before) by removing the computer "mode" (full scan vs total sum) from the cache key and creating the pipelines on demand**
- improves types for the binary op function (wider now - no problems with `std` and no `TgpuFn<any>`)
- simplified the timing logic by passing the ownership of the `QuerySet` to the user (the computer just writes the timestamps)
- removed some redundant shader builtins and logic
- general code cleanup (_slightly opinionated maybe_)
