### PR TITLE
docs: Make sidebar and code editor disabled by default

### DIFF
--- a/apps/typegpu-docs/src/utils/examples/exampleViewStateAtoms.ts
+++ b/apps/typegpu-docs/src/utils/examples/exampleViewStateAtoms.ts
@@ -2,11 +2,11 @@ import { atomWithStorage } from 'jotai/utils';
 
 const storageOptions = { getOnInit: true };
 
-export const menuShownAtom = atomWithStorage('menu-shown', true, undefined, storageOptions);
+export const menuShownAtom = atomWithStorage('menu-shown', false, undefined, storageOptions);
 
 export const codeEditorShownAtom = atomWithStorage(
   'code-editor-shown',
-  true,
+  false,
   undefined,
   storageOptions,
 );


### PR DESCRIPTION
This makes it so when we share an example the user does not have to press two buttons before seeing the actual example