### PR TITLE
impr: Improve orbit camera to better behave on mouse scroll-wheel

### DIFF
--- a/apps/typegpu-docs/src/examples/common/setup-orbit-camera.ts
+++ b/apps/typegpu-docs/src/examples/common/setup-orbit-camera.ts
@@ -130,7 +130,19 @@ export function setupOrbitCamera(
     'wheel',
     (event: WheelEvent) => {
       event.preventDefault();
-      zoomCamera(event.deltaY);
+      let delta = event.deltaY;
+      // Normalize deltaY across input devices (touchpad vs mouse wheel).
+      // Mouse wheel (deltaMode LINE) reports ~3 per notch; convert to pixels.
+      // Touchpad (deltaMode PIXEL) reports small values directly.
+      if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+        delta *= 16;
+      } else if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+        delta *= canvas.clientHeight;
+      }
+      // Clamp to prevent large jumps from discrete mouse wheel notches
+      // (Chrome reports deltaMode PIXEL with ~100 per mouse wheel notch).
+      delta = Math.sign(delta) * Math.min(Math.abs(delta), 60);
+      zoomCamera(delta);
     },
     { passive: false },
   );


### PR DESCRIPTION
## Summary

Normalizes `WheelEvent.deltaY` based on `deltaMode` in the orbit camera's
wheel event handler. Mouse scroll-wheel events report values ~20x larger
than touchpad events (Chrome: ~100px per notch in pixel mode; Firefox: ~3
in line mode), making zoom extremely jumpy with a mouse.

## Changes

**`apps/typegpu-docs/src/examples/common/setup-orbit-camera.ts`**
- Check `event.deltaMode` and convert line/page deltas to pixel equivalents
- Clamp the normalized delta to 60 to prevent large discrete jumps from
  mouse wheel notches (Chrome reports `deltaMode=0` but `deltaY=100`)

The touchpad experience is unchanged since touchpad events already use
pixel mode with small delta values (1-5).

Reference: [WheelEvent.deltaMode](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaMode)

Fixes #2160

This contribution was developed with AI assistance (Claude Code).