### PR TITLE
chore: Suggest workspace TS version when opening the project in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "[astro]": {
     "editor.defaultFormatter": "astro-build.astro-vscode"
   },
-  "typescript.preferences.importModuleSpecifier": "relative"
+  "typescript.preferences.importModuleSpecifier": "relative",
+  "typescript.enablePromptUseWorkspaceTsdk": true
 }


### PR DESCRIPTION
<img width="673" height="226" alt="image" src="https://github.com/user-attachments/assets/ecfc5d40-3077-47b1-9f42-0b86addcb75d" />
