### PR TITLE
chore: Sort treeshake-test results by impact in GitHub comments

### DIFF
--- a/apps/treeshake-test/resultsTable.ts
+++ b/apps/treeshake-test/resultsTable.ts
@@ -50,9 +50,10 @@ export class ResultsTable {
     }
     output += ' |\n';
 
-    const sortedResults = [...this.#results.entries()].toSorted(
-      ([, a], [, b]) => this.#maxAbsoluteChange(b) - this.#maxAbsoluteChange(a),
-    );
+    const sortedResults = [...this.#results.entries()]
+      .map(([test, row]) => [test, row, this.#maxAbsoluteChange(row)] as const)
+      .toSorted(([, , scoreA], [, , scoreB]) => scoreB - scoreA)
+      .map(([test, row]) => [test, row] as const);
 
     for (const [test, row] of sortedResults) {
       output += `| ${test.replaceAll('_', ' ')}`;


### PR DESCRIPTION
- Results in the treeshake-test GitHub comment are now sorted by the maximum absolute % size change across all bundlers, descending
- Entries with the biggest regressions or improvements appear at the top, making it easier to spot what changed