### PR TITLE
impr: Depreacte the `partialWrite` API and add `patch` API that better matches the `write` features

### DIFF
--- a/apps/typegpu-docs/src/content/docs/fundamentals/buffers.mdx
+++ b/apps/typegpu-docs/src/content/docs/fundamentals/buffers.mdx
@@ -364,12 +364,12 @@ buffer.write([d.vec3u(4, 5, 6)], {
 ```
 
 :::note
-In this particular case the `writePartial` method described in the next section would be a more convenient option, but the `startOffset` and `endOffset` options are useful for writing bigger slices of data.
+In this particular case the `patch` method described in the next section would be a more convenient option, but the `startOffset` and `endOffset` options are useful for writing bigger slices of data.
 :::
 
-### Partial writes
+### Patching buffers
 
-When you want to update only a subset of a buffer’s fields, you can use the `.writePartial(data)` method. This method updates only the fields provided in the `data` object and leaves the rest unchanged.
+When you want to update only a subset of a buffer’s fields, you can use the `.patch(data)` method. This method updates only the fields provided in the `data` object and leaves the rest unchanged.
 
 The format of the `data` value depends on your schema type:
 
@@ -377,9 +377,8 @@ The format of the `data` value depends on your schema type:
   Provide an object with keys corresponding to the subset of the schema’s fields you wish to update.
 
 - **For `d.array` schemas:**
-  Provide an array of objects. Each object should specify:
-  - `idx`: the index of the element to update.
-  - `value`: the new value for that element.
+  Provide an object with numeric keys as indices mapped to new values (sparse update),
+  a plain array for full replacement, or a `TypedArray` for byte-level replacement.
 
 ```ts twoslash
 import tgpu, { d } from 'typegpu';
@@ -394,12 +393,12 @@ const Planet = d.struct({
 
 const planetBuffer = root.createBuffer(Planet);
 
-planetBuffer.writePartial({
+planetBuffer.patch({
   mass: 123.1,
-  colors: [
-    { idx: 2, value: d.vec3f(1, 0, 0) },
-    { idx: 4, value: d.vec3f(0, 0, 1) },
-  ],
+  colors: {
+    2: d.vec3f(1, 0, 0),
+    4: d.vec3f(0, 0, 1),
+  },
 });
 ```
 

--- a/apps/typegpu-docs/src/content/docs/integration/wesl-interoperability.mdx
+++ b/apps/typegpu-docs/src/content/docs/integration/wesl-interoperability.mdx
@@ -124,15 +124,12 @@ const buffer = root.createBuffer(FishArray(512)).$usage('storage');
 //    ^?
 
 // Updating the 123rd fish's position
-buffer.writePartial([
-  {
-    idx: 123,
-    value: {
-      state: {
-        posit
-        //   ^|
-      },
-    }
+buffer.patch({
+  123: {
+    state: {
+      posit
+      //   ^|
+    },
   }
-]);
+});
 ```

--- a/apps/typegpu-docs/src/examples/algorithms/genetic-racing/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/genetic-racing/index.ts
@@ -401,7 +401,7 @@ function updateAspect() {
     return;
   }
   lastAspect = nextAspect;
-  params.writePartial({ aspect: nextAspect });
+  params.patch({ aspect: nextAspect });
 }
 
 function updatePopulation(nextPopulation: number) {
@@ -410,7 +410,7 @@ function updatePopulation(nextPopulation: number) {
     return;
   }
   population = clamped;
-  params.writePartial({ population: clamped });
+  params.patch({ population: clamped });
   ga.reinitCurrent(population);
 }
 
@@ -421,7 +421,7 @@ function frame() {
     if (pendingEvolve) {
       ga.evolve(population);
       steps = 0;
-      params.writePartial({ generation: ga.generation });
+      params.patch({ generation: ga.generation });
       pendingEvolve = false;
     }
 
@@ -430,7 +430,7 @@ function frame() {
       pendingEvolve = true;
     } else {
       const innerSteps = Math.min(stepsToRun, STEPS_PER_DISPATCH);
-      params.writePartial({ stepsPerDispatch: innerSteps });
+      params.patch({ stepsPerDispatch: innerSteps });
       const dispatchCount = Math.ceil(stepsToRun / innerSteps);
 
       const simEncoder = root.device.createCommandEncoder();
@@ -480,7 +480,7 @@ function applyTrack(result: TrackResult) {
   trackTexture.write(
     new ImageData(new Uint8ClampedArray(result.data), result.width, result.height),
   );
-  params.writePartial({
+  params.patch({
     spawnX: result.spawn.position[0],
     spawnY: result.spawn.position[1],
     spawnAngle: result.spawn.angle,
@@ -490,7 +490,7 @@ function applyTrack(result: TrackResult) {
 
 function applyGridSize(W: number, H: number) {
   const scale = 5 / Math.max(W, H);
-  params.writePartial(
+  params.patch(
     Object.fromEntries(
       Object.entries(BASE_SPATIAL_PARAMS).map(([k, v]) => [k, v * scale]),
     ) as typeof BASE_SPATIAL_PARAMS,
@@ -511,7 +511,7 @@ function startSimulation() {
   steps = 0;
   pendingEvolve = false;
   displayedBestFitness = 0;
-  params.writePartial({ generation: 0 });
+  params.patch({ generation: 0 });
   ga.init();
 
   updateAspect();
@@ -589,7 +589,7 @@ export const controls = defineControls({
     max: 0.4,
     step: 0.005,
     onSliderChange: (value: number) => {
-      params.writePartial({ mutationRate: value });
+      params.patch({ mutationRate: value });
     },
   },
   'Mutation strength': {
@@ -598,7 +598,7 @@ export const controls = defineControls({
     max: 0.8,
     step: 0.01,
     onSliderChange: (value: number) => {
-      params.writePartial({ mutationStrength: value });
+      params.patch({ mutationStrength: value });
     },
   },
 });

--- a/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/index.ts
@@ -300,7 +300,7 @@ function runFlood() {
 
 function drawAtPosition(canvasX: number, canvasY: number) {
   const rect = canvas.getBoundingClientRect();
-  brushUniform.writePartial({
+  brushUniform.patch({
     center: d.vec2f((canvasX * width) / rect.width, (canvasY * height) / rect.height),
   });
   drawSeed.with(resources.maskBindGroup).dispatchThreads(width, height);
@@ -371,7 +371,7 @@ const onMouseDown = (e: MouseEvent) => {
   if (e.button !== 0 && e.button !== 2) {
     return;
   }
-  brushUniform.writePartial({ erasing: e.button === 2 ? 1 : 0 });
+  brushUniform.patch({ erasing: e.button === 2 ? 1 : 0 });
   isDrawing = true;
   lastDrawPos = null;
   const rect = canvas.getBoundingClientRect();
@@ -395,7 +395,7 @@ const onTouchStart = (e: TouchEvent) => {
   isDrawing = true;
   lastDrawPos = null;
   const rect = canvas.getBoundingClientRect();
-  brushUniform.writePartial({ erasing: e.touches.length === 2 ? 1 : 0 });
+  brushUniform.patch({ erasing: e.touches.length === 2 ? 1 : 0 });
   const pos = getTouchPosition(rect, e.touches);
   interpolateAndDraw(pos.x, pos.y);
 };
@@ -405,7 +405,7 @@ const onTouchMove = (e: TouchEvent) => {
     return;
   }
   e.preventDefault();
-  brushUniform.writePartial({ erasing: e.touches.length === 2 ? 1 : 0 });
+  brushUniform.patch({ erasing: e.touches.length === 2 ? 1 : 0 });
   const rect = canvas.getBoundingClientRect();
   const pos = getTouchPosition(rect, e.touches);
   interpolateAndDraw(pos.x, pos.y);
@@ -427,7 +427,7 @@ canvas.addEventListener('touchend', onTouchEnd);
 canvas.addEventListener('touchcancel', onTouchEnd);
 
 function updateBrushSize() {
-  brushUniform.writePartial({
+  brushUniform.patch({
     radius: Math.ceil(Math.min(width, height) * brushSize),
   });
 }
@@ -449,14 +449,14 @@ export const controls = defineControls({
   'Show positive distance': {
     initial: true,
     onToggleChange(value: boolean) {
-      paramsUniform.writePartial({ showOutside: value ? 1 : 0 });
+      paramsUniform.patch({ showOutside: value ? 1 : 0 });
       render();
     },
   },
   'Show negative distance': {
     initial: false,
     onToggleChange(value: boolean) {
-      paramsUniform.writePartial({ showInside: value ? 1 : 0 });
+      paramsUniform.patch({ showInside: value ? 1 : 0 });
       render();
     },
   },

--- a/apps/typegpu-docs/src/examples/geometry/lines-combinations/index.ts
+++ b/apps/typegpu-docs/src/examples/geometry/lines-combinations/index.ts
@@ -338,7 +338,7 @@ let subdiv = {
 };
 
 const draw = (timeMs: number) => {
-  uniformsBuffer.writePartial({
+  uniformsBuffer.patch({
     time: timeMs * 1e-3,
   });
   const colorAttachment: ColorAttachment = {
@@ -453,7 +453,7 @@ export const controls = defineControls({
     options: Object.keys(fillOptions),
     onSelectChange: async (selected) => {
       fillType = fillOptions[selected as keyof typeof fillOptions];
-      uniformsBuffer.writePartial({ fillType });
+      uniformsBuffer.patch({ fillType });
     },
   },
   'Subdiv. Level': {

--- a/apps/typegpu-docs/src/examples/image-processing/background-segmentation/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/background-segmentation/index.ts
@@ -198,7 +198,7 @@ function updateCropBounds(aspectRatio: number) {
       uvMaxY = uvMinY + cropHeight;
     }
   }
-  paramsUniform.writePartial({
+  paramsUniform.patch({
     cropBounds: d.vec4f(uvMinX, uvMinY, uvMaxX, uvMaxY),
   });
 }
@@ -313,7 +313,7 @@ export const controls = defineControls({
     options: ['mipmaps', 'gaussian'],
     async onSelectChange(value) {
       useGaussianBlur = value === 'gaussian';
-      paramsUniform.writePartial({ useGaussian: useGaussianBlur ? 1 : 0 });
+      paramsUniform.patch({ useGaussian: useGaussianBlur ? 1 : 0 });
     },
   },
   'blur strength': {
@@ -323,7 +323,7 @@ export const controls = defineControls({
     step: 1,
     onSliderChange(newValue) {
       blurStrength = newValue;
-      paramsUniform.writePartial({ sampleBias: blurStrength });
+      paramsUniform.patch({ sampleBias: blurStrength });
     },
   },
   'square crop': {

--- a/apps/typegpu-docs/src/examples/image-processing/image-tuning/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/image-tuning/index.ts
@@ -284,7 +284,7 @@ export const controls = defineControls({
     onSelectChange: async (selected) => {
       if (selected === 'None') {
         currentLUTTexture = defaultLUTTexture;
-        lut.writePartial({ enabled: 0 });
+        lut.patch({ enabled: 0 });
       } else {
         await updateLUT(LUTFiles[selected as keyof typeof LUTFiles]);
       }
@@ -297,7 +297,7 @@ export const controls = defineControls({
     max: 2.0,
     step: 0.1,
     onSliderChange(value) {
-      adjustments.writePartial({ exposure: value });
+      adjustments.patch({ exposure: value });
       render();
     },
   },
@@ -307,7 +307,7 @@ export const controls = defineControls({
     max: 2.0,
     step: 0.1,
     onSliderChange(value) {
-      adjustments.writePartial({ contrast: value });
+      adjustments.patch({ contrast: value });
       render();
     },
   },
@@ -317,7 +317,7 @@ export const controls = defineControls({
     max: 2.0,
     step: 0.1,
     onSliderChange(value) {
-      adjustments.writePartial({ highlights: value });
+      adjustments.patch({ highlights: value });
       render();
     },
   },
@@ -327,7 +327,7 @@ export const controls = defineControls({
     max: 1.9,
     step: 0.1,
     onSliderChange(value) {
-      adjustments.writePartial({ shadows: value });
+      adjustments.patch({ shadows: value });
       render();
     },
   },
@@ -337,7 +337,7 @@ export const controls = defineControls({
     max: 2.0,
     step: 0.1,
     onSliderChange(value) {
-      adjustments.writePartial({ saturation: value });
+      adjustments.patch({ saturation: value });
       render();
     },
   },

--- a/apps/typegpu-docs/src/examples/rendering/box-raytracing/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/box-raytracing/index.ts
@@ -262,7 +262,7 @@ const runner = (timestamp: number) => {
     Math.sin(frame) * cameraDistance + cameraAnchor.z,
   );
 
-  uniforms.writePartial({
+  uniforms.patch({
     canvasDims: d.vec2f(width, height),
     invViewMatrix: mat4.aim(cameraPosition, cameraAnchor, d.vec3f(0, 1, 0), d.mat4x4f()),
   });
@@ -300,7 +300,7 @@ export const controls = defineControls({
     min: 0.1,
     max: 1,
     onSliderChange: (value) => {
-      uniforms.writePartial({
+      uniforms.patch({
         boxSize: value,
       });
     },
@@ -311,7 +311,7 @@ export const controls = defineControls({
     min: 0.2,
     max: 2,
     onSliderChange: (value) => {
-      uniforms.writePartial({
+      uniforms.patch({
         materialDensity: value,
       });
     },

--- a/apps/typegpu-docs/src/examples/rendering/clouds/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/clouds/index.ts
@@ -94,7 +94,7 @@ resizeObserver.observe(canvas);
 let frameId: number;
 
 function render(timestamp: number) {
-  paramsUniform.writePartial({ time: (timestamp / 1000) % 500 });
+  paramsUniform.patch({ time: (timestamp / 1000) % 500 });
 
   pipeline
     .with(bindGroup)
@@ -137,7 +137,7 @@ export const controls = defineControls({
     initial: 'medium',
     options: ['very high', 'high', 'medium', 'low', 'very low'],
     onSelectChange(value) {
-      paramsUniform.writePartial(qualityOptions[value]);
+      paramsUniform.patch(qualityOptions[value]);
     },
   },
 });

--- a/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.ts
@@ -287,7 +287,7 @@ const resizeObserver = new ResizeObserver((entries) => {
       10000,
       d.mat4x4f(),
     );
-    cameraBuffer.writePartial({ projection: newProj });
+    cameraBuffer.patch({ projection: newProj });
   }
 });
 resizeObserver.observe(canvas);
@@ -310,7 +310,7 @@ function updateCameraPosition() {
   const newCameraPos = d.vec4f(newCamX, newCamY, newCamZ, 1);
 
   const newView = m.mat4.lookAt(newCameraPos, d.vec3f(0, 0, 0), d.vec3f(0, 1, 0), d.mat4x4f());
-  cameraBuffer.writePartial({ view: newView, position: newCameraPos });
+  cameraBuffer.patch({ view: newView, position: newCameraPos });
 }
 
 function updateCameraOrbit(dx: number, dy: number) {
@@ -454,21 +454,21 @@ export const controls = defineControls({
     initial: materialProps.ambient,
     onColorChange: (value) => {
       materialProps.ambient = value;
-      materialBuffer.writePartial({ ambient: materialProps.ambient });
+      materialBuffer.patch({ ambient: materialProps.ambient });
     },
   },
   'diffuse color': {
     initial: materialProps.diffuse,
     onColorChange: (value) => {
       materialProps.diffuse = value;
-      materialBuffer.writePartial({ diffuse: materialProps.diffuse });
+      materialBuffer.patch({ diffuse: materialProps.diffuse });
     },
   },
   'specular color': {
     initial: materialProps.specular,
     onColorChange: (value) => {
       materialProps.specular = value;
-      materialBuffer.writePartial({ specular: materialProps.specular });
+      materialBuffer.patch({ specular: materialProps.specular });
     },
   },
   shininess: {
@@ -478,7 +478,7 @@ export const controls = defineControls({
     step: 1,
     onSliderChange: (value) => {
       materialProps.shininess = value;
-      materialBuffer.writePartial({ shininess: value });
+      materialBuffer.patch({ shininess: value });
     },
   },
   reflectivity: {
@@ -488,7 +488,7 @@ export const controls = defineControls({
     step: 0.1,
     onSliderChange: (value) => {
       materialProps.reflectivity = value;
-      materialBuffer.writePartial({ reflectivity: value });
+      materialBuffer.patch({ reflectivity: value });
     },
   },
 });

--- a/apps/typegpu-docs/src/examples/rendering/jelly-slider/camera.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-slider/camera.ts
@@ -88,7 +88,7 @@ export class CameraController {
     const jitteredProj = m.mat4.mul(jitterMatrix, this.#baseProj, d.mat4x4f());
     const jitteredProjInv = m.mat4.invert(jitteredProj, d.mat4x4f());
 
-    this.#uniform.writePartial({
+    this.#uniform.patch({
       proj: jitteredProj,
       projInv: jitteredProjInv,
     });
@@ -98,7 +98,7 @@ export class CameraController {
     this.#view = m.mat4.lookAt(position, target, up, d.mat4x4f());
     this.#viewInv = m.mat4.invert(this.#view, d.mat4x4f());
 
-    this.#uniform.writePartial({
+    this.#uniform.patch({
       view: this.#view,
       viewInv: this.#viewInv,
     });
@@ -111,7 +111,7 @@ export class CameraController {
     this.#baseProj = m.mat4.perspective(fov, width / height, near, far, d.mat4x4f());
     this.#baseProjInv = m.mat4.invert(this.#baseProj, d.mat4x4f());
 
-    this.#uniform.writePartial({
+    this.#uniform.patch({
       proj: this.#baseProj,
       projInv: this.#baseProjInv,
     });

--- a/apps/typegpu-docs/src/examples/rendering/jelly-slider/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-slider/index.ts
@@ -885,7 +885,7 @@ export const controls = defineControls({
       const dir1 = std.normalize(d.vec3f(0.18, -0.3, 0.64));
       const dir2 = std.normalize(d.vec3f(-0.5, -0.14, -0.8));
       const finalDir = std.normalize(std.mix(dir1, dir2, v));
-      lightUniform.writePartial({
+      lightUniform.patch({
         direction: finalDir,
       });
     },

--- a/apps/typegpu-docs/src/examples/rendering/jelly-switch/camera.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-switch/camera.ts
@@ -87,7 +87,7 @@ export class CameraController {
     const jitteredProj = m.mat4.mul(jitterMatrix, this.#baseProj, d.mat4x4f());
     const jitteredProjInv = m.mat4.invert(jitteredProj, d.mat4x4f());
 
-    this.#uniform.writePartial({
+    this.#uniform.patch({
       proj: jitteredProj,
       projInv: jitteredProjInv,
     });
@@ -97,7 +97,7 @@ export class CameraController {
     this.#view = m.mat4.lookAt(position, target, up, d.mat4x4f());
     this.#viewInv = m.mat4.invert(this.#view, d.mat4x4f());
 
-    this.#uniform.writePartial({
+    this.#uniform.patch({
       view: this.#view,
       viewInv: this.#viewInv,
     });
@@ -110,7 +110,7 @@ export class CameraController {
     this.#baseProj = m.mat4.perspective(fov, width / height, near, far, d.mat4x4f());
     this.#baseProjInv = m.mat4.invert(this.#baseProj, d.mat4x4f());
 
-    this.#uniform.writePartial({
+    this.#uniform.patch({
       proj: this.#baseProj,
       projInv: this.#baseProjInv,
     });

--- a/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.ts
@@ -663,7 +663,7 @@ export const controls = defineControls({
       const dir1 = std.normalize(d.vec3f(0.18, -0.3, 0.64));
       const dir2 = std.normalize(d.vec3f(-0.5, -0.14, -0.8));
       const finalDir = std.normalize(std.mix(dir1, dir2, v));
-      lightUniform.writePartial({
+      lightUniform.patch({
         direction: finalDir,
       });
     },

--- a/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.ts
@@ -29,7 +29,7 @@ const { cleanupCamera } = setupOrbitCamera(
     minZoom: 8,
     maxZoom: 40,
   },
-  (updates) => cameraUniform.writePartial(updates),
+  (updates) => cameraUniform.patch(updates),
 );
 
 // shaders
@@ -127,7 +127,7 @@ export const controls = defineControls({
   'light color': {
     initial: p.initialControls.lightColor,
     onColorChange(value) {
-      exampleControlsUniform.writePartial({ lightColor: value });
+      exampleControlsUniform.patch({ lightColor: value });
     },
   },
   'light direction': {
@@ -136,13 +136,13 @@ export const controls = defineControls({
     initial: p.initialControls.lightDirection,
     step: d.vec3f(0.01, 0.01, 0.01),
     onVectorSliderChange(v) {
-      exampleControlsUniform.writePartial({ lightDirection: v });
+      exampleControlsUniform.patch({ lightDirection: v });
     },
   },
   'ambient color': {
     initial: p.initialControls.ambientColor,
     onColorChange(value) {
-      exampleControlsUniform.writePartial({ ambientColor: value });
+      exampleControlsUniform.patch({ ambientColor: value });
     },
   },
   'ambient strength': {
@@ -151,7 +151,7 @@ export const controls = defineControls({
     initial: p.initialControls.ambientStrength,
     step: 0.01,
     onSliderChange(v) {
-      exampleControlsUniform.writePartial({ ambientStrength: v });
+      exampleControlsUniform.patch({ ambientStrength: v });
     },
   },
   'specular exponent': {
@@ -160,7 +160,7 @@ export const controls = defineControls({
     initial: p.initialControls.specularExponent,
     step: 0.1,
     onSliderChange(v) {
-      exampleControlsUniform.writePartial({ specularExponent: v });
+      exampleControlsUniform.patch({ specularExponent: v });
     },
   },
 });

--- a/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.ts
@@ -612,7 +612,7 @@ export const controls = defineControls({
     max: 64,
     step: 1,
     onSliderChange: (v) => {
-      shadowParams.writePartial({ pcfSamples: v });
+      shadowParams.patch({ pcfSamples: v });
     },
   },
   'PCF Disk Radius': {
@@ -621,7 +621,7 @@ export const controls = defineControls({
     max: 0.1,
     step: 0.001,
     onSliderChange: (v) => {
-      shadowParams.writePartial({ diskRadius: v });
+      shadowParams.patch({ diskRadius: v });
     },
   },
   'Normal Bias Base': {
@@ -630,7 +630,7 @@ export const controls = defineControls({
     max: 0.1,
     step: 0.0001,
     onSliderChange: (v) => {
-      shadowParams.writePartial({ normalBiasBase: v });
+      shadowParams.patch({ normalBiasBase: v });
     },
   },
   'Normal Bias Slope': {
@@ -639,7 +639,7 @@ export const controls = defineControls({
     max: 0.5,
     step: 0.0005,
     onSliderChange: (v) => {
-      shadowParams.writePartial({ normalBiasSlope: v });
+      shadowParams.patch({ normalBiasSlope: v });
     },
   },
 });

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.ts
@@ -52,7 +52,7 @@ const { cleanupCamera } = setupOrbitCamera(
     minZoom: 5,
     maxZoom: 100,
   },
-  (updates) => cameraBuffer.writePartial(updates),
+  (updates) => cameraBuffer.patch(updates),
 );
 
 const cameraBindGroup = root.createBindGroup(cameraLayout, {

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles/index.ts
@@ -52,7 +52,7 @@ const { cleanupCamera } = setupOrbitCamera(
     minZoom: 5,
     maxZoom: 100,
   },
-  (updates) => cameraBuffer.writePartial(updates),
+  (updates) => cameraBuffer.patch(updates),
 );
 
 const cameraBindGroup = root.createBindGroup(cameraLayout, {

--- a/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.ts
@@ -270,12 +270,12 @@ const shadowPipeline = root.createRenderPipeline({
 function updateLightDirection(dir: d.v3f) {
   currentLightDirection = dir;
 
-  light.writePartial({
+  light.patch({
     direction: dir,
   });
 
   const newLightViewProj = makeLightViewProj(currentLightDirection);
-  lightSpaceUniform.writePartial({
+  lightSpaceUniform.patch({
     viewProj: newLightViewProj,
   });
 }
@@ -350,7 +350,7 @@ const resizeObserver = new ResizeObserver(() => {
     100,
     d.mat4x4f(),
   );
-  cameraUniform.writePartial({
+  cameraUniform.patch({
     projection: newProjection,
   });
 });
@@ -369,7 +369,7 @@ export const controls = defineControls({
         d.vec3f(0, 1, 0),
         d.mat4x4f(),
       );
-      cameraUniform.writePartial({
+      cameraUniform.patch({
         view: newView,
         position: d.vec3f(value, 2, 5),
       });

--- a/apps/typegpu-docs/src/examples/rendering/smoky-triangle/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/smoky-triangle/index.ts
@@ -82,7 +82,7 @@ const context = root.configureContext({ canvas, alphaMode: 'premultiplied' });
 
 let frameId: number;
 function frame(timestamp: number) {
-  paramsUniform.writePartial({
+  paramsUniform.patch({
     time: timestamp / 1000,
     grainSeed: Math.floor(Math.random() * 100),
   });
@@ -100,7 +100,7 @@ export const controls = {
     max: 0.2,
     step: 0.001,
     onSliderChange(v: number) {
-      paramsUniform.writePartial({ distortion: v });
+      paramsUniform.patch({ distortion: v });
     },
   },
   Sharpness: {
@@ -109,36 +109,36 @@ export const controls = {
     max: 7,
     step: 0.1,
     onSliderChange(v: number) {
-      paramsUniform.writePartial({ sharpness: v ** 2 });
+      paramsUniform.patch({ sharpness: v ** 2 });
     },
   },
   'From Color': {
     initial: [0.057, 0.2235, 0.4705],
     onColorChange(value: readonly [number, number, number]) {
-      paramsUniform.writePartial({ fromColor: d.vec3f(...value) });
+      paramsUniform.patch({ fromColor: d.vec3f(...value) });
     },
   },
   'To Color': {
     initial: [1.538, 0.784, 2],
     onColorChange(value: readonly [number, number, number]) {
-      paramsUniform.writePartial({ toColor: d.vec3f(...value) });
+      paramsUniform.patch({ toColor: d.vec3f(...value) });
     },
   },
   'Polar Coordinates': {
     initial: false,
     onToggleChange(value: boolean) {
-      paramsUniform.writePartial({ polarCoords: value ? 1 : 0 });
+      paramsUniform.patch({ polarCoords: value ? 1 : 0 });
     },
   },
   Squashed: {
     initial: true,
     onToggleChange(value: boolean) {
-      paramsUniform.writePartial({ squashed: value ? 1 : 0 });
+      paramsUniform.patch({ squashed: value ? 1 : 0 });
     },
   },
   'Clouds Preset': {
     onButtonClick() {
-      paramsUniform.writePartial({
+      paramsUniform.patch({
         distortion: 0.05,
         sharpness: 4.5 ** 2,
         fromColor: d.vec3f(0.057, 0.2235, 0.4705),
@@ -150,7 +150,7 @@ export const controls = {
   },
   'Fire Preset': {
     onButtonClick() {
-      paramsUniform.writePartial({
+      paramsUniform.patch({
         distortion: 0.1,
         sharpness: 7 ** 2,
         fromColor: d.vec3f(2, 0.4, 0.5),

--- a/apps/typegpu-docs/src/examples/rendering/xor-dev-centrifuge-2/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/xor-dev-centrifuge-2/index.ts
@@ -108,7 +108,7 @@ let isRunning = true;
 function draw(timestamp: number) {
   if (!isRunning) return;
 
-  paramsUniform.writePartial({
+  paramsUniform.patch({
     aspectRatio: canvas.clientWidth / canvas.clientHeight,
     time: (timestamp * 0.001) % 1000,
   });
@@ -129,7 +129,7 @@ export const controls = defineControls({
     max: 200,
     step: 1,
     onSliderChange(v: number) {
-      paramsUniform.writePartial({ tunnelDepth: v });
+      paramsUniform.patch({ tunnelDepth: v });
     },
   },
   'big strips': {
@@ -138,7 +138,7 @@ export const controls = defineControls({
     max: 60,
     step: 0.01,
     onSliderChange(v: number) {
-      paramsUniform.writePartial({ bigStrips: v });
+      paramsUniform.patch({ bigStrips: v });
     },
   },
   'small strips': {
@@ -147,7 +147,7 @@ export const controls = defineControls({
     max: 10,
     step: 0.01,
     onSliderChange(v: number) {
-      paramsUniform.writePartial({ smallStrips: v });
+      paramsUniform.patch({ smallStrips: v });
     },
   },
   'dolly zoom': {
@@ -156,7 +156,7 @@ export const controls = defineControls({
     max: 1,
     step: 0.01,
     onSliderChange(v: number) {
-      paramsUniform.writePartial({ dollyZoom: v });
+      paramsUniform.patch({ dollyZoom: v });
     },
   },
   'camera pos': {
@@ -165,13 +165,13 @@ export const controls = defineControls({
     initial: d.vec2f(0, -7),
     step: d.vec2f(0.01, 0.01),
     onVectorSliderChange(v) {
-      paramsUniform.writePartial({ cameraPos: v });
+      paramsUniform.patch({ cameraPos: v });
     },
   },
   color: {
     initial: d.vec3f(0.2, 0, 0.3),
     onColorChange(value) {
-      paramsUniform.writePartial({ color: value });
+      paramsUniform.patch({ color: value });
     },
   },
 });

--- a/apps/typegpu-docs/src/examples/rendering/xor-dev-runner/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/xor-dev-runner/index.ts
@@ -141,7 +141,7 @@ const { cleanupCamera, updatePosition } = setupFirstPersonCamera(
     speed: d.vec3f(0.001, 0.1, 1),
   },
   (props) => {
-    cameraUniform.writePartial(props);
+    cameraUniform.patch(props);
   },
 );
 

--- a/apps/typegpu-docs/src/examples/simple/liquid-glass/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/liquid-glass/index.ts
@@ -194,7 +194,7 @@ export const controls = defineControls({
     max: d.vec2f(0.5, 0.5),
     step: d.vec2f(0.01, 0.01),
     onVectorSliderChange: (v) => {
-      paramsUniform.writePartial({
+      paramsUniform.patch({
         rectDims: d.vec2f(...(v as [number, number])),
       });
     },
@@ -205,7 +205,7 @@ export const controls = defineControls({
     max: 0.05,
     step: 0.001,
     onSliderChange: (v) => {
-      paramsUniform.writePartial({
+      paramsUniform.patch({
         radius: v,
       });
     },
@@ -216,7 +216,7 @@ export const controls = defineControls({
     max: 0.1,
     step: 0.001,
     onSliderChange: (v) => {
-      paramsUniform.writePartial({
+      paramsUniform.patch({
         start: v,
       });
     },
@@ -227,7 +227,7 @@ export const controls = defineControls({
     max: 0.2,
     step: 0.001,
     onSliderChange: (v) => {
-      paramsUniform.writePartial({
+      paramsUniform.patch({
         end: v,
       });
     },
@@ -238,7 +238,7 @@ export const controls = defineControls({
     max: 0.1,
     step: 0.001,
     onSliderChange: (v) => {
-      paramsUniform.writePartial({
+      paramsUniform.patch({
         chromaticStrength: v,
       });
     },
@@ -249,7 +249,7 @@ export const controls = defineControls({
     max: 0.2,
     step: 0.001,
     onSliderChange: (v) => {
-      paramsUniform.writePartial({
+      paramsUniform.patch({
         refractionStrength: v,
       });
     },
@@ -260,7 +260,7 @@ export const controls = defineControls({
     max: 6.0,
     step: 0.1,
     onSliderChange: (v) => {
-      paramsUniform.writePartial({ blur: v });
+      paramsUniform.patch({ blur: v });
     },
   },
   'Edge blur multiplier': {
@@ -269,7 +269,7 @@ export const controls = defineControls({
     max: 1.0,
     step: 0.05,
     onSliderChange: (v) => {
-      paramsUniform.writePartial({ edgeBlurMultiplier: v });
+      paramsUniform.patch({ edgeBlurMultiplier: v });
     },
   },
   'Feather ammount': {
@@ -278,7 +278,7 @@ export const controls = defineControls({
     max: 3.0,
     step: 0.1,
     onSliderChange: (v) => {
-      paramsUniform.writePartial({ edgeFeather: v });
+      paramsUniform.patch({ edgeFeather: v });
     },
   },
   'Tint strength': {
@@ -287,13 +287,13 @@ export const controls = defineControls({
     max: 1.0,
     step: 0.01,
     onSliderChange: (v) => {
-      paramsUniform.writePartial({ tintStrength: v });
+      paramsUniform.patch({ tintStrength: v });
     },
   },
   'Tint color': {
     initial: defaultParams.tintColor,
     onColorChange: (rgb) => {
-      paramsUniform.writePartial({
+      paramsUniform.patch({
         tintColor: d.vec3f(...(rgb as [number, number, number])),
       });
     },

--- a/apps/typegpu-docs/src/examples/simple/oklab/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/oklab/index.ts
@@ -174,7 +174,7 @@ export const controls = defineControls({
     step: 0.001,
     onSliderChange: (hue: number) => {
       uniformsValue.hue = hue;
-      uniforms.writePartial({ hue });
+      uniforms.patch({ hue });
       draw();
     },
   },
@@ -194,7 +194,7 @@ export const controls = defineControls({
     step: 0.001,
     onSliderChange: (alpha: number) => {
       uniformsValue.alpha = alpha;
-      uniforms.writePartial({ alpha });
+      uniforms.patch({ alpha });
       draw();
     },
   },

--- a/apps/typegpu-docs/src/examples/simple/ripple-cube/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/ripple-cube/index.ts
@@ -117,7 +117,7 @@ const postProcessing = createPostProcessingPipelines(root, width, height, initia
 const cameraResult = setupOrbitCamera(
   canvas,
   { initPos: d.vec4f(2, 2, 2, 1), maxZoom: 4, minZoom: 1 },
-  (newProps) => cameraUniform.writePartial(newProps),
+  (newProps) => cameraUniform.patch(newProps),
 );
 
 const getRayForUV = (uv: d.v2f) => {
@@ -230,7 +230,7 @@ export const controls = defineControls({
     initial: initialMaterial.metallic,
     step: 0.01,
     onSliderChange(v: number) {
-      materialUniform.writePartial({ metallic: v });
+      materialUniform.patch({ metallic: v });
     },
   },
   roughness: {
@@ -239,7 +239,7 @@ export const controls = defineControls({
     initial: initialMaterial.roughness,
     step: 0.01,
     onSliderChange(v: number) {
-      materialUniform.writePartial({ roughness: v });
+      materialUniform.patch({ roughness: v });
     },
   },
   'ambient occlusion': {
@@ -248,7 +248,7 @@ export const controls = defineControls({
     initial: initialMaterial.ao,
     step: 0.01,
     onSliderChange(v: number) {
-      materialUniform.writePartial({ ao: v });
+      materialUniform.patch({ ao: v });
     },
   },
   'bloom threshold': {
@@ -257,7 +257,7 @@ export const controls = defineControls({
     initial: initialBloom.threshold,
     step: 0.01,
     onSliderChange(v: number) {
-      postProcessing.bloomUniform.writePartial({ threshold: v });
+      postProcessing.bloomUniform.patch({ threshold: v });
     },
   },
   'bloom intensity': {
@@ -266,7 +266,7 @@ export const controls = defineControls({
     initial: initialBloom.intensity,
     step: 0.01,
     onSliderChange(v: number) {
-      postProcessing.bloomUniform.writePartial({ intensity: v });
+      postProcessing.bloomUniform.patch({ intensity: v });
     },
   },
   'blend factor': {

--- a/apps/typegpu-docs/src/examples/simple/square/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/square/index.ts
@@ -68,12 +68,7 @@ render();
 function updateColor(color: d.v3f, position: keyof typeof colors): void {
   colors[position] = d.vec4f(color, 1);
   const idx = colorIndices[position];
-  colorBuffer.writePartial([
-    {
-      idx,
-      value: colors[position],
-    },
-  ]);
+  colorBuffer.patch({ [idx]: colors[position] });
   render();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/fluid-with-atomics/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/fluid-with-atomics/index.ts
@@ -279,7 +279,7 @@ const fragment = tgpu.fragmentFn({
 const vertexInstanceLayout = tgpu.vertexLayout(d.arrayOf(d.u32), 'instance');
 const vertexLayout = tgpu.vertexLayout(d.arrayOf(d.vec2f), 'vertex');
 
-let drawCanvasData: { idx: number; value: number }[] = [];
+let drawCanvasData: Record<number, number> = {};
 
 let msSinceLastTick = 0;
 let render: () => void;
@@ -287,7 +287,7 @@ let applyDrawCanvas: () => void;
 let renderChanges: () => void;
 
 function resetGameData() {
-  drawCanvasData = [];
+  drawCanvasData = {};
 
   const compute = tgpu.computeFn({
     in: { gid: d.builtin.globalInvocationId },
@@ -334,9 +334,9 @@ function resetGameData() {
   };
 
   applyDrawCanvas = () => {
-    nextState.writePartial(drawCanvasData);
+    nextState.patch(drawCanvasData);
 
-    drawCanvasData = [];
+    drawCanvasData = {};
   };
 
   renderChanges = () => {
@@ -390,7 +390,7 @@ const handleDrawing = (x: number, y: number) => {
         if (iSq + j * j > brushSize * brushSize) continue;
 
         const index = cellY * size + cellX;
-        drawCanvasData.push({ idx: index, value: drawValue });
+        drawCanvasData[index] = drawValue;
       }
     }
   };
@@ -472,10 +472,7 @@ const createSampleScene = () => {
   for (let i = -radius; i <= radius; i++) {
     for (let j = -radius; j <= radius; j++) {
       if (i * i + j * j <= radius * radius) {
-        drawCanvasData.push({
-          idx: (middlePoint + j) * options.size + middlePoint + i,
-          value: 1 << 24,
-        });
+        drawCanvasData[(middlePoint + j) * options.size + middlePoint + i] = 1 << 24;
       }
     }
   }
@@ -484,27 +481,22 @@ const createSampleScene = () => {
   for (let i = -smallRadius; i <= smallRadius; i++) {
     for (let j = -smallRadius; j <= smallRadius; j++) {
       if (i * i + j * j <= smallRadius * smallRadius) {
-        drawCanvasData.push({
-          idx: (middlePoint + j + options.size / 4) * options.size + middlePoint + i,
-          value: 2 << 24,
-        });
+        drawCanvasData[(middlePoint + j + options.size / 4) * options.size + middlePoint + i] =
+          2 << 24;
       }
     }
   }
 
   for (let i = 0; i < options.size; i++) {
-    drawCanvasData.push({ idx: i, value: 1 << 24 });
+    drawCanvasData[i] = 1 << 24;
   }
 
   for (let i = 0; i < Math.floor(options.size / 8); i++) {
-    drawCanvasData.push({ idx: i * options.size, value: 1 << 24 });
+    drawCanvasData[i * options.size] = 1 << 24;
   }
 
   for (let i = 0; i < Math.floor(options.size / 8); i++) {
-    drawCanvasData.push({
-      idx: i * options.size + options.size - 1,
-      value: 1 << 24,
-    });
+    drawCanvasData[i * options.size + options.size - 1] = 1 << 24;
   }
 };
 

--- a/apps/typegpu-docs/src/examples/simulation/gravity/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/gravity/index.ts
@@ -46,7 +46,7 @@ const { cleanupCamera, targetCamera } = setupOrbitCamera(
     minZoom: 10,
     maxZoom: 800,
   },
-  (updates) => camera.writePartial(updates),
+  (updates) => camera.patch(updates),
 );
 
 const skyBoxVertexBuffer = root
@@ -160,7 +160,7 @@ function frame(timestamp: DOMHighResTimeStamp) {
   if (destroyed) {
     return;
   }
-  time.writePartial({
+  time.patch({
     passed: Math.min((timestamp - lastTimestamp) / 1000, 0.1),
   });
   lastTimestamp = timestamp;
@@ -245,7 +245,7 @@ export const controls = defineControls({
     max: 5,
     step: 1,
     onSliderChange: (newValue: number) => {
-      time.writePartial({ multiplier: 2 ** newValue });
+      time.patch({ multiplier: 2 ** newValue });
     },
   },
 });

--- a/apps/typegpu-docs/src/examples/simulation/slime-mold-3d/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/slime-mold-3d/index.ts
@@ -446,7 +446,7 @@ function frame(timestamp: number) {
   const deltaTime = Math.min(lastTime !== null ? (timestamp - lastTime) / 1000 : 0, 0.1);
   lastTime = timestamp;
 
-  params.writePartial({ deltaTime });
+  params.patch({ deltaTime });
 
   blurPipeline
     .with(blurBindGroups[currentTexture])
@@ -578,7 +578,7 @@ export const controls = defineControls({
     max: 100,
     step: 1,
     onSliderChange: (newValue) => {
-      params.writePartial({ moveSpeed: newValue });
+      params.patch({ moveSpeed: newValue });
     },
   },
   'Sensor Angle': {
@@ -587,7 +587,7 @@ export const controls = defineControls({
     max: 3.14,
     step: 0.01,
     onSliderChange: (newValue) => {
-      params.writePartial({ sensorAngle: newValue });
+      params.patch({ sensorAngle: newValue });
     },
   },
   'Sensor Distance': {
@@ -596,7 +596,7 @@ export const controls = defineControls({
     max: 50,
     step: 0.5,
     onSliderChange: (newValue) => {
-      params.writePartial({ sensorDistance: newValue });
+      params.patch({ sensorDistance: newValue });
     },
   },
   'Turn Speed': {
@@ -605,7 +605,7 @@ export const controls = defineControls({
     max: 100,
     step: 0.1,
     onSliderChange: (newValue) => {
-      params.writePartial({ turnSpeed: newValue });
+      params.patch({ turnSpeed: newValue });
     },
   },
   'Evaporation Rate': {
@@ -614,7 +614,7 @@ export const controls = defineControls({
     max: 0.5,
     step: 0.01,
     onSliderChange: (newValue) => {
-      params.writePartial({ evaporationRate: newValue });
+      params.patch({ evaporationRate: newValue });
     },
   },
 });

--- a/apps/typegpu-docs/src/examples/simulation/slime-mold/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/slime-mold/index.ts
@@ -252,7 +252,7 @@ export const controls = defineControls({
     max: 100,
     step: 1,
     onSliderChange: (newValue) => {
-      params.writePartial({ moveSpeed: newValue });
+      params.patch({ moveSpeed: newValue });
     },
   },
   'Sensor Angle': {
@@ -261,7 +261,7 @@ export const controls = defineControls({
     max: 3.14,
     step: 0.01,
     onSliderChange: (newValue) => {
-      params.writePartial({ sensorAngle: newValue });
+      params.patch({ sensorAngle: newValue });
     },
   },
   'Sensor Distance': {
@@ -270,7 +270,7 @@ export const controls = defineControls({
     max: 50,
     step: 0.5,
     onSliderChange: (newValue) => {
-      params.writePartial({ sensorDistance: newValue });
+      params.patch({ sensorDistance: newValue });
     },
   },
   'Turn Speed': {
@@ -279,7 +279,7 @@ export const controls = defineControls({
     max: 10,
     step: 0.1,
     onSliderChange: (newValue) => {
-      params.writePartial({ turnSpeed: newValue });
+      params.patch({ turnSpeed: newValue });
     },
   },
   'Evaporation Rate': {
@@ -288,7 +288,7 @@ export const controls = defineControls({
     max: 0.5,
     step: 0.01,
     onSliderChange: (newValue) => {
-      params.writePartial({ evaporationRate: newValue });
+      params.patch({ evaporationRate: newValue });
     },
   },
 });

--- a/apps/typegpu-docs/src/examples/simulation/stable-fluid/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/stable-fluid/index.ts
@@ -280,7 +280,7 @@ function loop() {
   }
 
   if (brushState.isDown) {
-    brushParamBuffer.writePartial({
+    brushParamBuffer.patch({
       pos: d.vec2i(...brushState.pos),
       delta: d.vec2f(...brushState.delta),
     });
@@ -440,7 +440,7 @@ export const controls = defineControls({
     step: 0.01,
     onSliderChange: (value) => {
       p.params.dt = value;
-      simParamBuffer.writePartial({
+      simParamBuffer.patch({
         dt: p.params.dt,
       });
     },
@@ -452,7 +452,7 @@ export const controls = defineControls({
     step: 0.000001,
     onSliderChange: (value) => {
       p.params.viscosity = value;
-      simParamBuffer.writePartial({
+      simParamBuffer.patch({
         viscosity: p.params.viscosity,
       });
     },

--- a/apps/typegpu-docs/src/examples/simulation/wind-map/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/wind-map/index.ts
@@ -225,7 +225,7 @@ function createPipelines() {
 const pipelines = createPipelines();
 
 const draw = () => {
-  uniformsBuffer.writePartial({ frameCount });
+  uniformsBuffer.patch({ frameCount });
 
   pipelines.advect
     .with(bindGroupWritable)

--- a/apps/typegpu-docs/src/pages/benchmark/test-suites/partial-write.ts
+++ b/apps/typegpu-docs/src/pages/benchmark/test-suites/partial-write.ts
@@ -80,12 +80,9 @@ export const partialWriteSuite = createSuite(
 
       const randomBoid = Math.floor(Math.random() * amountOfBoids);
 
-      buffer.writePartial([
-        {
-          idx: randomBoid,
-          value: { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
-        },
-      ]);
+      buffer.patch({
+        [randomBoid]: { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
+      });
 
       await root.device.queue.onSubmittedWorkDone();
     },
@@ -93,15 +90,15 @@ export const partialWriteSuite = createSuite(
     '20% of the buffer - not contiguous': (getCtx) => async () => {
       const { amountOfBoids, d, root, buffer } = getCtx();
 
-      const writes = Array.from({ length: amountOfBoids })
-        .map((_, i) => i)
-        .filter((_, i) => i % 5 === 0)
-        .map((i) => ({
-          idx: i,
-          value: { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
-        }));
+      const writes: Record<
+        number,
+        { pos: ReturnType<typeof d.vec3f>; vel: ReturnType<typeof d.vec3f> }
+      > = {};
+      for (let i = 0; i < amountOfBoids; i += 5) {
+        writes[i] = { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) };
+      }
 
-      buffer.writePartial(writes);
+      buffer.patch(writes);
 
       await root.device.queue.onSubmittedWorkDone();
     },
@@ -109,28 +106,30 @@ export const partialWriteSuite = createSuite(
     '20% of the buffer - contiguous': (getCtx) => async () => {
       const { amountOfBoids, d, root, buffer } = getCtx();
 
-      const writes = Array.from({ length: amountOfBoids / 5 })
-        .map((_, i) => i)
-        .map((i) => ({
-          idx: i,
-          value: { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
-        }));
+      const writes: Record<
+        number,
+        { pos: ReturnType<typeof d.vec3f>; vel: ReturnType<typeof d.vec3f> }
+      > = {};
+      for (let i = 0; i < amountOfBoids / 5; i++) {
+        writes[i] = { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) };
+      }
 
-      buffer.writePartial(writes);
+      buffer.patch(writes);
       await root.device.queue.onSubmittedWorkDone();
     },
 
     '100% of the buffer - contiguous': (getCtx) => async () => {
       const { amountOfBoids, d, root, buffer } = getCtx();
 
-      const writes = Array.from({ length: amountOfBoids })
-        .map((_, i) => i)
-        .map((i) => ({
-          idx: i,
-          value: { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
-        }));
+      const writes: Record<
+        number,
+        { pos: ReturnType<typeof d.vec3f>; vel: ReturnType<typeof d.vec3f> }
+      > = {};
+      for (let i = 0; i < amountOfBoids; i++) {
+        writes[i] = { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) };
+      }
 
-      buffer.writePartial(writes);
+      buffer.patch(writes);
       await root.device.queue.onSubmittedWorkDone();
     },
   },

--- a/apps/typegpu-docs/src/pages/benchmark/test-suites/partial-write.ts
+++ b/apps/typegpu-docs/src/pages/benchmark/test-suites/partial-write.ts
@@ -80,9 +80,12 @@ export const partialWriteSuite = createSuite(
 
       const randomBoid = Math.floor(Math.random() * amountOfBoids);
 
-      buffer.patch({
-        [randomBoid]: { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
-      });
+      buffer.writePartial([
+        {
+          idx: randomBoid,
+          value: { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
+        },
+      ]);
 
       await root.device.queue.onSubmittedWorkDone();
     },
@@ -90,14 +93,15 @@ export const partialWriteSuite = createSuite(
     '20% of the buffer - not contiguous': (getCtx) => async () => {
       const { amountOfBoids, d, root, buffer } = getCtx();
 
-      const writes = Object.fromEntries(
-        Array.from({ length: amountOfBoids / 5 }, (_, i) => [
-          i,
-          { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
-        ]),
-      );
+      const writes = Array.from({ length: amountOfBoids })
+        .map((_, i) => i)
+        .filter((_, i) => i % 5 === 0)
+        .map((i) => ({
+          idx: i,
+          value: { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
+        }));
 
-      buffer.patch(writes);
+      buffer.writePartial(writes);
 
       await root.device.queue.onSubmittedWorkDone();
     },
@@ -105,28 +109,28 @@ export const partialWriteSuite = createSuite(
     '20% of the buffer - contiguous': (getCtx) => async () => {
       const { amountOfBoids, d, root, buffer } = getCtx();
 
-      const writes = Object.fromEntries(
-        Array.from({ length: amountOfBoids / 5 }, (_, i) => [
-          i,
-          { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
-        ]),
-      );
+      const writes = Array.from({ length: amountOfBoids / 5 })
+        .map((_, i) => i)
+        .map((i) => ({
+          idx: i,
+          value: { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
+        }));
 
-      buffer.patch(writes);
+      buffer.writePartial(writes);
       await root.device.queue.onSubmittedWorkDone();
     },
 
     '100% of the buffer - contiguous': (getCtx) => async () => {
       const { amountOfBoids, d, root, buffer } = getCtx();
 
-      const writes = Object.fromEntries(
-        Array.from({ length: amountOfBoids / 5 }, (_, i) => [
-          i,
-          { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
-        ]),
-      );
+      const writes = Array.from({ length: amountOfBoids })
+        .map((_, i) => i)
+        .map((i) => ({
+          idx: i,
+          value: { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
+        }));
 
-      buffer.patch(writes);
+      buffer.writePartial(writes);
       await root.device.queue.onSubmittedWorkDone();
     },
   },

--- a/apps/typegpu-docs/src/pages/benchmark/test-suites/partial-write.ts
+++ b/apps/typegpu-docs/src/pages/benchmark/test-suites/partial-write.ts
@@ -90,13 +90,12 @@ export const partialWriteSuite = createSuite(
     '20% of the buffer - not contiguous': (getCtx) => async () => {
       const { amountOfBoids, d, root, buffer } = getCtx();
 
-      const writes: Record<
-        number,
-        { pos: ReturnType<typeof d.vec3f>; vel: ReturnType<typeof d.vec3f> }
-      > = {};
-      for (let i = 0; i < amountOfBoids; i += 5) {
-        writes[i] = { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) };
-      }
+      const writes = Object.fromEntries(
+        Array.from({ length: amountOfBoids / 5 }, (_, i) => [
+          i,
+          { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
+        ]),
+      );
 
       buffer.patch(writes);
 
@@ -106,13 +105,12 @@ export const partialWriteSuite = createSuite(
     '20% of the buffer - contiguous': (getCtx) => async () => {
       const { amountOfBoids, d, root, buffer } = getCtx();
 
-      const writes: Record<
-        number,
-        { pos: ReturnType<typeof d.vec3f>; vel: ReturnType<typeof d.vec3f> }
-      > = {};
-      for (let i = 0; i < amountOfBoids / 5; i++) {
-        writes[i] = { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) };
-      }
+      const writes = Object.fromEntries(
+        Array.from({ length: amountOfBoids / 5 }, (_, i) => [
+          i,
+          { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
+        ]),
+      );
 
       buffer.patch(writes);
       await root.device.queue.onSubmittedWorkDone();
@@ -121,13 +119,12 @@ export const partialWriteSuite = createSuite(
     '100% of the buffer - contiguous': (getCtx) => async () => {
       const { amountOfBoids, d, root, buffer } = getCtx();
 
-      const writes: Record<
-        number,
-        { pos: ReturnType<typeof d.vec3f>; vel: ReturnType<typeof d.vec3f> }
-      > = {};
-      for (let i = 0; i < amountOfBoids; i++) {
-        writes[i] = { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) };
-      }
+      const writes = Object.fromEntries(
+        Array.from({ length: amountOfBoids / 5 }, (_, i) => [
+          i,
+          { pos: d.vec3f(1, 2, 3), vel: d.vec3f(4, 5, 6) },
+        ]),
+      );
 
       buffer.patch(writes);
       await root.device.queue.onSubmittedWorkDone();

--- a/packages/typegpu/src/core/buffer/buffer.ts
+++ b/packages/typegpu/src/core/buffer/buffer.ts
@@ -1,5 +1,5 @@
 import { BufferReader, BufferWriter, getSystemEndianness } from 'typed-binary';
-import { getCompiledWriterForSchema } from '../../data/compiledIO.ts';
+import { getCompiledWriter } from '../../data/compiledIO.ts';
 import { readData, writeData } from '../../data/dataIO.ts';
 import type { AnyData } from '../../data/dataTypes.ts';
 import { getWriteInstructions } from '../../data/partialIO.ts';
@@ -344,7 +344,7 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
   }
 
   compileWriter(): void {
-    getCompiledWriterForSchema(this.dataType);
+    getCompiledWriter(this.dataType);
   }
 
   #writeToTarget(
@@ -376,7 +376,7 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
     const dataView = new DataView(target);
     const isLittleEndian = endianness === 'little';
 
-    const compiledWriter = getCompiledWriterForSchema(this.dataType);
+    const compiledWriter = getCompiledWriter(this.dataType);
 
     if (compiledWriter) {
       try {
@@ -452,17 +452,11 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
       const mappedView = new Uint8Array(mappedRange);
 
       for (const instruction of instructions) {
-        mappedView.set(instruction.data, instruction.data.byteOffset);
+        mappedView.set(instruction.data, instruction.gpuOffset);
       }
     } else {
       for (const instruction of instructions) {
-        this.#device.queue.writeBuffer(
-          gpuBuffer,
-          instruction.data.byteOffset,
-          instruction.data,
-          0,
-          instruction.data.byteLength,
-        );
+        this.#device.queue.writeBuffer(gpuBuffer, instruction.gpuOffset, instruction.data);
       }
     }
   }

--- a/packages/typegpu/src/core/buffer/buffer.ts
+++ b/packages/typegpu/src/core/buffer/buffer.ts
@@ -205,7 +205,11 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
   #buffer: GPUBuffer | null = null;
   #ownBuffer: boolean;
   #destroyed = false;
-  #hostBuffer: ArrayBuffer | undefined;
+  #internalBuffer: ArrayBuffer | undefined;
+
+  get #hostBuffer(): ArrayBuffer {
+    return (this.#internalBuffer ??= new ArrayBuffer(sizeOf(this.dataType)));
+  }
   #mappedRange: ArrayBuffer | undefined;
   #initialCallback: BufferInitCallback<TData> | undefined;
   readonly #disallowedUsages: UsageLiteral[] | undefined;
@@ -274,10 +278,6 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
     const gpuBuffer = this.buffer;
     if (gpuBuffer.mapState === 'mapped') {
       return this.#getMappedRange();
-    }
-
-    if (!this.#hostBuffer) {
-      this.#hostBuffer = new ArrayBuffer(sizeOf(this.dataType));
     }
 
     return this.#hostBuffer;
@@ -437,10 +437,6 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
       return;
     }
 
-    if (!this.#hostBuffer) {
-      this.#hostBuffer = new ArrayBuffer(bufferSize);
-    }
-
     // If the caller already wrote directly into #hostBuffer via
     // arrayBuffer, skip the redundant copy, the data is already in place.
     if (!(data instanceof ArrayBuffer && data === this.#hostBuffer)) {
@@ -452,12 +448,16 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
   /** @deprecated Use {@link patch} instead. */
   public writePartial(data: InferPartial<TData>): void {
     this.#applyInstructions(
-      getPatchInstructions(this.dataType, convertPartialToPatch(this.dataType, data)),
+      getPatchInstructions(
+        this.dataType,
+        convertPartialToPatch(this.dataType, data),
+        this.#hostBuffer,
+      ),
     );
   }
 
   public patch(data: InferPatch<TData>): void {
-    this.#applyInstructions(getPatchInstructions(this.dataType, data));
+    this.#applyInstructions(getPatchInstructions(this.dataType, data, this.#hostBuffer));
   }
 
   #applyInstructions(instructions: WriteInstruction[]): void {

--- a/packages/typegpu/src/core/buffer/buffer.ts
+++ b/packages/typegpu/src/core/buffer/buffer.ts
@@ -2,7 +2,11 @@ import { BufferReader, BufferWriter, getSystemEndianness } from 'typed-binary';
 import { getCompiledWriter } from '../../data/compiledIO.ts';
 import { readData, writeData } from '../../data/dataIO.ts';
 import type { AnyData } from '../../data/dataTypes.ts';
-import { getWriteInstructions } from '../../data/partialIO.ts';
+import {
+  type WriteInstruction,
+  convertPartialToPatch,
+  getPatchInstructions,
+} from '../../data/partialIO.ts';
 import { sizeOf } from '../../data/sizeOf.ts';
 import type { BaseData } from '../../data/wgslTypes.ts';
 import { isWgslArray, isWgslData } from '../../data/wgslTypes.ts';
@@ -12,6 +16,7 @@ import { getName, setName } from '../../shared/meta.ts';
 import type {
   Infer,
   InferInput,
+  InferPatch,
   InferPartial,
   IsValidIndexSchema,
   IsValidStorageSchema,
@@ -147,7 +152,9 @@ export interface TgpuBuffer<TData extends BaseData> extends TgpuNamable {
   compileWriter(): void;
   write(data: InferInput<TData>, options?: BufferWriteOptions): void;
   write(data: ArrayBuffer, options?: BufferWriteOptions): void;
+  /** @deprecated Use {@link patch} instead. */
   writePartial(data: InferPartial<TData>): void;
+  patch(data: InferPatch<TData>): void;
   clear(): void;
   copyFrom(srcBuffer: TgpuBuffer<MemIdentity<TData>>): void;
   read(): Promise<Infer<TData>>;
@@ -442,21 +449,29 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
     this.#device.queue.writeBuffer(gpuBuffer, startOffset, this.#hostBuffer, startOffset, size);
   }
 
+  /** @deprecated Use {@link patch} instead. */
   public writePartial(data: InferPartial<TData>): void {
-    const gpuBuffer = this.buffer;
+    this.#applyInstructions(
+      getPatchInstructions(this.dataType, convertPartialToPatch(this.dataType, data)),
+    );
+  }
 
-    const instructions = getWriteInstructions(this.dataType, data);
+  public patch(data: InferPatch<TData>): void {
+    this.#applyInstructions(getPatchInstructions(this.dataType, data));
+  }
+
+  #applyInstructions(instructions: WriteInstruction[]): void {
+    const gpuBuffer = this.buffer;
 
     if (gpuBuffer.mapState === 'mapped') {
       const mappedRange = this.#getMappedRange();
       const mappedView = new Uint8Array(mappedRange);
-
-      for (const instruction of instructions) {
-        mappedView.set(instruction.data, instruction.gpuOffset);
+      for (const { data, gpuOffset } of instructions) {
+        mappedView.set(data, gpuOffset);
       }
     } else {
-      for (const instruction of instructions) {
-        this.#device.queue.writeBuffer(gpuBuffer, instruction.gpuOffset, instruction.data);
+      for (const { data, gpuOffset } of instructions) {
+        this.#device.queue.writeBuffer(gpuBuffer, gpuOffset, data);
       }
     }
   }

--- a/packages/typegpu/src/core/buffer/bufferShorthand.ts
+++ b/packages/typegpu/src/core/buffer/bufferShorthand.ts
@@ -2,7 +2,7 @@ import type { ResolvedSnippet } from '../../data/snippet.ts';
 import type { BaseData } from '../../data/wgslTypes.ts';
 import type { StorageFlag } from '../../extension.ts';
 import { getName, setName, type TgpuNamable } from '../../shared/meta.ts';
-import type { Infer, InferGPU, InferInput, InferPartial } from '../../shared/repr.ts';
+import type { Infer, InferGPU, InferInput, InferPatch, InferPartial } from '../../shared/repr.ts';
 import { $getNameForward, $gpuValueOf, $internal, $resolve } from '../../shared/symbols.ts';
 import type { ResolutionCtx, SelfResolvable } from '../../types.ts';
 import type { BufferWriteOptions, TgpuBuffer, UniformFlag } from './buffer.ts';
@@ -17,7 +17,9 @@ interface TgpuBufferShorthandBase<TData extends BaseData> extends TgpuNamable {
 
   // Accessible on the CPU
   write(data: InferInput<TData>, options?: BufferWriteOptions): void;
+  /** @deprecated Use {@link patch} instead. */
   writePartial(data: InferPartial<TData>): void;
+  patch(data: InferPatch<TData>): void;
   read(): Promise<Infer<TData>>;
   // ---
 
@@ -112,8 +114,13 @@ export class TgpuBufferShorthandImpl<
     this.buffer.write(data, options);
   }
 
+  /** @deprecated Use {@link patch} instead. */
   writePartial(data: InferPartial<TData>): void {
     this.buffer.writePartial(data);
+  }
+
+  patch(data: InferPatch<TData>): void {
+    this.buffer.patch(data);
   }
 
   read(): Promise<Infer<TData>> {

--- a/packages/typegpu/src/data/attributes.ts
+++ b/packages/typegpu/src/data/attributes.ts
@@ -1,6 +1,7 @@
 import type {
   Infer,
   InferGPU,
+  InferInput,
   InferPartial,
   IsValidStorageSchema,
   IsValidUniformSchema,
@@ -10,6 +11,7 @@ import type {
 import { $internal } from '../shared/symbols.ts';
 import {
   $gpuRepr,
+  $inRepr,
   $invalidSchemaReason,
   $memIdent,
   $repr,
@@ -405,6 +407,7 @@ class DecoratedImpl<TInner extends BaseData, TAttribs extends unknown[]>
   public readonly type = 'decorated';
 
   // Type-tokens, not available at runtime
+  declare readonly [$inRepr]: InferInput<TInner>;
   declare readonly [$memIdent]: TAttribs extends Location[]
     ? MemIdentity<TInner> | Decorated<MemIdentity<TInner>, TAttribs>
     : Decorated<MemIdentity<TInner>, TAttribs>;

--- a/packages/typegpu/src/data/attributes.ts
+++ b/packages/typegpu/src/data/attributes.ts
@@ -2,6 +2,7 @@ import type {
   Infer,
   InferGPU,
   InferInput,
+  InferPatch,
   InferPartial,
   IsValidStorageSchema,
   IsValidUniformSchema,
@@ -16,6 +17,7 @@ import {
   $memIdent,
   $repr,
   $reprPartial,
+  $reprPatch,
   $validStorageSchema,
   $validUniformSchema,
   $validVertexSchema,
@@ -354,6 +356,7 @@ class BaseDecoratedImpl<TInner extends BaseData, TAttribs extends unknown[]> {
   declare readonly [$repr]: Infer<TInner>;
   declare readonly [$gpuRepr]: InferGPU<TInner>;
   declare readonly [$reprPartial]: InferPartial<TInner>;
+  declare readonly [$reprPatch]: InferPatch<TInner>;
   // ---
 
   constructor(inner: TInner, attribs: TAttribs) {

--- a/packages/typegpu/src/data/compiledIO.ts
+++ b/packages/typegpu/src/data/compiledIO.ts
@@ -1,5 +1,4 @@
 import { roundUp } from '../mathUtils.ts';
-import type { InferInput } from '../shared/repr.ts';
 import { alignmentOf } from './alignmentOf.ts';
 import { isDisarray, isUnstruct } from './dataTypes.ts';
 import { offsetsForProps } from './offsets.ts';
@@ -17,16 +16,15 @@ export const EVAL_ALLOWED_IN_ENV: boolean = (() => {
   }
 })();
 
-const compiledWriters = new WeakMap<
-  wgsl.BaseData,
-  (
-    output: DataView,
-    offset: number,
-    value: unknown,
-    littleEndian?: boolean,
-    endOffset?: number,
-  ) => void
->();
+export type CompiledWriter = (
+  output: DataView,
+  offset: number,
+  value: unknown,
+  littleEndian?: boolean,
+  endOffset?: number,
+) => void;
+
+const compiledWriters = new WeakMap<wgsl.BaseData, CompiledWriter>();
 
 const typeToPrimitive = {
   u32: 'u32',
@@ -285,30 +283,14 @@ export function buildWriter(
   return go(node, offsetExpr, valueExpr, depth);
 }
 
-export function getCompiledWriterForSchema<T extends wgsl.BaseData>(
-  schema: T,
-):
-  | ((
-      output: DataView,
-      offset: number,
-      value: InferInput<T>,
-      littleEndian?: boolean,
-      endOffset?: number,
-    ) => void)
-  | undefined {
+export function getCompiledWriter(schema: wgsl.BaseData): CompiledWriter | undefined {
   if (!EVAL_ALLOWED_IN_ENV) {
-    console.warn('This environment does not allow eval - using default writer as fallback');
     return undefined;
   }
 
-  if (compiledWriters.has(schema)) {
-    return compiledWriters.get(schema) as (
-      output: DataView,
-      offset: number,
-      value: InferInput<T>,
-      littleEndian?: boolean,
-      endOffset?: number,
-    ) => void;
+  const cached = compiledWriters.get(schema);
+  if (cached) {
+    return cached;
   }
 
   try {
@@ -324,16 +306,9 @@ export function getCompiledWriterForSchema<T extends wgsl.BaseData>(
       'littleEndian=true',
       'endOffset=output.byteLength',
       body,
-    ) as (
-      output: DataView,
-      offset: number,
-      value: unknown,
-      littleEndian?: boolean,
-      endOffset?: number,
-    ) => void;
+    ) as CompiledWriter;
 
     compiledWriters.set(schema, fn);
-
     return fn;
   } catch (error) {
     console.warn(

--- a/packages/typegpu/src/data/compiledIO.ts
+++ b/packages/typegpu/src/data/compiledIO.ts
@@ -285,6 +285,7 @@ export function buildWriter(
 
 export function getCompiledWriter(schema: wgsl.BaseData): CompiledWriter | undefined {
   if (!EVAL_ALLOWED_IN_ENV) {
+    console.warn('This environment does not allow eval - using default writer as fallback');
     return undefined;
   }
 

--- a/packages/typegpu/src/data/dataTypes.ts
+++ b/packages/typegpu/src/data/dataTypes.ts
@@ -5,6 +5,8 @@ import type {
   InferGPURecord,
   InferInput,
   InferInputRecord,
+  InferPatch,
+  InferPatchRecord,
   InferPartial,
   InferPartialRecord,
   InferRecord,
@@ -18,6 +20,7 @@ import type {
   $memIdent,
   $repr,
   $reprPartial,
+  $reprPatch,
   $validVertexSchema,
 } from '../shared/symbols.ts';
 import { $internal } from '../shared/symbols.ts';
@@ -50,8 +53,9 @@ export interface Disarray<out TElement extends wgsl.BaseData = wgsl.BaseData>
   // Type-tokens, not available at runtime
   readonly [$repr]: Infer<TElement>[];
   readonly [$inRepr]: InferInput<TElement>[] | wgsl.TypedArrayFor<TElement>;
-  readonly [$reprPartial]:
-    | { idx: number; value: InferPartial<TElement> }[]
+  readonly [$reprPartial]: { idx: number; value: InferPartial<TElement> }[] | undefined;
+  readonly [$reprPatch]:
+    | Record<number, InferPatch<TElement>>
     | InferInput<TElement>[]
     | wgsl.TypedArrayFor<TElement>
     | undefined;
@@ -84,6 +88,7 @@ export interface Unstruct<
   readonly [$gpuRepr]: Prettify<InferGPURecord<TProps>>;
   readonly [$memIdent]: Unstruct<Prettify<MemIdentityRecord<TProps>>>;
   readonly [$reprPartial]: Prettify<Partial<InferPartialRecord<TProps>>> | undefined;
+  readonly [$reprPatch]: Prettify<Partial<InferPatchRecord<TProps>>> | undefined;
   readonly [$validVertexSchema]: {
     [K in keyof TProps]: IsValidVertexSchema<TProps[K]>;
   }[keyof TProps] extends true

--- a/packages/typegpu/src/data/dataTypes.ts
+++ b/packages/typegpu/src/data/dataTypes.ts
@@ -50,7 +50,11 @@ export interface Disarray<out TElement extends wgsl.BaseData = wgsl.BaseData>
   // Type-tokens, not available at runtime
   readonly [$repr]: Infer<TElement>[];
   readonly [$inRepr]: InferInput<TElement>[] | wgsl.TypedArrayFor<TElement>;
-  readonly [$reprPartial]: { idx: number; value: InferPartial<TElement> }[] | undefined;
+  readonly [$reprPartial]:
+    | { idx: number; value: InferPartial<TElement> }[]
+    | InferInput<TElement>[]
+    | wgsl.TypedArrayFor<TElement>
+    | undefined;
   readonly [$validVertexSchema]: IsValidVertexSchema<TElement>;
   readonly [$invalidSchemaReason]: 'Disarrays are not host-shareable, use arrays instead';
   // ---

--- a/packages/typegpu/src/data/index.ts
+++ b/packages/typegpu/src/data/index.ts
@@ -231,4 +231,4 @@ export type {
   BuiltinVertexIndex,
   BuiltinWorkgroupId,
 } from '../builtin.ts';
-export type { Infer, InferGPU, InferInput, InferPartial } from '../shared/repr.ts';
+export type { Infer, InferGPU, InferInput, InferPartial, InferPatch } from '../shared/repr.ts';

--- a/packages/typegpu/src/data/partialIO.ts
+++ b/packages/typegpu/src/data/partialIO.ts
@@ -133,7 +133,6 @@ export function getPatchInstructions<TData extends wgsl.BaseData>(
   }
 
   collect(schema, data, 0);
-  // segments.sort((a, b) => a.start - b.start);
 
   const instructions: WriteInstruction[] = [];
   let run: Segment | null = null;

--- a/packages/typegpu/src/data/partialIO.ts
+++ b/packages/typegpu/src/data/partialIO.ts
@@ -58,14 +58,15 @@ interface Segment {
 export function getPatchInstructions<TData extends wgsl.BaseData>(
   schema: TData,
   data: unknown,
+  targetBuffer?: ArrayBuffer,
 ): WriteInstruction[] {
   const totalSize = sizeOf(schema);
   if (totalSize === 0 || data === undefined || data === null) {
     return [];
   }
 
-  const bigBuffer = new ArrayBuffer(totalSize);
-  const writer = new BufferWriter(bigBuffer);
+  const buf = targetBuffer ?? new ArrayBuffer(totalSize);
+  const writer = new BufferWriter(buf);
 
   const segments: Segment[] = [];
 
@@ -96,7 +97,7 @@ export function getPatchInstructions<TData extends wgsl.BaseData>(
 
       if (ArrayBuffer.isView(value)) {
         const copyLen = Math.min(value.byteLength, arrSchema.elementCount * elementSize);
-        new Uint8Array(bigBuffer, offset, copyLen).set(
+        new Uint8Array(buf, offset, copyLen).set(
           new Uint8Array(value.buffer, value.byteOffset, copyLen),
         );
         segments.push({ start: offset, end: offset + copyLen, padding });
@@ -123,7 +124,7 @@ export function getPatchInstructions<TData extends wgsl.BaseData>(
     const leafSize = sizeOf(node);
     const compiledWriter = getCompiledWriter(node);
     if (compiledWriter) {
-      compiledWriter(new DataView(bigBuffer), offset, value, isLittleEndian, offset + leafSize);
+      compiledWriter(new DataView(buf), offset, value, isLittleEndian, offset + leafSize);
     } else {
       writer.seekTo(offset);
       writeData(writer, node, value);
@@ -144,7 +145,7 @@ export function getPatchInstructions<TData extends wgsl.BaseData>(
       if (run) {
         instructions.push({
           gpuOffset: run.start,
-          data: new Uint8Array(bigBuffer, run.start, run.end - run.start),
+          data: new Uint8Array(buf, run.start, run.end - run.start),
         });
       }
       run = seg;
@@ -153,7 +154,7 @@ export function getPatchInstructions<TData extends wgsl.BaseData>(
   if (run) {
     instructions.push({
       gpuOffset: run.start,
-      data: new Uint8Array(bigBuffer, run.start, run.end - run.start),
+      data: new Uint8Array(buf, run.start, run.end - run.start),
     });
   }
 

--- a/packages/typegpu/src/data/partialIO.ts
+++ b/packages/typegpu/src/data/partialIO.ts
@@ -1,9 +1,9 @@
 import { BufferWriter, getSystemEndianness } from 'typed-binary';
 import { roundUp } from '../mathUtils.ts';
 import { alignmentOf } from './alignmentOf.ts';
-import { type CompiledWriter, getCompiledWriter } from './compiledIO.ts';
+import { getCompiledWriter } from './compiledIO.ts';
 import { writeData } from './dataIO.ts';
-import { isDisarray, isUnstruct, type Unstruct } from './dataTypes.ts';
+import { isDisarray, isUnstruct } from './dataTypes.ts';
 import { offsetsForProps } from './offsets.ts';
 import { sizeOf } from './sizeOf.ts';
 import type * as wgsl from './wgslTypes.ts';
@@ -15,10 +15,7 @@ export interface WriteInstruction {
 }
 
 /**
- * Converts a value in the legacy `InferPartial` format (with `{idx, value}[]`
- * sparse arrays) into the `InferPatch` format (with `Record<number, T>`).
- * Dense arrays, typed arrays, and leaves are already patch-compatible and
- * pass through untouched.
+ * Converts `{idx, value}[]` sparse arrays into `Record<number, T>` format.
  */
 export function convertPartialToPatch(schema: wgsl.BaseData, data: unknown): unknown {
   if (data === undefined || data === null) {
@@ -59,213 +56,68 @@ export function convertPartialToPatch(schema: wgsl.BaseData, data: unknown): unk
 
 const isLittleEndian = getSystemEndianness() === 'little';
 
-interface Update {
-  offset: number;
-  size: number;
-  padding: number;
-  write: (view: DataView, localOffset: number) => void;
-}
-
-/**
- * Compiled writers require every field to be present and every array field
- * to be in dense form (plain array or TypedArray, not a sparse Record).
- */
-function canUseDirectWriter(
-  node: wgsl.WgslStruct | Unstruct,
-  value: Record<string, unknown>,
-): boolean {
-  for (const key of Object.keys(node.propTypes)) {
-    const childValue = value[key];
-    if (childValue === undefined || childValue === null) {
-      return false;
-    }
-
-    const subSchema = node.propTypes[key];
-
-    if (isWgslStruct(subSchema) || isUnstruct(subSchema)) {
-      if (!canUseDirectWriter(subSchema, childValue as Record<string, unknown>)) {
-        return false;
-      }
-    }
-
-    if (
-      (isWgslArray(subSchema) || isDisarray(subSchema)) &&
-      !Array.isArray(childValue) &&
-      !ArrayBuffer.isView(childValue)
-    ) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function makeWriteFn(
-  writer: CompiledWriter | undefined,
-  node: wgsl.BaseData,
-  size: number,
-  value: unknown,
-): (view: DataView, localOffset: number) => void {
-  if (writer) {
-    return (view, localOffset) =>
-      writer(view, localOffset, value, isLittleEndian, localOffset + size);
-  }
-  return (view, localOffset) => {
-    const bw = new BufferWriter(view.buffer, { byteOffset: view.byteOffset });
-    bw.seekTo(localOffset);
-    writeData(bw, node, value);
-  };
-}
-
-interface Run {
+interface Segment {
   start: number;
   end: number;
-  padding: number;
-  entries: Update[];
-}
-
-function flushRun(run: Run): WriteInstruction {
-  const buf = new ArrayBuffer(run.end - run.start);
-  const view = new DataView(buf);
-  for (const entry of run.entries) {
-    entry.write(view, entry.offset - run.start);
-  }
-  return { gpuOffset: run.start, data: new Uint8Array(buf) };
-}
-
-function coalesceUpdates(updates: Update[]): WriteInstruction[] {
-  updates.sort((a, b) => a.offset - b.offset);
-
-  const instructions: WriteInstruction[] = [];
-  let run: Run | null = null;
-
-  for (const u of updates) {
-    if (run && u.offset === run.end + run.padding) {
-      run.end = u.offset + u.size;
-      run.padding = u.padding;
-      run.entries.push(u);
-    } else {
-      if (run) {
-        instructions.push(flushRun(run));
-      }
-      run = { start: u.offset, end: u.offset + u.size, padding: u.padding, entries: [u] };
-    }
-  }
-  if (run) {
-    instructions.push(flushRun(run));
-  }
-
-  return instructions;
+  padding?: number | undefined;
 }
 
 export function getPatchInstructions<TData extends wgsl.BaseData>(
   schema: TData,
   data: unknown,
 ): WriteInstruction[] {
-  if (sizeOf(schema) === 0 || data === undefined || data === null) {
+  const totalSize = sizeOf(schema);
+  if (totalSize === 0 || data === undefined || data === null) {
     return [];
   }
 
-  const updates: Update[] = [];
+  const bigBuffer = new ArrayBuffer(totalSize);
+  const writer = new BufferWriter(bigBuffer);
 
-  function collectStruct(
-    node: wgsl.WgslStruct | Unstruct,
-    value: Record<string, unknown>,
-    offset: number,
-    padding: number,
-  ) {
-    if (canUseDirectWriter(node, value)) {
-      const writer = getCompiledWriter(node);
-      if (writer) {
-        const nodeSize = sizeOf(node);
-        updates.push({
-          offset,
-          size: nodeSize,
-          padding,
-          write: makeWriteFn(writer, node, nodeSize, value),
-        });
-        return;
-      }
-    }
+  const segments: Segment[] = [];
 
-    const propOffsets = offsetsForProps(node);
-    for (const key of Object.keys(propOffsets)) {
-      const propOffset = propOffsets[key];
-      const subSchema = node.propTypes[key];
-      if (!subSchema || !propOffset) {
-        continue;
-      }
-      const childValue = value[key];
-      if (childValue !== undefined) {
-        collect(subSchema, childValue, offset + propOffset.offset, propOffset.padding ?? padding);
-      }
-    }
-  }
-
-  function collectArrayDense(
-    arrSchema: wgsl.WgslArray,
-    value: unknown[] | ArrayBufferView,
-    offset: number,
-    padding: number,
-  ) {
-    const elementSize = roundUp(sizeOf(arrSchema.elementType), alignmentOf(arrSchema.elementType));
-
-    if (ArrayBuffer.isView(value)) {
-      const copyLen = Math.min(value.byteLength, arrSchema.elementCount * elementSize);
-      updates.push({
-        offset,
-        size: copyLen,
-        padding,
-        write: (view, localOffset) => {
-          new Uint8Array(view.buffer, view.byteOffset + localOffset, copyLen).set(
-            new Uint8Array(value.buffer, value.byteOffset, copyLen),
-          );
-        },
-      });
-      return;
-    }
-
-    const arrWriter = getCompiledWriter(arrSchema);
-    if (arrWriter) {
-      const arrSize = arrSchema.elementCount * elementSize;
-      updates.push({
-        offset,
-        size: arrSize,
-        padding,
-        write: makeWriteFn(arrWriter, arrSchema, arrSize, value),
-      });
-      return;
-    }
-
-    const elementPadding = elementSize - sizeOf(arrSchema.elementType);
-    for (let i = 0; i < Math.min(arrSchema.elementCount, value.length); i++) {
-      collect(arrSchema.elementType, value[i], offset + i * elementSize, elementPadding);
-    }
-  }
-
-  function collect(node: wgsl.BaseData, value: unknown, offset: number, padding: number) {
+  function collect(node: wgsl.BaseData, value: unknown, offset: number, padding?: number) {
     if (value === undefined || value === null) {
       return;
     }
 
     if (isWgslStruct(node) || isUnstruct(node)) {
-      collectStruct(node, value as Record<string, unknown>, offset, padding);
+      const propOffsets = offsetsForProps(node);
+      for (const [key, propOffset] of Object.entries(propOffsets)) {
+        const childValue = (value as Record<string, unknown>)[key];
+        const subSchema = node.propTypes[key];
+        if (childValue !== undefined && subSchema) {
+          collect(subSchema, childValue, offset + propOffset.offset, propOffset.padding ?? padding);
+        }
+      }
       return;
     }
 
     if (isWgslArray(node) || isDisarray(node)) {
       const arrSchema = node as wgsl.WgslArray;
-
-      if (ArrayBuffer.isView(value) || Array.isArray(value)) {
-        collectArrayDense(arrSchema, value, offset, padding);
-        return;
-      }
-
-      const sparse = value as Record<string, unknown>;
       const elementSize = roundUp(
         sizeOf(arrSchema.elementType),
         alignmentOf(arrSchema.elementType),
       );
       const elementPadding = elementSize - sizeOf(arrSchema.elementType);
+
+      if (ArrayBuffer.isView(value)) {
+        const copyLen = Math.min(value.byteLength, arrSchema.elementCount * elementSize);
+        new Uint8Array(bigBuffer, offset, copyLen).set(
+          new Uint8Array(value.buffer, value.byteOffset, copyLen),
+        );
+        segments.push({ start: offset, end: offset + copyLen, padding });
+        return;
+      }
+
+      if (Array.isArray(value)) {
+        for (let i = 0; i < Math.min(arrSchema.elementCount, value.length); i++) {
+          collect(arrSchema.elementType, value[i], offset + i * elementSize, elementPadding);
+        }
+        return;
+      }
+
+      const sparse = value as Record<string, unknown>;
       for (const key of Object.keys(sparse)) {
         const idx = Number(key);
         if (!Number.isNaN(idx)) {
@@ -276,14 +128,41 @@ export function getPatchInstructions<TData extends wgsl.BaseData>(
     }
 
     const leafSize = sizeOf(node);
-    updates.push({
-      offset,
-      size: leafSize,
-      padding,
-      write: makeWriteFn(getCompiledWriter(node), node, leafSize, value),
+    const compiledWriter = getCompiledWriter(node);
+    if (compiledWriter) {
+      compiledWriter(new DataView(bigBuffer), offset, value, isLittleEndian, offset + leafSize);
+    } else {
+      writer.seekTo(offset);
+      writeData(writer, node, value);
+    }
+    segments.push({ start: offset, end: offset + leafSize, padding });
+  }
+
+  collect(schema, data, 0);
+  segments.sort((a, b) => a.start - b.start);
+
+  const instructions: WriteInstruction[] = [];
+  let run: Segment | null = null;
+
+  for (const seg of segments) {
+    if (run && seg.start === run.end + (run.padding ?? 0)) {
+      run = { start: run.start, end: seg.end, padding: seg.padding };
+    } else {
+      if (run) {
+        instructions.push({
+          gpuOffset: run.start,
+          data: new Uint8Array(bigBuffer, run.start, run.end - run.start),
+        });
+      }
+      run = seg;
+    }
+  }
+  if (run) {
+    instructions.push({
+      gpuOffset: run.start,
+      data: new Uint8Array(bigBuffer, run.start, run.end - run.start),
     });
   }
 
-  collect(schema, data, 0, 0);
-  return coalesceUpdates(updates);
+  return instructions;
 }

--- a/packages/typegpu/src/data/partialIO.ts
+++ b/packages/typegpu/src/data/partialIO.ts
@@ -1,6 +1,5 @@
 import { BufferWriter, getSystemEndianness } from 'typed-binary';
 import { roundUp } from '../mathUtils.ts';
-import type { InferPartial } from '../shared/repr.ts';
 import { alignmentOf } from './alignmentOf.ts';
 import { type CompiledWriter, getCompiledWriter } from './compiledIO.ts';
 import { writeData } from './dataIO.ts';
@@ -15,6 +14,51 @@ export interface WriteInstruction {
   gpuOffset: number;
 }
 
+/**
+ * Converts a value in the legacy `InferPartial` format (with `{idx, value}[]`
+ * sparse arrays) into the `InferPatch` format (with `Record<number, T>`).
+ * Dense arrays, typed arrays, and leaves are already patch-compatible and
+ * pass through untouched.
+ */
+export function convertPartialToPatch(schema: wgsl.BaseData, data: unknown): unknown {
+  if (data === undefined || data === null) {
+    return data;
+  }
+
+  if (isWgslStruct(schema) || isUnstruct(schema)) {
+    const result: Record<string, unknown> = {};
+    const record = data as Record<string, unknown>;
+    for (const key of Object.keys(schema.propTypes)) {
+      const subSchema = schema.propTypes[key];
+      const value = record[key];
+      if (value !== undefined && subSchema) {
+        result[key] = convertPartialToPatch(subSchema, value);
+      }
+    }
+    return result;
+  }
+
+  if (
+    (isWgslArray(schema) || isDisarray(schema)) &&
+    Array.isArray(data) &&
+    data.length > 0 &&
+    typeof data[0] === 'object' &&
+    data[0] !== null &&
+    'idx' in data[0]
+  ) {
+    const arrSchema = schema as wgsl.WgslArray;
+    const result: Record<number, unknown> = {};
+    for (const entry of data as { idx: number; value: unknown }[]) {
+      result[entry.idx] = convertPartialToPatch(arrSchema.elementType, entry.value);
+    }
+    return result;
+  }
+
+  return data;
+}
+
+const isLittleEndian = getSystemEndianness() === 'little';
+
 interface Update {
   offset: number;
   size: number;
@@ -22,27 +66,15 @@ interface Update {
   write: (view: DataView, localOffset: number) => void;
 }
 
-const isLittleEndian = getSystemEndianness() === 'little';
-
-function isSparseArray(value: unknown): boolean {
-  return (
-    Array.isArray(value) &&
-    value.length > 0 &&
-    typeof value[0] === 'object' &&
-    value[0] !== null &&
-    'idx' in (value[0] as object)
-  );
-}
-
 /**
- * Can the partial value be passed directly to the struct's compiled writer?
- * True when every field is present and no array field uses sparse format.
+ * Compiled writers require every field to be present and every array field
+ * to be in dense form (plain array or TypedArray, not a sparse Record).
  */
 function canUseDirectWriter(
   node: wgsl.WgslStruct | Unstruct,
   value: Record<string, unknown>,
 ): boolean {
-  for (const key of Object.keys(offsetsForProps(node))) {
+  for (const key of Object.keys(node.propTypes)) {
     const childValue = value[key];
     if (childValue === undefined || childValue === null) {
       return false;
@@ -50,13 +82,16 @@ function canUseDirectWriter(
 
     const subSchema = node.propTypes[key];
 
-    if ((isWgslArray(subSchema) || isDisarray(subSchema)) && isSparseArray(childValue)) {
-      return false;
+    if (isWgslStruct(subSchema) || isUnstruct(subSchema)) {
+      if (!canUseDirectWriter(subSchema, childValue as Record<string, unknown>)) {
+        return false;
+      }
     }
 
     if (
-      (isWgslStruct(subSchema) || isUnstruct(subSchema)) &&
-      !canUseDirectWriter(subSchema as wgsl.WgslStruct, childValue as Record<string, unknown>)
+      (isWgslArray(subSchema) || isDisarray(subSchema)) &&
+      !Array.isArray(childValue) &&
+      !ArrayBuffer.isView(childValue)
     ) {
       return false;
     }
@@ -81,9 +116,50 @@ function makeWriteFn(
   };
 }
 
-export function getWriteInstructions<TData extends wgsl.BaseData>(
+interface Run {
+  start: number;
+  end: number;
+  padding: number;
+  entries: Update[];
+}
+
+function flushRun(run: Run): WriteInstruction {
+  const buf = new ArrayBuffer(run.end - run.start);
+  const view = new DataView(buf);
+  for (const entry of run.entries) {
+    entry.write(view, entry.offset - run.start);
+  }
+  return { gpuOffset: run.start, data: new Uint8Array(buf) };
+}
+
+function coalesceUpdates(updates: Update[]): WriteInstruction[] {
+  updates.sort((a, b) => a.offset - b.offset);
+
+  const instructions: WriteInstruction[] = [];
+  let run: Run | null = null;
+
+  for (const u of updates) {
+    if (run && u.offset === run.end + run.padding) {
+      run.end = u.offset + u.size;
+      run.padding = u.padding;
+      run.entries.push(u);
+    } else {
+      if (run) {
+        instructions.push(flushRun(run));
+      }
+      run = { start: u.offset, end: u.offset + u.size, padding: u.padding, entries: [u] };
+    }
+  }
+  if (run) {
+    instructions.push(flushRun(run));
+  }
+
+  return instructions;
+}
+
+export function getPatchInstructions<TData extends wgsl.BaseData>(
   schema: TData,
-  data: InferPartial<TData>,
+  data: unknown,
 ): WriteInstruction[] {
   if (sizeOf(schema) === 0 || data === undefined || data === null) {
     return [];
@@ -91,157 +167,123 @@ export function getWriteInstructions<TData extends wgsl.BaseData>(
 
   const updates: Update[] = [];
 
-  function collect(node: wgsl.BaseData, partialValue: unknown, offset: number, padding: number) {
-    if (partialValue === undefined || partialValue === null) {
-      return;
-    }
-
-    if (isWgslStruct(node) || isUnstruct(node)) {
-      const writer = canUseDirectWriter(node, partialValue as Record<string, unknown>)
-        ? getCompiledWriter(node)
-        : undefined;
-
+  function collectStruct(
+    node: wgsl.WgslStruct | Unstruct,
+    value: Record<string, unknown>,
+    offset: number,
+    padding: number,
+  ) {
+    if (canUseDirectWriter(node, value)) {
+      const writer = getCompiledWriter(node);
       if (writer) {
         const nodeSize = sizeOf(node);
         updates.push({
           offset,
           size: nodeSize,
           padding,
-          write: makeWriteFn(writer, node, nodeSize, partialValue),
+          write: makeWriteFn(writer, node, nodeSize, value),
         });
         return;
       }
+    }
 
-      const propOffsets = offsetsForProps(node);
-      for (const key of Object.keys(propOffsets)) {
-        const propOffset = propOffsets[key];
-        const subSchema = node.propTypes[key];
-        if (!subSchema || !propOffset) {
-          continue;
-        }
-
-        const childValue = (partialValue as Record<string, unknown>)[key];
-        if (childValue !== undefined) {
-          collect(subSchema, childValue, offset + propOffset.offset, propOffset.padding ?? padding);
-        }
+    const propOffsets = offsetsForProps(node);
+    for (const key of Object.keys(propOffsets)) {
+      const propOffset = propOffsets[key];
+      const subSchema = node.propTypes[key];
+      if (!subSchema || !propOffset) {
+        continue;
       }
+      const childValue = value[key];
+      if (childValue !== undefined) {
+        collect(subSchema, childValue, offset + propOffset.offset, propOffset.padding ?? padding);
+      }
+    }
+  }
+
+  function collectArrayDense(
+    arrSchema: wgsl.WgslArray,
+    value: unknown[] | ArrayBufferView,
+    offset: number,
+    padding: number,
+  ) {
+    const elementSize = roundUp(sizeOf(arrSchema.elementType), alignmentOf(arrSchema.elementType));
+
+    if (ArrayBuffer.isView(value)) {
+      const copyLen = Math.min(value.byteLength, arrSchema.elementCount * elementSize);
+      updates.push({
+        offset,
+        size: copyLen,
+        padding,
+        write: (view, localOffset) => {
+          new Uint8Array(view.buffer, view.byteOffset + localOffset, copyLen).set(
+            new Uint8Array(value.buffer, value.byteOffset, copyLen),
+          );
+        },
+      });
+      return;
+    }
+
+    const arrWriter = getCompiledWriter(arrSchema);
+    if (arrWriter) {
+      const arrSize = arrSchema.elementCount * elementSize;
+      updates.push({
+        offset,
+        size: arrSize,
+        padding,
+        write: makeWriteFn(arrWriter, arrSchema, arrSize, value),
+      });
+      return;
+    }
+
+    const elementPadding = elementSize - sizeOf(arrSchema.elementType);
+    for (let i = 0; i < Math.min(arrSchema.elementCount, value.length); i++) {
+      collect(arrSchema.elementType, value[i], offset + i * elementSize, elementPadding);
+    }
+  }
+
+  function collect(node: wgsl.BaseData, value: unknown, offset: number, padding: number) {
+    if (value === undefined || value === null) {
+      return;
+    }
+
+    if (isWgslStruct(node) || isUnstruct(node)) {
+      collectStruct(node, value as Record<string, unknown>, offset, padding);
       return;
     }
 
     if (isWgslArray(node) || isDisarray(node)) {
       const arrSchema = node as wgsl.WgslArray;
+
+      if (ArrayBuffer.isView(value) || Array.isArray(value)) {
+        collectArrayDense(arrSchema, value, offset, padding);
+        return;
+      }
+
+      const sparse = value as Record<string, unknown>;
       const elementSize = roundUp(
         sizeOf(arrSchema.elementType),
         alignmentOf(arrSchema.elementType),
       );
       const elementPadding = elementSize - sizeOf(arrSchema.elementType);
-
-      if (ArrayBuffer.isView(partialValue)) {
-        const src = partialValue;
-        const copyLen = Math.min(src.byteLength, arrSchema.elementCount * elementSize);
-        updates.push({
-          offset,
-          size: copyLen,
-          padding,
-          write: (view, localOffset) => {
-            new Uint8Array(view.buffer, view.byteOffset + localOffset, copyLen).set(
-              new Uint8Array(src.buffer, src.byteOffset, copyLen),
-            );
-          },
-        });
-        return;
-      }
-
-      if (!Array.isArray(partialValue)) {
-        throw new Error('Partial value for array must be an array');
-      }
-
-      if (isSparseArray(partialValue)) {
-        const entries = partialValue as { idx: number; value: unknown }[];
-        entries.sort((a, b) => a.idx - b.idx);
-        for (const { idx, value } of entries) {
-          collect(arrSchema.elementType, value, offset + idx * elementSize, elementPadding);
-        }
-        return;
-      }
-
-      // Full replacement with plain array
-      const arrWriter = getCompiledWriter(node);
-      if (arrWriter) {
-        const arrSize = arrSchema.elementCount * elementSize;
-        updates.push({
-          offset,
-          size: arrSize,
-          padding,
-          write: makeWriteFn(arrWriter, node, arrSize, partialValue),
-        });
-      } else {
-        for (let i = 0; i < Math.min(arrSchema.elementCount, partialValue.length); i++) {
-          collect(arrSchema.elementType, partialValue[i], offset + i * elementSize, elementPadding);
+      for (const key of Object.keys(sparse)) {
+        const idx = Number(key);
+        if (!Number.isNaN(idx)) {
+          collect(arrSchema.elementType, sparse[key], offset + idx * elementSize, elementPadding);
         }
       }
       return;
     }
 
-    // Leaf (vec, mat, scalar, packed)
     const leafSize = sizeOf(node);
     updates.push({
       offset,
       size: leafSize,
       padding,
-      write: makeWriteFn(getCompiledWriter(node), node, leafSize, partialValue),
+      write: makeWriteFn(getCompiledWriter(node), node, leafSize, value),
     });
   }
 
   collect(schema, data, 0, 0);
-
-  if (updates.length === 0) {
-    return [];
-  }
-
-  // Coalesce adjacent updates (bridging known alignment padding) into runs
-  updates.sort((a, b) => a.offset - b.offset);
-
-  const first = updates[0];
-  if (!first) {
-    return [];
-  }
-
-  const instructions: WriteInstruction[] = [];
-  let run = {
-    start: first.offset,
-    end: first.offset + first.size,
-    padding: first.padding,
-    entries: [first],
-  };
-
-  for (let i = 1; i < updates.length; i++) {
-    const u = updates[i];
-    if (!u) {
-      continue;
-    }
-    if (u.offset === run.end + run.padding) {
-      run.end = u.offset + u.size;
-      run.padding = u.padding;
-      run.entries.push(u);
-    } else {
-      instructions.push(flushRun(run));
-      run = { start: u.offset, end: u.offset + u.size, padding: u.padding, entries: [u] };
-    }
-  }
-  instructions.push(flushRun(run));
-
-  return instructions;
-}
-
-function flushRun(run: { start: number; end: number; entries: Update[] }): WriteInstruction {
-  const runSize = run.end - run.start;
-  const buf = new ArrayBuffer(runSize);
-  const view = new DataView(buf);
-
-  for (const entry of run.entries) {
-    entry.write(view, entry.offset - run.start);
-  }
-
-  return { gpuOffset: run.start, data: new Uint8Array(buf) };
+  return coalesceUpdates(updates);
 }

--- a/packages/typegpu/src/data/partialIO.ts
+++ b/packages/typegpu/src/data/partialIO.ts
@@ -145,7 +145,7 @@ export function getPatchInstructions<TData extends wgsl.BaseData>(
       if (run) {
         instructions.push({
           gpuOffset: run.start,
-          data: new Uint8Array(buf, run.start, run.end - run.start),
+          data: new Uint8Array(buf, run.start, run.end - run.start).slice(),
         });
       }
       run = seg;
@@ -154,7 +154,7 @@ export function getPatchInstructions<TData extends wgsl.BaseData>(
   if (run) {
     instructions.push({
       gpuOffset: run.start,
-      data: new Uint8Array(buf, run.start, run.end - run.start),
+      data: new Uint8Array(buf, run.start, run.end - run.start).slice(),
     });
   }
 

--- a/packages/typegpu/src/data/partialIO.ts
+++ b/packages/typegpu/src/data/partialIO.ts
@@ -133,7 +133,7 @@ export function getPatchInstructions<TData extends wgsl.BaseData>(
   }
 
   collect(schema, data, 0);
-  segments.sort((a, b) => a.start - b.start);
+  // segments.sort((a, b) => a.start - b.start);
 
   const instructions: WriteInstruction[] = [];
   let run: Segment | null = null;

--- a/packages/typegpu/src/data/partialIO.ts
+++ b/packages/typegpu/src/data/partialIO.ts
@@ -35,18 +35,11 @@ export function convertPartialToPatch(schema: wgsl.BaseData, data: unknown): unk
     return result;
   }
 
-  if (
-    (isWgslArray(schema) || isDisarray(schema)) &&
-    Array.isArray(data) &&
-    data.length > 0 &&
-    typeof data[0] === 'object' &&
-    data[0] !== null &&
-    'idx' in data[0]
-  ) {
+  if (isWgslArray(schema) || isDisarray(schema)) {
     const arrSchema = schema as wgsl.WgslArray;
     const result: Record<number, unknown> = {};
-    for (const entry of data as { idx: number; value: unknown }[]) {
-      result[entry.idx] = convertPartialToPatch(arrSchema.elementType, entry.value);
+    for (const { idx, value } of data as { idx: number; value: unknown }[]) {
+      result[idx] = convertPartialToPatch(arrSchema.elementType, value);
     }
     return result;
   }

--- a/packages/typegpu/src/data/partialIO.ts
+++ b/packages/typegpu/src/data/partialIO.ts
@@ -1,9 +1,10 @@
-import { BufferWriter } from 'typed-binary';
+import { BufferWriter, getSystemEndianness } from 'typed-binary';
 import { roundUp } from '../mathUtils.ts';
-import type { Infer, InferPartial } from '../shared/repr.ts';
+import type { InferPartial } from '../shared/repr.ts';
 import { alignmentOf } from './alignmentOf.ts';
+import { type CompiledWriter, getCompiledWriter } from './compiledIO.ts';
 import { writeData } from './dataIO.ts';
-import { isDisarray, isUnstruct } from './dataTypes.ts';
+import { isDisarray, isUnstruct, type Unstruct } from './dataTypes.ts';
 import { offsetsForProps } from './offsets.ts';
 import { sizeOf } from './sizeOf.ts';
 import type * as wgsl from './wgslTypes.ts';
@@ -11,53 +12,117 @@ import { isWgslArray, isWgslStruct } from './wgslTypes.ts';
 
 export interface WriteInstruction {
   data: Uint8Array<ArrayBuffer>;
+  gpuOffset: number;
+}
+
+interface Update {
+  offset: number;
+  size: number;
+  padding: number;
+  write: (view: DataView, localOffset: number) => void;
+}
+
+const isLittleEndian = getSystemEndianness() === 'little';
+
+function isSparseArray(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    typeof value[0] === 'object' &&
+    value[0] !== null &&
+    'idx' in (value[0] as object)
+  );
+}
+
+/**
+ * Can the partial value be passed directly to the struct's compiled writer?
+ * True when every field is present and no array field uses sparse format.
+ */
+function canUseDirectWriter(
+  node: wgsl.WgslStruct | Unstruct,
+  value: Record<string, unknown>,
+): boolean {
+  for (const key of Object.keys(offsetsForProps(node))) {
+    const childValue = value[key];
+    if (childValue === undefined || childValue === null) {
+      return false;
+    }
+
+    const subSchema = node.propTypes[key];
+
+    if ((isWgslArray(subSchema) || isDisarray(subSchema)) && isSparseArray(childValue)) {
+      return false;
+    }
+
+    if (
+      (isWgslStruct(subSchema) || isUnstruct(subSchema)) &&
+      !canUseDirectWriter(subSchema as wgsl.WgslStruct, childValue as Record<string, unknown>)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function makeWriteFn(
+  writer: CompiledWriter | undefined,
+  node: wgsl.BaseData,
+  size: number,
+  value: unknown,
+): (view: DataView, localOffset: number) => void {
+  if (writer) {
+    return (view, localOffset) =>
+      writer(view, localOffset, value, isLittleEndian, localOffset + size);
+  }
+  return (view, localOffset) => {
+    const bw = new BufferWriter(view.buffer, { byteOffset: view.byteOffset });
+    bw.seekTo(localOffset);
+    writeData(bw, node, value);
+  };
 }
 
 export function getWriteInstructions<TData extends wgsl.BaseData>(
   schema: TData,
   data: InferPartial<TData>,
 ): WriteInstruction[] {
-  const totalSize = sizeOf(schema);
-  if (totalSize === 0 || data === undefined || data === null) {
+  if (sizeOf(schema) === 0 || data === undefined || data === null) {
     return [];
   }
 
-  const bigBuffer = new ArrayBuffer(totalSize);
-  const writer = new BufferWriter(bigBuffer);
+  const updates: Update[] = [];
 
-  const segments: Array<{
-    start: number;
-    end: number;
-    padding?: number | undefined;
-  }> = [];
-
-  function gatherAndWrite<T extends wgsl.BaseData>(
-    node: T,
-    partialValue: InferPartial<T> | undefined,
-    offset: number,
-    padding?: number,
-  ) {
+  function collect(node: wgsl.BaseData, partialValue: unknown, offset: number, padding: number) {
     if (partialValue === undefined || partialValue === null) {
       return;
     }
 
     if (isWgslStruct(node) || isUnstruct(node)) {
-      const propOffsets = offsetsForProps(node);
+      const writer = canUseDirectWriter(node, partialValue as Record<string, unknown>)
+        ? getCompiledWriter(node)
+        : undefined;
 
-      for (const [key, propOffset] of Object.entries(propOffsets)) {
+      if (writer) {
+        const nodeSize = sizeOf(node);
+        updates.push({
+          offset,
+          size: nodeSize,
+          padding,
+          write: makeWriteFn(writer, node, nodeSize, partialValue),
+        });
+        return;
+      }
+
+      const propOffsets = offsetsForProps(node);
+      for (const key of Object.keys(propOffsets)) {
+        const propOffset = propOffsets[key];
         const subSchema = node.propTypes[key];
-        if (!subSchema) {
+        if (!subSchema || !propOffset) {
           continue;
         }
 
-        const childValue = partialValue[key as keyof typeof partialValue];
+        const childValue = (partialValue as Record<string, unknown>)[key];
         if (childValue !== undefined) {
-          gatherAndWrite(
-            subSchema,
-            childValue,
-            offset + propOffset.offset,
-            propOffset.padding ?? padding,
-          );
+          collect(subSchema, childValue, offset + propOffset.offset, propOffset.padding ?? padding);
         }
       }
       return;
@@ -69,63 +134,114 @@ export function getWriteInstructions<TData extends wgsl.BaseData>(
         sizeOf(arrSchema.elementType),
         alignmentOf(arrSchema.elementType),
       );
+      const elementPadding = elementSize - sizeOf(arrSchema.elementType);
+
+      if (ArrayBuffer.isView(partialValue)) {
+        const src = partialValue;
+        const copyLen = Math.min(src.byteLength, arrSchema.elementCount * elementSize);
+        updates.push({
+          offset,
+          size: copyLen,
+          padding,
+          write: (view, localOffset) => {
+            new Uint8Array(view.buffer, view.byteOffset + localOffset, copyLen).set(
+              new Uint8Array(src.buffer, src.byteOffset, copyLen),
+            );
+          },
+        });
+        return;
+      }
 
       if (!Array.isArray(partialValue)) {
         throw new Error('Partial value for array must be an array');
       }
-      const arrayPartialValue = (partialValue as InferPartial<wgsl.WgslArray>) ?? [];
 
-      arrayPartialValue.sort((a, b) => a.idx - b.idx);
-
-      for (const { idx, value } of arrayPartialValue) {
-        gatherAndWrite(
-          arrSchema.elementType,
-          value,
-          offset + idx * elementSize,
-          elementSize - sizeOf(arrSchema.elementType),
-        );
+      if (isSparseArray(partialValue)) {
+        const entries = partialValue as { idx: number; value: unknown }[];
+        entries.sort((a, b) => a.idx - b.idx);
+        for (const { idx, value } of entries) {
+          collect(arrSchema.elementType, value, offset + idx * elementSize, elementPadding);
+        }
+        return;
       }
-    } else {
-      const leafSize = sizeOf(node);
-      writer.seekTo(offset);
-      writeData(writer, node, partialValue as Infer<T>);
 
-      segments.push({ start: offset, end: offset + leafSize, padding });
+      // Full replacement with plain array
+      const arrWriter = getCompiledWriter(node);
+      if (arrWriter) {
+        const arrSize = arrSchema.elementCount * elementSize;
+        updates.push({
+          offset,
+          size: arrSize,
+          padding,
+          write: makeWriteFn(arrWriter, node, arrSize, partialValue),
+        });
+      } else {
+        for (let i = 0; i < Math.min(arrSchema.elementCount, partialValue.length); i++) {
+          collect(arrSchema.elementType, partialValue[i], offset + i * elementSize, elementPadding);
+        }
+      }
+      return;
     }
+
+    // Leaf (vec, mat, scalar, packed)
+    const leafSize = sizeOf(node);
+    updates.push({
+      offset,
+      size: leafSize,
+      padding,
+      write: makeWriteFn(getCompiledWriter(node), node, leafSize, partialValue),
+    });
   }
 
-  gatherAndWrite(schema, data, 0);
+  collect(schema, data, 0, 0);
 
-  if (segments.length === 0) {
+  if (updates.length === 0) {
+    return [];
+  }
+
+  // Coalesce adjacent updates (bridging known alignment padding) into runs
+  updates.sort((a, b) => a.offset - b.offset);
+
+  const first = updates[0];
+  if (!first) {
     return [];
   }
 
   const instructions: WriteInstruction[] = [];
-  let current = segments[0];
+  let run = {
+    start: first.offset,
+    end: first.offset + first.size,
+    padding: first.padding,
+    entries: [first],
+  };
 
-  for (let i = 1; i < segments.length; i++) {
-    const next = segments[i];
-    if (!next || !current) {
-      throw new Error('Internal error: missing segment');
+  for (let i = 1; i < updates.length; i++) {
+    const u = updates[i];
+    if (!u) {
+      continue;
     }
-    if (next.start === current.end + (current.padding ?? 0)) {
-      current.end = next.end;
-      current.padding = next.padding;
+    if (u.offset === run.end + run.padding) {
+      run.end = u.offset + u.size;
+      run.padding = u.padding;
+      run.entries.push(u);
     } else {
-      instructions.push({
-        data: new Uint8Array(bigBuffer, current.start, current.end - current.start),
-      });
-      current = next;
+      instructions.push(flushRun(run));
+      run = { start: u.offset, end: u.offset + u.size, padding: u.padding, entries: [u] };
     }
   }
-
-  if (!current) {
-    throw new Error('Internal error: missing segment');
-  }
-
-  instructions.push({
-    data: new Uint8Array(bigBuffer, current.start, current.end - current.start),
-  });
+  instructions.push(flushRun(run));
 
   return instructions;
+}
+
+function flushRun(run: { start: number; end: number; entries: Update[] }): WriteInstruction {
+  const runSize = run.end - run.start;
+  const buf = new ArrayBuffer(runSize);
+  const view = new DataView(buf);
+
+  for (const entry of run.entries) {
+    entry.write(view, entry.offset - run.start);
+  }
+
+  return { gpuOffset: run.start, data: new Uint8Array(buf) };
 }

--- a/packages/typegpu/src/data/partialIO.ts
+++ b/packages/typegpu/src/data/partialIO.ts
@@ -67,6 +67,7 @@ export function getPatchInstructions<TData extends wgsl.BaseData>(
 
   const buf = targetBuffer ?? new ArrayBuffer(totalSize);
   const writer = new BufferWriter(buf);
+  const compiledView = new DataView(buf);
 
   const segments: Segment[] = [];
 
@@ -124,7 +125,7 @@ export function getPatchInstructions<TData extends wgsl.BaseData>(
     const leafSize = sizeOf(node);
     const compiledWriter = getCompiledWriter(node);
     if (compiledWriter) {
-      compiledWriter(new DataView(buf), offset, value, isLittleEndian, offset + leafSize);
+      compiledWriter(compiledView, offset, value, isLittleEndian, offset + leafSize);
     } else {
       writer.seekTo(offset);
       writeData(writer, node, value);

--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -1169,7 +1169,11 @@ export interface WgslArray<out TElement extends BaseData = BaseData> extends Bas
   readonly [$repr]: Infer<TElement>[];
   readonly [$inRepr]: InferInput<TElement>[] | TypedArrayFor<TElement>;
   readonly [$gpuRepr]: InferGPU<TElement>[];
-  readonly [$reprPartial]: { idx: number; value: InferPartial<TElement> }[] | undefined;
+  readonly [$reprPartial]:
+    | { idx: number; value: InferPartial<TElement> }[]
+    | InferInput<TElement>[]
+    | TypedArrayFor<TElement>
+    | undefined;
   readonly [$memIdent]: WgslArray<MemIdentity<TElement>>;
   readonly [$validStorageSchema]: IsValidStorageSchema<TElement>;
   readonly [$validUniformSchema]: IsValidUniformSchema<TElement>;
@@ -1336,6 +1340,7 @@ export interface Decorated<
 
   // Type-tokens, not available at runtime
   readonly [$repr]: Infer<TInner>;
+  readonly [$inRepr]: InferInput<TInner>;
   readonly [$gpuRepr]: InferGPU<TInner>;
   readonly [$reprPartial]: InferPartial<TInner>;
   readonly [$memIdent]: TAttribs extends Location[]

--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -10,6 +10,8 @@ import type {
   InferGPURecord,
   InferInput,
   InferInputRecord,
+  InferPatch,
+  InferPatchRecord,
   InferPartial,
   InferPartialRecord,
   InferRecord,
@@ -26,6 +28,7 @@ import type {
   $memIdent,
   $repr,
   $reprPartial,
+  $reprPatch,
   $validStorageSchema,
   $validUniformSchema,
   $validVertexSchema,
@@ -1169,8 +1172,9 @@ export interface WgslArray<out TElement extends BaseData = BaseData> extends Bas
   readonly [$repr]: Infer<TElement>[];
   readonly [$inRepr]: InferInput<TElement>[] | TypedArrayFor<TElement>;
   readonly [$gpuRepr]: InferGPU<TElement>[];
-  readonly [$reprPartial]:
-    | { idx: number; value: InferPartial<TElement> }[]
+  readonly [$reprPartial]: { idx: number; value: InferPartial<TElement> }[] | undefined;
+  readonly [$reprPatch]:
+    | Record<number, InferPatch<TElement>>
     | InferInput<TElement>[]
     | TypedArrayFor<TElement>
     | undefined;
@@ -1211,6 +1215,7 @@ export interface WgslStruct<
   readonly [$gpuRepr]: Prettify<InferGPURecord<TProps>>;
   readonly [$memIdent]: WgslStruct<Prettify<MemIdentityRecord<TProps>>>;
   readonly [$reprPartial]: Prettify<Partial<InferPartialRecord<TProps>>> | undefined;
+  readonly [$reprPatch]: Prettify<Partial<InferPatchRecord<TProps>>> | undefined;
   readonly [$invalidSchemaReason]: SwapNever<
     {
       [K in keyof TProps]: ExtractInvalidSchemaError<
@@ -1343,6 +1348,7 @@ export interface Decorated<
   readonly [$inRepr]: InferInput<TInner>;
   readonly [$gpuRepr]: InferGPU<TInner>;
   readonly [$reprPartial]: InferPartial<TInner>;
+  readonly [$reprPatch]: InferPatch<TInner>;
   readonly [$memIdent]: TAttribs extends Location[]
     ? MemIdentity<TInner> | Decorated<MemIdentity<TInner>, TAttribs>
     : Decorated<MemIdentity<TInner>, TAttribs>;

--- a/packages/typegpu/src/shared/repr.ts
+++ b/packages/typegpu/src/shared/repr.ts
@@ -1,7 +1,7 @@
 import type { TgpuTexture } from '../core/texture/texture.ts';
 import type { Disarray, Undecorate } from '../data/dataTypes.ts';
 import type { WgslStorageTexture, WgslTexture } from '../data/texture.ts';
-import type { U16, U32, WgslArray } from '../data/wgslTypes.ts';
+import type { TypedArrayFor, U16, U32, WgslArray } from '../data/wgslTypes.ts';
 import type {
   $gpuRepr,
   $gpuValueOf,
@@ -15,7 +15,7 @@ import type {
   $validVertexSchema,
 } from './symbols.ts';
 import type { ViewDimensionToDimension } from '../core/texture/textureFormats.ts';
-import type { Default } from './utilityTypes.ts';
+import type { Default, Prettify } from './utilityTypes.ts';
 
 /**
  * Extracts the inferred representation of a resource.
@@ -76,6 +76,31 @@ export type InferInputRecord<T extends Record<string | number | symbol, unknown>
 
 export type InferPartialRecord<T extends Record<string | number | symbol, unknown>> = {
   [Key in keyof T]?: InferPartial<T[Key]>;
+};
+
+/**
+ * Extracts the patch representation of a resource.
+ * Used by the `buffer.patch` API. Differs from {@link InferPartial} in that
+ * sparse array updates use `Record<number, T>` instead of `{idx, value}[]`.
+ *
+ * @example
+ * type A = InferPatch<F32> // => number | undefined
+ * type B = InferPatch<WgslStruct<{ a: F32 }>> // => { a?: number | undefined }
+ * type C = InferPatch<WgslArray<F32>> // => Record<number, number | undefined> | number[] | undefined
+ */
+export type InferPatch<T> =
+  T extends WgslArray<infer E>
+    ? Record<number, InferPatch<E>> | InferInput<E>[] | TypedArrayFor<E> | undefined
+    : T extends Disarray<infer E>
+      ? Record<number, InferPatch<E>> | InferInput<E>[] | TypedArrayFor<E> | undefined
+      : T extends { readonly propTypes: infer P extends Record<string, unknown> }
+        ? Prettify<Partial<InferPatchRecord<P>>> | undefined
+        : T extends { readonly inner: infer I }
+          ? InferPatch<I>
+          : InferInput<T> | undefined;
+
+export type InferPatchRecord<T extends Record<string | number | symbol, unknown>> = {
+  [Key in keyof T]?: InferPatch<T[Key]>;
 };
 
 export type InferGPURecord<T extends Record<string | number | symbol, unknown>> = {

--- a/packages/typegpu/src/shared/repr.ts
+++ b/packages/typegpu/src/shared/repr.ts
@@ -45,7 +45,9 @@ export type InferInput<T> =
 
 /**
  * Extracts a sparse/partial inferred representation of a resource.
- * Used by the deprecated `buffer.writePartial` API.
+ * Used by the `buffer.writePartial` API.
+ *
+ * @deprecated
  *
  * @example
  * type A = InferPartial<F32> // => number | undefined
@@ -76,14 +78,14 @@ export type InferInputRecord<T extends Record<string | number | symbol, unknown>
   [Key in keyof T]: InferInput<T[Key]>;
 };
 
+/** @deprecated */
 export type InferPartialRecord<T extends Record<string | number | symbol, unknown>> = {
   [Key in keyof T]?: InferPartial<T[Key]>;
 };
 
 /**
  * Extracts the patch representation of a resource.
- * Used by the `buffer.patch` API. Differs from {@link InferPartial} in that
- * sparse array updates use `Record<number, T>` instead of `{idx, value}[]`.
+ * Used by the `buffer.patch` API.
  *
  * @example
  * type A = InferPatch<F32> // => number | undefined

--- a/packages/typegpu/src/shared/repr.ts
+++ b/packages/typegpu/src/shared/repr.ts
@@ -50,12 +50,11 @@ export type InferInput<T> =
  * type A = InferPartial<F32> // => number | undefined
  * type B = InferPartial<WgslStruct<{ a: F32 }>> // => { a?: number | undefined }
  * type C = InferPartial<WgslArray<F32>> // => { idx: number; value: number | undefined }[] | undefined
+ * type D = InferPartial<Vec3f> // => v3f | [number, number, number] | Float32Array | undefined
  */
 export type InferPartial<T> = T extends { readonly [$reprPartial]: infer TRepr }
   ? TRepr
-  : T extends { readonly [$repr]: infer TRepr }
-    ? TRepr | undefined
-    : T;
+  : InferInput<T> | undefined;
 
 /**
  * Extracts the inferred representation of a resource (as seen by the GPU).

--- a/packages/typegpu/src/shared/repr.ts
+++ b/packages/typegpu/src/shared/repr.ts
@@ -1,7 +1,7 @@
 import type { TgpuTexture } from '../core/texture/texture.ts';
 import type { Disarray, Undecorate } from '../data/dataTypes.ts';
 import type { WgslStorageTexture, WgslTexture } from '../data/texture.ts';
-import type { TypedArrayFor, U16, U32, WgslArray } from '../data/wgslTypes.ts';
+import type { U16, U32, WgslArray } from '../data/wgslTypes.ts';
 import type {
   $gpuRepr,
   $gpuValueOf,
@@ -10,12 +10,13 @@ import type {
   $memIdent,
   $repr,
   $reprPartial,
+  $reprPatch,
   $validStorageSchema,
   $validUniformSchema,
   $validVertexSchema,
 } from './symbols.ts';
 import type { ViewDimensionToDimension } from '../core/texture/textureFormats.ts';
-import type { Default, Prettify } from './utilityTypes.ts';
+import type { Default } from './utilityTypes.ts';
 
 /**
  * Extracts the inferred representation of a resource.
@@ -44,17 +45,18 @@ export type InferInput<T> =
 
 /**
  * Extracts a sparse/partial inferred representation of a resource.
- * Used by the `buffer.writePartial` API.
+ * Used by the deprecated `buffer.writePartial` API.
  *
  * @example
  * type A = InferPartial<F32> // => number | undefined
  * type B = InferPartial<WgslStruct<{ a: F32 }>> // => { a?: number | undefined }
  * type C = InferPartial<WgslArray<F32>> // => { idx: number; value: number | undefined }[] | undefined
- * type D = InferPartial<Vec3f> // => v3f | [number, number, number] | Float32Array | undefined
  */
 export type InferPartial<T> = T extends { readonly [$reprPartial]: infer TRepr }
   ? TRepr
-  : InferInput<T> | undefined;
+  : T extends { readonly [$repr]: infer TRepr }
+    ? TRepr | undefined
+    : T;
 
 /**
  * Extracts the inferred representation of a resource (as seen by the GPU).
@@ -88,16 +90,9 @@ export type InferPartialRecord<T extends Record<string | number | symbol, unknow
  * type B = InferPatch<WgslStruct<{ a: F32 }>> // => { a?: number | undefined }
  * type C = InferPatch<WgslArray<F32>> // => Record<number, number | undefined> | number[] | undefined
  */
-export type InferPatch<T> =
-  T extends WgslArray<infer E>
-    ? Record<number, InferPatch<E>> | InferInput<E>[] | TypedArrayFor<E> | undefined
-    : T extends Disarray<infer E>
-      ? Record<number, InferPatch<E>> | InferInput<E>[] | TypedArrayFor<E> | undefined
-      : T extends { readonly propTypes: infer P extends Record<string, unknown> }
-        ? Prettify<Partial<InferPatchRecord<P>>> | undefined
-        : T extends { readonly inner: infer I }
-          ? InferPatch<I>
-          : InferInput<T> | undefined;
+export type InferPatch<T> = T extends { readonly [$reprPatch]: infer TRepr }
+  ? TRepr
+  : InferInput<T> | undefined;
 
 export type InferPatchRecord<T extends Record<string | number | symbol, unknown>> = {
   [Key in keyof T]?: InferPatch<T[Key]>;

--- a/packages/typegpu/src/shared/symbols.ts
+++ b/packages/typegpu/src/shared/symbols.ts
@@ -54,6 +54,11 @@ export const $gpuRepr = Symbol(`typegpu:${version}:$gpuRepr`);
  */
 export const $reprPartial = Symbol(`typegpu:${version}:$reprPartial`);
 /**
+ * Type token for the inferred patch representation of a resource.
+ * Used by the `buffer.patch` API with `Record<number, T>` sparse arrays.
+ */
+export const $reprPatch = Symbol(`typegpu:${version}:$reprPatch`);
+/**
  * Type token for the write-side (input) representation of a resource.
  */
 export const $inRepr = Symbol(`typegpu:${version}:$inRepr`);

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -469,28 +469,23 @@ describe('TgpuBuffer', () => {
 
   it('should allow for partial writes', ({ root, device }) => {
     const buffer = root.createBuffer(d.struct({ a: d.u32, b: d.u32 }));
-
-    buffer.writePartial({ a: 3 });
-
     const rawBuffer = root.unwrap(buffer);
     expect(rawBuffer).toBeDefined();
 
+    buffer.writePartial({ a: 3 });
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
       [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
     ]);
+    device.mock.queue.writeBuffer.mockClear();
 
     buffer.writePartial({ b: 4 });
-
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
       [rawBuffer, 4, toUint8Array(new Uint32Array([4]))],
     ]);
+    device.mock.queue.writeBuffer.mockClear();
 
     buffer.writePartial({ a: 5, b: 6 }); // should merge the writes
-
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
-      [rawBuffer, 4, toUint8Array(new Uint32Array([4]))],
       [rawBuffer, 0, toUint8Array(new Uint32Array([5, 6]))],
     ]);
   });
@@ -503,22 +498,20 @@ describe('TgpuBuffer', () => {
         d: d.arrayOf(d.u32, 3),
       }),
     );
-
-    buffer.writePartial({ a: 3 });
-
     const rawBuffer = root.unwrap(buffer);
     expect(rawBuffer).toBeDefined();
 
+    buffer.writePartial({ a: 3 });
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
       [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
     ]);
+    device.mock.queue.writeBuffer.mockClear();
 
     buffer.writePartial({ b: { c: d.vec2f(1, 2) } });
-
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
       [rawBuffer, 8, toUint8Array(new Float32Array([1, 2]))],
     ]);
+    device.mock.queue.writeBuffer.mockClear();
 
     buffer.writePartial({
       d: [
@@ -526,13 +519,11 @@ describe('TgpuBuffer', () => {
         { idx: 2, value: 3 },
       ],
     });
-
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
-      [rawBuffer, 8, toUint8Array(new Float32Array([1, 2]))],
       [rawBuffer, 16, toUint8Array(new Uint32Array([1]))],
       [rawBuffer, 24, toUint8Array(new Uint32Array([3]))],
     ]);
+    device.mock.queue.writeBuffer.mockClear();
 
     buffer.writePartial({
       b: { c: d.vec2f(3, 4) },
@@ -541,12 +532,7 @@ describe('TgpuBuffer', () => {
         { idx: 1, value: 3 },
       ],
     }); // should merge the writes
-
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
-      [rawBuffer, 8, toUint8Array(new Float32Array([1, 2]))],
-      [rawBuffer, 16, toUint8Array(new Uint32Array([1]))],
-      [rawBuffer, 24, toUint8Array(new Uint32Array([3]))],
       [rawBuffer, 8, toUint8Array(new Float32Array([3, 4]), new Uint32Array([2, 3]))],
     ]);
   });

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -973,7 +973,7 @@ describe('TgpuBuffer (.patch() with flexible inputs)', () => {
     });
 
     // Full replacement with TypedArray
-    arrBuf.patch({ items: new Float32Array(48) });
+    arrBuf.patch({ items: new Float32Array(64) });
   });
 
   it('should patch a vec3f struct field from a tuple', ({ root, device }) => {

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -5,7 +5,11 @@ import * as d from '../src/data/index.ts';
 import { sizeOf } from '../src/data/sizeOf.ts';
 import type { ValidateBufferSchema, ValidUsagesFor } from '../src/index.js';
 import { getName } from '../src/shared/meta.ts';
-import type { IsValidBufferSchema, IsValidUniformSchema } from '../src/shared/repr.ts';
+import type {
+  InferPartial,
+  IsValidBufferSchema,
+  IsValidUniformSchema,
+} from '../src/shared/repr.ts';
 import type { TypedArray } from '../src/shared/utilityTypes.ts';
 import { it } from 'typegpu-testing-utility';
 
@@ -476,22 +480,22 @@ describe('TgpuBuffer', () => {
     expect(rawBuffer).toBeDefined();
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Uint32Array([3])), 0, 4],
+      [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
     ]);
 
     buffer.writePartial({ b: 4 });
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Uint32Array([3])), 0, 4],
-      [rawBuffer, 4, toUint8Array(new Uint32Array([4])), 0, 4],
+      [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
+      [rawBuffer, 4, toUint8Array(new Uint32Array([4]))],
     ]);
 
     buffer.writePartial({ a: 5, b: 6 }); // should merge the writes
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Uint32Array([3])), 0, 4],
-      [rawBuffer, 4, toUint8Array(new Uint32Array([4])), 0, 4],
-      [rawBuffer, 0, toUint8Array(new Uint32Array([5, 6])), 0, 8],
+      [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
+      [rawBuffer, 4, toUint8Array(new Uint32Array([4]))],
+      [rawBuffer, 0, toUint8Array(new Uint32Array([5, 6]))],
     ]);
   });
 
@@ -510,14 +514,14 @@ describe('TgpuBuffer', () => {
     expect(rawBuffer).toBeDefined();
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Uint32Array([3])), 0, 4],
+      [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
     ]);
 
     buffer.writePartial({ b: { c: d.vec2f(1, 2) } });
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Uint32Array([3])), 0, 4],
-      [rawBuffer, 8, toUint8Array(new Float32Array([1, 2])), 0, 8],
+      [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
+      [rawBuffer, 8, toUint8Array(new Float32Array([1, 2]))],
     ]);
 
     buffer.writePartial({
@@ -528,10 +532,10 @@ describe('TgpuBuffer', () => {
     });
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Uint32Array([3])), 0, 4],
-      [rawBuffer, 8, toUint8Array(new Float32Array([1, 2])), 0, 8],
-      [rawBuffer, 16, toUint8Array(new Uint32Array([1])), 0, 4],
-      [rawBuffer, 24, toUint8Array(new Uint32Array([3])), 0, 4],
+      [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
+      [rawBuffer, 8, toUint8Array(new Float32Array([1, 2]))],
+      [rawBuffer, 16, toUint8Array(new Uint32Array([1]))],
+      [rawBuffer, 24, toUint8Array(new Uint32Array([3]))],
     ]);
 
     buffer.writePartial({
@@ -543,11 +547,11 @@ describe('TgpuBuffer', () => {
     }); // should merge the writes
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Uint32Array([3])), 0, 4],
-      [rawBuffer, 8, toUint8Array(new Float32Array([1, 2])), 0, 8],
-      [rawBuffer, 16, toUint8Array(new Uint32Array([1])), 0, 4],
-      [rawBuffer, 24, toUint8Array(new Uint32Array([3])), 0, 4],
-      [rawBuffer, 8, toUint8Array(new Float32Array([3, 4]), new Uint32Array([2, 3])), 0, 16],
+      [rawBuffer, 0, toUint8Array(new Uint32Array([3]))],
+      [rawBuffer, 8, toUint8Array(new Float32Array([1, 2]))],
+      [rawBuffer, 16, toUint8Array(new Uint32Array([1]))],
+      [rawBuffer, 24, toUint8Array(new Uint32Array([3]))],
+      [rawBuffer, 8, toUint8Array(new Float32Array([3, 4]), new Uint32Array([2, 3]))],
     ]);
   });
 
@@ -565,23 +569,24 @@ describe('TgpuBuffer', () => {
     const rawBuffer = root.unwrap(buffer);
     expect(rawBuffer).toBeDefined();
 
+    // unorm16: Math.round(0.5 * 65535) = 32768 -> [0, 128] in LE
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 8, new Uint8Array([255, 127, 255, 127]), 0, 4],
+      [rawBuffer, 8, new Uint8Array([0, 128, 0, 128])],
     ]);
 
     buffer.writePartial({ b: d.vec2f(-0.5, 0.5) });
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 8, new Uint8Array([255, 127, 255, 127]), 0, 4],
-      [rawBuffer, 16, new Uint8Array([193, 64]), 0, 2],
+      [rawBuffer, 8, new Uint8Array([0, 128, 0, 128])],
+      [rawBuffer, 16, new Uint8Array([193, 64])],
     ]);
 
     buffer.writePartial({ c: { d: 3 } });
 
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 8, new Uint8Array([255, 127, 255, 127]), 0, 4],
-      [rawBuffer, 16, new Uint8Array([193, 64]), 0, 2],
-      [rawBuffer, 18, new Uint8Array([3, 0, 0, 0]), 0, 4],
+      [rawBuffer, 8, new Uint8Array([0, 128, 0, 128])],
+      [rawBuffer, 16, new Uint8Array([193, 64])],
+      [rawBuffer, 18, new Uint8Array([3, 0, 0, 0])],
     ]);
   });
 
@@ -941,6 +946,164 @@ describe('TgpuBuffer (InferInput)', () => {
     expect([...new Uint8Array(data, countLayout.offset)]).toStrictEqual(
       Array(d.sizeOf(Schema) - countLayout.offset).fill(0),
     );
+  });
+});
+
+describe('TgpuBuffer (writePartial with flexible inputs)', () => {
+  it('should accept tuples, TypedArrays, and number[] for leaf types at the type level', ({
+    root,
+  }) => {
+    const structBuf = root.createBuffer(
+      d.struct({ pos: d.vec3f, color: d.vec4f, transform: d.mat3x3f }),
+    );
+
+    expectTypeOf<InferPartial<d.Vec3f>>().toEqualTypeOf<
+      d.v3f | [number, number, number] | Float32Array | undefined
+    >();
+
+    expectTypeOf<InferPartial<d.Mat3x3f>>().toEqualTypeOf<
+      d.m3x3f | number[] | Float32Array | undefined
+    >();
+
+    // Struct partial should accept flexible types for fields
+    structBuf.writePartial({ pos: [1, 2, 3] });
+    structBuf.writePartial({ pos: new Float32Array([1, 2, 3]) });
+    structBuf.writePartial({ transform: [1, 2, 3, 4, 5, 6, 7, 8, 9] });
+    structBuf.writePartial({ transform: new Float32Array(12) });
+  });
+
+  it('should accept both sparse and full-replacement forms for arrays at the type level', ({
+    root,
+  }) => {
+    const arrBuf = root.createBuffer(d.struct({ items: d.arrayOf(d.vec3f, 4), count: d.u32 }));
+
+    // Sparse form
+    arrBuf.writePartial({ items: [{ idx: 0, value: d.vec3f(1, 2, 3) }] });
+    arrBuf.writePartial({ items: [{ idx: 0, value: [1, 2, 3] }] });
+
+    // Full replacement with plain array
+    arrBuf.writePartial({
+      items: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [10, 11, 12],
+      ],
+    });
+
+    // Full replacement with TypedArray
+    arrBuf.writePartial({ items: new Float32Array(48) });
+  });
+
+  it('should writePartial a vec3f struct field from a tuple', ({ root, device }) => {
+    const buffer = root.createBuffer(d.struct({ a: d.u32, b: d.vec3f }));
+
+    buffer.writePartial({ b: [1, 2, 3] });
+
+    const rawBuffer = root.unwrap(buffer);
+    expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
+      [rawBuffer, 16, toUint8Array(new Float32Array([1, 2, 3]))],
+    ]);
+  });
+
+  it('should writePartial a vec3f struct field from a Float32Array', ({ root, device }) => {
+    const buffer = root.createBuffer(d.struct({ a: d.u32, b: d.vec3f }));
+
+    buffer.writePartial({ b: new Float32Array([4, 5, 6]) });
+
+    const rawBuffer = root.unwrap(buffer);
+    expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
+      [rawBuffer, 16, toUint8Array(new Float32Array([4, 5, 6]))],
+    ]);
+  });
+
+  it('should writePartial a mat3x3f struct field from a packed number[]', ({ root, device }) => {
+    const buffer = root.createBuffer(d.struct({ a: d.u32, b: d.mat3x3f }));
+
+    // 9 packed floats (no column padding)
+    buffer.writePartial({ b: [1, 2, 3, 4, 5, 6, 7, 8, 9] });
+
+    const rawBuffer = root.unwrap(buffer);
+    // mat3x3f is padded: each column is 16 bytes (vec3f + 4 bytes padding)
+    // Offset: a=u32 (4 bytes) + padding to 16 = 16
+    expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
+      [rawBuffer, 16, toUint8Array(new Float32Array([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0]))],
+    ]);
+  });
+
+  it('should writePartial a mat3x3f struct field from a padded Float32Array', ({
+    root,
+    device,
+  }) => {
+    const buffer = root.createBuffer(d.struct({ a: d.u32, b: d.mat3x3f }));
+
+    // 12-element padded Float32Array (with column padding)
+    buffer.writePartial({ b: new Float32Array([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0]) });
+
+    const rawBuffer = root.unwrap(buffer);
+    expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
+      [rawBuffer, 16, toUint8Array(new Float32Array([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0]))],
+    ]);
+  });
+
+  it('should writePartial an array field with full TypedArray replacement', ({ root, device }) => {
+    const buffer = root.createBuffer(d.struct({ tag: d.u32, values: d.arrayOf(d.f32, 3) }));
+
+    buffer.writePartial({ values: new Float32Array([10, 20, 30]) });
+
+    const rawBuffer = root.unwrap(buffer);
+    expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
+      [rawBuffer, 4, toUint8Array(new Float32Array([10, 20, 30]))],
+    ]);
+  });
+
+  it('should writePartial an array field with full plain-array replacement', ({ root, device }) => {
+    const buffer = root.createBuffer(d.struct({ tag: d.u32, values: d.arrayOf(d.u32, 3) }));
+
+    buffer.writePartial({ values: [100, 200, 300] });
+
+    const rawBuffer = root.unwrap(buffer);
+    expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
+      [rawBuffer, 4, toUint8Array(new Uint32Array([100, 200, 300]))],
+    ]);
+  });
+
+  it('should writePartial an array of vec3f with full replacement using tuples', ({
+    root,
+    device,
+  }) => {
+    const buffer = root.createBuffer(d.struct({ values: d.arrayOf(d.vec3f, 2) }));
+
+    buffer.writePartial({
+      values: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+    });
+
+    const rawBuffer = root.unwrap(buffer);
+    // vec3f in array: compiled writer writes the full array including padding
+    expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
+      [rawBuffer, 0, toUint8Array(new Float32Array([1, 2, 3, 0, 4, 5, 6, 0]))],
+    ]);
+  });
+
+  it('should writePartial an array with sparse indexed updates using flexible value types', ({
+    root,
+    device,
+  }) => {
+    const buffer = root.createBuffer(d.arrayOf(d.vec3f, 4));
+
+    buffer.writePartial([
+      { idx: 1, value: [10, 20, 30] },
+      { idx: 3, value: [40, 50, 60] },
+    ]);
+
+    const rawBuffer = root.unwrap(buffer);
+    expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
+      [rawBuffer, 16, toUint8Array(new Float32Array([10, 20, 30]))],
+      [rawBuffer, 48, toUint8Array(new Float32Array([40, 50, 60]))],
+    ]);
   });
 });
 

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -1085,8 +1085,8 @@ describe('TgpuBuffer (.patch() with flexible inputs)', () => {
     const buffer = root.createBuffer(d.arrayOf(d.vec3f, 4));
 
     buffer.patch({
-      1: [10, 20, 30],
       3: [40, 50, 60],
+      1: [10, 20, 30],
     });
 
     const rawBuffer = root.unwrap(buffer);

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -5,11 +5,7 @@ import * as d from '../src/data/index.ts';
 import { sizeOf } from '../src/data/sizeOf.ts';
 import type { ValidateBufferSchema, ValidUsagesFor } from '../src/index.js';
 import { getName } from '../src/shared/meta.ts';
-import type {
-  InferPartial,
-  IsValidBufferSchema,
-  IsValidUniformSchema,
-} from '../src/shared/repr.ts';
+import type { InferPatch, IsValidBufferSchema, IsValidUniformSchema } from '../src/shared/repr.ts';
 import type { TypedArray } from '../src/shared/utilityTypes.ts';
 import { it } from 'typegpu-testing-utility';
 
@@ -949,7 +945,7 @@ describe('TgpuBuffer (InferInput)', () => {
   });
 });
 
-describe('TgpuBuffer (writePartial with flexible inputs)', () => {
+describe('TgpuBuffer (.patch() with flexible inputs)', () => {
   it('should accept tuples, TypedArrays, and number[] for leaf types at the type level', ({
     root,
   }) => {
@@ -957,19 +953,19 @@ describe('TgpuBuffer (writePartial with flexible inputs)', () => {
       d.struct({ pos: d.vec3f, color: d.vec4f, transform: d.mat3x3f }),
     );
 
-    expectTypeOf<InferPartial<d.Vec3f>>().toEqualTypeOf<
+    expectTypeOf<InferPatch<d.Vec3f>>().toEqualTypeOf<
       d.v3f | [number, number, number] | Float32Array | undefined
     >();
 
-    expectTypeOf<InferPartial<d.Mat3x3f>>().toEqualTypeOf<
+    expectTypeOf<InferPatch<d.Mat3x3f>>().toEqualTypeOf<
       d.m3x3f | number[] | Float32Array | undefined
     >();
 
-    // Struct partial should accept flexible types for fields
-    structBuf.writePartial({ pos: [1, 2, 3] });
-    structBuf.writePartial({ pos: new Float32Array([1, 2, 3]) });
-    structBuf.writePartial({ transform: [1, 2, 3, 4, 5, 6, 7, 8, 9] });
-    structBuf.writePartial({ transform: new Float32Array(12) });
+    // Struct patch should accept flexible types for fields
+    structBuf.patch({ pos: [1, 2, 3] });
+    structBuf.patch({ pos: new Float32Array([1, 2, 3]) });
+    structBuf.patch({ transform: [1, 2, 3, 4, 5, 6, 7, 8, 9] });
+    structBuf.patch({ transform: new Float32Array(12) });
   });
 
   it('should accept both sparse and full-replacement forms for arrays at the type level', ({
@@ -977,12 +973,12 @@ describe('TgpuBuffer (writePartial with flexible inputs)', () => {
   }) => {
     const arrBuf = root.createBuffer(d.struct({ items: d.arrayOf(d.vec3f, 4), count: d.u32 }));
 
-    // Sparse form
-    arrBuf.writePartial({ items: [{ idx: 0, value: d.vec3f(1, 2, 3) }] });
-    arrBuf.writePartial({ items: [{ idx: 0, value: [1, 2, 3] }] });
+    // Sparse form (Record<number, T>)
+    arrBuf.patch({ items: { 0: d.vec3f(1, 2, 3) } });
+    arrBuf.patch({ items: { 0: [1, 2, 3] } });
 
     // Full replacement with plain array
-    arrBuf.writePartial({
+    arrBuf.patch({
       items: [
         [1, 2, 3],
         [4, 5, 6],
@@ -992,13 +988,13 @@ describe('TgpuBuffer (writePartial with flexible inputs)', () => {
     });
 
     // Full replacement with TypedArray
-    arrBuf.writePartial({ items: new Float32Array(48) });
+    arrBuf.patch({ items: new Float32Array(48) });
   });
 
-  it('should writePartial a vec3f struct field from a tuple', ({ root, device }) => {
+  it('should patch a vec3f struct field from a tuple', ({ root, device }) => {
     const buffer = root.createBuffer(d.struct({ a: d.u32, b: d.vec3f }));
 
-    buffer.writePartial({ b: [1, 2, 3] });
+    buffer.patch({ b: [1, 2, 3] });
 
     const rawBuffer = root.unwrap(buffer);
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
@@ -1006,10 +1002,10 @@ describe('TgpuBuffer (writePartial with flexible inputs)', () => {
     ]);
   });
 
-  it('should writePartial a vec3f struct field from a Float32Array', ({ root, device }) => {
+  it('should patch a vec3f struct field from a Float32Array', ({ root, device }) => {
     const buffer = root.createBuffer(d.struct({ a: d.u32, b: d.vec3f }));
 
-    buffer.writePartial({ b: new Float32Array([4, 5, 6]) });
+    buffer.patch({ b: new Float32Array([4, 5, 6]) });
 
     const rawBuffer = root.unwrap(buffer);
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
@@ -1017,11 +1013,11 @@ describe('TgpuBuffer (writePartial with flexible inputs)', () => {
     ]);
   });
 
-  it('should writePartial a mat3x3f struct field from a packed number[]', ({ root, device }) => {
+  it('should patch a mat3x3f struct field from a packed number[]', ({ root, device }) => {
     const buffer = root.createBuffer(d.struct({ a: d.u32, b: d.mat3x3f }));
 
     // 9 packed floats (no column padding)
-    buffer.writePartial({ b: [1, 2, 3, 4, 5, 6, 7, 8, 9] });
+    buffer.patch({ b: [1, 2, 3, 4, 5, 6, 7, 8, 9] });
 
     const rawBuffer = root.unwrap(buffer);
     // mat3x3f is padded: each column is 16 bytes (vec3f + 4 bytes padding)
@@ -1031,14 +1027,11 @@ describe('TgpuBuffer (writePartial with flexible inputs)', () => {
     ]);
   });
 
-  it('should writePartial a mat3x3f struct field from a padded Float32Array', ({
-    root,
-    device,
-  }) => {
+  it('should patch a mat3x3f struct field from a padded Float32Array', ({ root, device }) => {
     const buffer = root.createBuffer(d.struct({ a: d.u32, b: d.mat3x3f }));
 
     // 12-element padded Float32Array (with column padding)
-    buffer.writePartial({ b: new Float32Array([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0]) });
+    buffer.patch({ b: new Float32Array([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0]) });
 
     const rawBuffer = root.unwrap(buffer);
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
@@ -1046,10 +1039,10 @@ describe('TgpuBuffer (writePartial with flexible inputs)', () => {
     ]);
   });
 
-  it('should writePartial an array field with full TypedArray replacement', ({ root, device }) => {
+  it('should patch an array field with full TypedArray replacement', ({ root, device }) => {
     const buffer = root.createBuffer(d.struct({ tag: d.u32, values: d.arrayOf(d.f32, 3) }));
 
-    buffer.writePartial({ values: new Float32Array([10, 20, 30]) });
+    buffer.patch({ values: new Float32Array([10, 20, 30]) });
 
     const rawBuffer = root.unwrap(buffer);
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
@@ -1057,10 +1050,10 @@ describe('TgpuBuffer (writePartial with flexible inputs)', () => {
     ]);
   });
 
-  it('should writePartial an array field with full plain-array replacement', ({ root, device }) => {
+  it('should patch an array field with full plain-array replacement', ({ root, device }) => {
     const buffer = root.createBuffer(d.struct({ tag: d.u32, values: d.arrayOf(d.u32, 3) }));
 
-    buffer.writePartial({ values: [100, 200, 300] });
+    buffer.patch({ values: [100, 200, 300] });
 
     const rawBuffer = root.unwrap(buffer);
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
@@ -1068,13 +1061,10 @@ describe('TgpuBuffer (writePartial with flexible inputs)', () => {
     ]);
   });
 
-  it('should writePartial an array of vec3f with full replacement using tuples', ({
-    root,
-    device,
-  }) => {
+  it('should patch an array of vec3f with full replacement using tuples', ({ root, device }) => {
     const buffer = root.createBuffer(d.struct({ values: d.arrayOf(d.vec3f, 2) }));
 
-    buffer.writePartial({
+    buffer.patch({
       values: [
         [1, 2, 3],
         [4, 5, 6],
@@ -1082,27 +1072,39 @@ describe('TgpuBuffer (writePartial with flexible inputs)', () => {
     });
 
     const rawBuffer = root.unwrap(buffer);
-    // vec3f in array: compiled writer writes the full array including padding
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
       [rawBuffer, 0, toUint8Array(new Float32Array([1, 2, 3, 0, 4, 5, 6, 0]))],
     ]);
   });
 
-  it('should writePartial an array with sparse indexed updates using flexible value types', ({
+  it('should patch an array with sparse indexed updates using flexible value types', ({
     root,
     device,
   }) => {
     const buffer = root.createBuffer(d.arrayOf(d.vec3f, 4));
 
-    buffer.writePartial([
-      { idx: 1, value: [10, 20, 30] },
-      { idx: 3, value: [40, 50, 60] },
-    ]);
+    buffer.patch({
+      1: [10, 20, 30],
+      3: [40, 50, 60],
+    });
 
     const rawBuffer = root.unwrap(buffer);
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
       [rawBuffer, 16, toUint8Array(new Float32Array([10, 20, 30]))],
       [rawBuffer, 48, toUint8Array(new Float32Array([40, 50, 60]))],
+    ]);
+  });
+
+  it('should not false-positive on struct elements with idx/value fields', ({ root, device }) => {
+    const WeirdSchema = d.struct({ idx: d.u32, value: d.f32 });
+    const buffer = root.createBuffer(d.arrayOf(WeirdSchema, 4));
+
+    // Sparse: update index 1 only
+    buffer.patch({ 1: { idx: 42, value: 3.14 } });
+
+    const rawBuffer = root.unwrap(buffer);
+    expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
+      [rawBuffer, 8, toUint8Array(new Uint32Array([42]), new Float32Array([3.14]))],
     ]);
   });
 });

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -565,7 +565,6 @@ describe('TgpuBuffer', () => {
     const rawBuffer = root.unwrap(buffer);
     expect(rawBuffer).toBeDefined();
 
-    // unorm16: Math.round(0.5 * 65535) = 32768 -> [0, 128] in LE
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
       [rawBuffer, 8, new Uint8Array([0, 128, 0, 128])],
     ]);
@@ -1072,8 +1071,10 @@ describe('TgpuBuffer (.patch() with flexible inputs)', () => {
     });
 
     const rawBuffer = root.unwrap(buffer);
+    // vec3f elements are 12 bytes each with 4 bytes padding between them
+    // (the trailing padding after the last element is not included)
     expect(device.mock.queue.writeBuffer.mock.calls).toStrictEqual([
-      [rawBuffer, 0, toUint8Array(new Float32Array([1, 2, 3, 0, 4, 5, 6, 0]))],
+      [rawBuffer, 0, toUint8Array(new Float32Array([1, 2, 3, 0, 4, 5, 6]))],
     ]);
   });
 

--- a/packages/typegpu/tests/compiledIO.test.ts
+++ b/packages/typegpu/tests/compiledIO.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from 'vitest';
-import { buildWriter, getCompiledWriterForSchema } from '../src/data/compiledIO.ts';
+import { buildWriter, getCompiledWriter } from '../src/data/compiledIO.ts';
 import * as d from '../src/data/index.ts';
 import { sizeOf } from '../src/data/sizeOf.ts';
 import { it } from 'typegpu-testing-utility';
@@ -349,7 +349,7 @@ describe('createCompileInstructions', () => {
       b: d.vec3f,
     });
 
-    const writer = getCompiledWriterForSchema(struct)!;
+    const writer = getCompiledWriter(struct)!;
 
     const arr = new ArrayBuffer(sizeOf(struct));
     const dataView = new DataView(arr);
@@ -367,7 +367,7 @@ describe('createCompileInstructions', () => {
       c: d.arrayOf(d.u32, 3),
     });
 
-    const writer = getCompiledWriterForSchema(struct)!;
+    const writer = getCompiledWriter(struct)!;
 
     const arr = new ArrayBuffer(sizeOf(struct));
     const dataView = new DataView(arr);
@@ -393,7 +393,7 @@ describe('createCompileInstructions', () => {
       c: d.arrayOf(d.struct({ d: d.u32 }), 3),
     });
 
-    const writer = getCompiledWriterForSchema(struct)!;
+    const writer = getCompiledWriter(struct)!;
 
     const arr = new ArrayBuffer(sizeOf(struct));
     const dataView = new DataView(arr);
@@ -412,7 +412,7 @@ describe('createCompileInstructions', () => {
   it('should compile a writer for an array', () => {
     const array = d.arrayOf(d.vec3f, 5);
 
-    const writer = getCompiledWriterForSchema(array)!;
+    const writer = getCompiledWriter(array)!;
 
     const arr = new ArrayBuffer(sizeOf(array));
     const dataView = new DataView(arr);
@@ -433,7 +433,7 @@ describe('createCompileInstructions', () => {
   it('should compile a writer for nested arrays', () => {
     const nestedArray = d.arrayOf(d.arrayOf(d.u32, 3), 2);
 
-    const writer = getCompiledWriterForSchema(nestedArray)!;
+    const writer = getCompiledWriter(nestedArray)!;
 
     const arr = new ArrayBuffer(sizeOf(nestedArray));
     const dataView = new DataView(arr);
@@ -453,7 +453,7 @@ describe('createCompileInstructions', () => {
       b: d.arrayOf(d.arrayOf(d.vec2f, 2), 2),
     });
 
-    const writer = getCompiledWriterForSchema(struct)!;
+    const writer = getCompiledWriter(struct)!;
 
     const arr = new ArrayBuffer(sizeOf(struct));
     const dataView = new DataView(arr);
@@ -473,7 +473,7 @@ describe('createCompileInstructions', () => {
   it('should compile a writer for deeply nested arrays', () => {
     const deeplyNested = d.arrayOf(d.arrayOf(d.arrayOf(d.u32, 2), 2), 2);
 
-    const writer = getCompiledWriterForSchema(deeplyNested)!;
+    const writer = getCompiledWriter(deeplyNested)!;
 
     const arr = new ArrayBuffer(sizeOf(deeplyNested));
     const dataView = new DataView(arr);
@@ -531,7 +531,7 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const writer = getCompiledWriterForSchema(nestedArray)!;
+    const writer = getCompiledWriter(nestedArray)!;
 
     expect;
 
@@ -564,7 +564,7 @@ describe('createCompileInstructions', () => {
 
   it('should stop writing elements at the given endOffset', () => {
     const schema = d.arrayOf(d.vec3u, 4);
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
     const endLayout = d.memoryLayoutOf(schema, (a) => a[2]);
@@ -578,7 +578,7 @@ describe('createCompileInstructions', () => {
 
   it('should write a padded array chunk from the beginning offset through the end when endOffset is omitted', () => {
     const schema = d.arrayOf(d.vec3u, 4);
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
     const layout = d.memoryLayoutOf(schema, (a) => a[1]?.x);
@@ -597,7 +597,7 @@ describe('createCompileInstructions', () => {
 
   it('should write a scalar array chunk from the beginning offset through the end when endOffset is omitted', () => {
     const schema = d.arrayOf(d.u32, 6);
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
     const layout = d.memoryLayoutOf(schema, (a) => a[3]);
@@ -612,7 +612,7 @@ describe('createCompileInstructions', () => {
       transform: d.mat4x4f,
     });
 
-    const writer = getCompiledWriterForSchema(Schema)!;
+    const writer = getCompiledWriter(Schema)!;
 
     const arr = new ArrayBuffer(sizeOf(Schema));
     const dataView = new DataView(arr);
@@ -629,7 +629,7 @@ describe('createCompileInstructions', () => {
       transform: d.mat3x3f,
     });
 
-    const writer = getCompiledWriterForSchema(Schema)!;
+    const writer = getCompiledWriter(Schema)!;
 
     const arr = new ArrayBuffer(sizeOf(Schema));
     const dataView = new DataView(arr);
@@ -647,7 +647,7 @@ describe('createCompileInstructions', () => {
       transform: d.mat2x2f,
     });
 
-    const writer = getCompiledWriterForSchema(Schema)!;
+    const writer = getCompiledWriter(Schema)!;
 
     const arr = new ArrayBuffer(sizeOf(Schema));
     const dataView = new DataView(arr);
@@ -663,7 +663,7 @@ describe('createCompileInstructions', () => {
   it('should compile a writer for an array of u16', () => {
     const array = d.arrayOf(d.u16, 5);
 
-    const writer = getCompiledWriterForSchema(array)!;
+    const writer = getCompiledWriter(array)!;
 
     const arr = new ArrayBuffer(sizeOf(array));
     const dataView = new DataView(arr);
@@ -692,7 +692,7 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
 
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
@@ -721,7 +721,7 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
 
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
@@ -755,7 +755,7 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const writer = getCompiledWriterForSchema(unstruct)!;
+    const writer = getCompiledWriter(unstruct)!;
 
     const arr = new ArrayBuffer(sizeOf(unstruct));
     const dataView = new DataView(arr);
@@ -785,7 +785,7 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const writer = getCompiledWriterForSchema(disarray)!;
+    const writer = getCompiledWriter(disarray)!;
 
     const arr = new ArrayBuffer(sizeOf(disarray));
     const dataView = new DataView(arr);
@@ -848,7 +848,7 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const writer = getCompiledWriterForSchema(disarray)!;
+    const writer = getCompiledWriter(disarray)!;
 
     const arr = new ArrayBuffer(sizeOf(disarray));
     const dataView = new DataView(arr);
@@ -884,7 +884,7 @@ describe('createCompileInstructions', () => {
       output.setUint8(((offset + 10) + 3), Math.round(value.d.w * 255), littleEndian);
       "
     `);
-    const writer = getCompiledWriterForSchema(unstruct)!;
+    const writer = getCompiledWriter(unstruct)!;
 
     const arr = new ArrayBuffer(sizeOf(unstruct));
     const dataView = new DataView(arr);
@@ -932,7 +932,7 @@ describe('createCompileInstructions', () => {
 
   it('should write a vec3f from a plain tuple', () => {
     const schema = d.vec3f;
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(16);
     const dataView = new DataView(arr);
 
@@ -943,7 +943,7 @@ describe('createCompileInstructions', () => {
 
   it('should write a vec3f from a Float32Array', () => {
     const schema = d.vec3f;
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(16);
     const dataView = new DataView(arr);
 
@@ -954,7 +954,7 @@ describe('createCompileInstructions', () => {
 
   it('should write a mat3x3f from a packed number[]', () => {
     const schema = d.mat3x3f;
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
 
@@ -966,7 +966,7 @@ describe('createCompileInstructions', () => {
 
   it('should write a mat3x3f from a padded Float32Array', () => {
     const schema = d.mat3x3f;
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
 
@@ -978,7 +978,7 @@ describe('createCompileInstructions', () => {
 
   it('should write a mat4x4f from a Float32Array', () => {
     const schema = d.mat4x4f;
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
 
@@ -989,7 +989,7 @@ describe('createCompileInstructions', () => {
 
   it('should write an array of vec3f from plain tuples', () => {
     const schema = d.arrayOf(d.vec3f, 3);
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
 
@@ -1006,7 +1006,7 @@ describe('createCompileInstructions', () => {
 
   it('should write an array of vec3f from a padded Float32Array (raw bytes, 16-byte stride)', () => {
     const schema = d.arrayOf(d.vec3f, 3);
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
 
@@ -1019,7 +1019,7 @@ describe('createCompileInstructions', () => {
 
   it('should write an array of vec3f where each element is its own Float32Array', () => {
     const schema = d.arrayOf(d.vec3f, 3);
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
 
@@ -1040,7 +1040,7 @@ describe('createCompileInstructions', () => {
 
   it('should write a vec3h from a plain tuple with correct 2-byte component offsets', () => {
     const schema = d.vec3h;
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(8);
     const dataView = new DataView(arr);
 
@@ -1053,7 +1053,7 @@ describe('createCompileInstructions', () => {
 
   it('should write an arrayOf(vec3h) from plain tuples with stride-corrected 2-byte offsets', () => {
     const schema = d.arrayOf(d.vec3h, 2);
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
 
@@ -1072,7 +1072,7 @@ describe('createCompileInstructions', () => {
 
   it('should write an array of f32 scalars from a Float32Array', () => {
     const schema = d.arrayOf(d.f32, 4);
-    const writer = getCompiledWriterForSchema(schema)!;
+    const writer = getCompiledWriter(schema)!;
     const arr = new ArrayBuffer(sizeOf(schema));
     const dataView = new DataView(arr);
 
@@ -1119,7 +1119,7 @@ describe('createCompileInstructions', () => {
       "
     `);
 
-    const compiled = getCompiledWriterForSchema(disarray)!;
+    const compiled = getCompiledWriter(disarray)!;
 
     const arr = new ArrayBuffer(sizeOf(disarray));
     const dataView = new DataView(arr);
@@ -1207,7 +1207,7 @@ describe('createCompileInstructions', () => {
       padded: d.arrayOf(d.vec3f, 2),
     });
 
-    const writer = getCompiledWriterForSchema(outer)!;
+    const writer = getCompiledWriter(outer)!;
     const arr = new ArrayBuffer(sizeOf(outer));
     const dataView = new DataView(arr);
 

--- a/packages/typegpu/tests/partialIo.noEval.test.ts
+++ b/packages/typegpu/tests/partialIo.noEval.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for getPatchInstructions when the compiled writer is unavailable
+ * (CSP/eval-restricted environments). vi.mock is hoisted by vitest so this
+ * file's entire module graph sees getCompiledWriter returning undefined,
+ * forcing the typed-binary fallback path in partialIO.ts.
+ */
+import { describe, expect, vi } from 'vitest';
+import { it } from 'typegpu-testing-utility';
+import type { TypedArray } from '../src/shared/utilityTypes.ts';
+import type { WriteInstruction } from '../src/data/partialIO.ts';
+
+vi.mock('../src/data/compiledIO.ts', () => ({
+  EVAL_ALLOWED_IN_ENV: false,
+  getCompiledWriter: () => undefined,
+  buildWriter: () => '',
+}));
+
+// Dynamic imports are required AFTER vi.mock to get the mocked versions.
+const { getPatchInstructions } = await import('../src/data/partialIO.ts');
+const d = await import('../src/data/index.ts');
+
+function expectInstruction(
+  instruction: WriteInstruction,
+  {
+    start,
+    length,
+    expectedData,
+  }: {
+    start: number;
+    length: number;
+    expectedData: TypedArray | TypedArray[];
+  },
+): void {
+  expect(instruction.gpuOffset).toBe(start);
+  expect(instruction.data.byteLength).toBe(length);
+
+  const dataArrays = Array.isArray(expectedData) ? expectedData : [expectedData];
+  const totalByteLength = dataArrays.reduce((acc, arr) => acc + arr.byteLength, 0);
+  const mergedExpected = new Uint8Array(totalByteLength);
+  let offset = 0;
+  for (const arr of dataArrays) {
+    mergedExpected.set(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength), offset);
+    offset += arr.byteLength;
+  }
+
+  expect(instruction.data).toHaveLength(totalByteLength);
+  expect(new Uint8Array(instruction.data)).toStrictEqual(mergedExpected);
+}
+
+describe('getPatchInstructions (no-eval / typed-binary fallback)', () => {
+  it('should produce correct instructions for a scalar', () => {
+    const instructions = getPatchInstructions(d.u32, 3) as [WriteInstruction];
+    expect(instructions).toHaveLength(1);
+    expectInstruction(instructions[0], {
+      start: 0,
+      length: 4,
+      expectedData: new Uint32Array([3]),
+    });
+  });
+
+  it('should produce correct instructions for a struct', () => {
+    const struct = d.struct({
+      a: d.u32,
+      b: d.vec3f,
+      c: d.struct({ d: d.u32 }),
+    });
+
+    const instructions = getPatchInstructions(struct, {
+      a: 3,
+      b: d.vec3f(1, 2, 3),
+      c: { d: 4 },
+    }) as [WriteInstruction];
+
+    expect(instructions).toHaveLength(1);
+    expectInstruction(instructions[0], {
+      start: 0,
+      length: 32,
+      expectedData: [
+        new Uint32Array([3, 0, 0, 0]),
+        new Float32Array([1, 2, 3]),
+        new Uint32Array([4]),
+      ],
+    });
+  });
+
+  it('should handle sparse array updates', () => {
+    const struct = d.struct({
+      a: d.u32,
+      b: d.arrayOf(d.vec3f, 4),
+    });
+
+    const instructions = getPatchInstructions(struct, {
+      b: { 1: d.vec3f(4, 5, 6) },
+    }) as [WriteInstruction];
+
+    expect(instructions).toHaveLength(1);
+    expectInstruction(instructions[0], {
+      start: 32, // offset of b[1]: 16 (b start) + 1 * 16 (element stride)
+      length: 12,
+      expectedData: new Float32Array([4, 5, 6]),
+    });
+  });
+
+  it('should split instructions at non-contiguous gaps', () => {
+    const struct = d.struct({
+      a: d.u32,
+      b: d.vec3f,
+    });
+
+    // Only patch b, leaving a out — creates a gap after start
+    const instructions = getPatchInstructions(struct, { b: d.vec3f(1, 2, 3) }) as [
+      WriteInstruction,
+    ];
+
+    expect(instructions).toHaveLength(1);
+    expectInstruction(instructions[0], {
+      start: 16,
+      length: 12,
+      expectedData: new Float32Array([1, 2, 3]),
+    });
+  });
+});

--- a/packages/typegpu/tests/partialIo.noEval.test.ts
+++ b/packages/typegpu/tests/partialIo.noEval.test.ts
@@ -1,8 +1,5 @@
 /**
- * Tests for getPatchInstructions when the compiled writer is unavailable
- * (CSP/eval-restricted environments). vi.mock is hoisted by vitest so this
- * file's entire module graph sees getCompiledWriter returning undefined,
- * forcing the typed-binary fallback path in partialIO.ts.
+ * Tests for getPatchInstructions when the compiled writer is unavailable.
  */
 import { describe, expect, vi } from 'vitest';
 import { it } from 'typegpu-testing-utility';

--- a/packages/typegpu/tests/partialIo.noEval.test.ts
+++ b/packages/typegpu/tests/partialIo.noEval.test.ts
@@ -8,6 +8,8 @@ import { describe, expect, vi } from 'vitest';
 import { it } from 'typegpu-testing-utility';
 import type { TypedArray } from '../src/shared/utilityTypes.ts';
 import type { WriteInstruction } from '../src/data/partialIO.ts';
+import { getPatchInstructions } from '../src/data/partialIO.ts';
+import * as d from '../src/data/index.ts';
 
 vi.mock('../src/data/compiledIO.ts', () => ({
   EVAL_ALLOWED_IN_ENV: false,
@@ -15,12 +17,8 @@ vi.mock('../src/data/compiledIO.ts', () => ({
   buildWriter: () => '',
 }));
 
-// Dynamic imports are required AFTER vi.mock to get the mocked versions.
-const { getPatchInstructions } = await import('../src/data/partialIO.ts');
-const d = await import('../src/data/index.ts');
-
 function expectInstruction(
-  instruction: WriteInstruction,
+  instruction: WriteInstruction | undefined,
   {
     start,
     length,
@@ -31,6 +29,9 @@ function expectInstruction(
     expectedData: TypedArray | TypedArray[];
   },
 ): void {
+  if (!instruction) {
+    throw new Error('Instruction is undefined');
+  }
   expect(instruction.gpuOffset).toBe(start);
   expect(instruction.data.byteLength).toBe(length);
 
@@ -43,13 +44,12 @@ function expectInstruction(
     offset += arr.byteLength;
   }
 
-  expect(instruction.data).toHaveLength(totalByteLength);
   expect(new Uint8Array(instruction.data)).toStrictEqual(mergedExpected);
 }
 
 describe('getPatchInstructions (no-eval / typed-binary fallback)', () => {
   it('should produce correct instructions for a scalar', () => {
-    const instructions = getPatchInstructions(d.u32, 3) as [WriteInstruction];
+    const instructions = getPatchInstructions(d.u32, 3);
     expect(instructions).toHaveLength(1);
     expectInstruction(instructions[0], {
       start: 0,
@@ -69,7 +69,7 @@ describe('getPatchInstructions (no-eval / typed-binary fallback)', () => {
       a: 3,
       b: d.vec3f(1, 2, 3),
       c: { d: 4 },
-    }) as [WriteInstruction];
+    });
 
     expect(instructions).toHaveLength(1);
     expectInstruction(instructions[0], {
@@ -91,7 +91,7 @@ describe('getPatchInstructions (no-eval / typed-binary fallback)', () => {
 
     const instructions = getPatchInstructions(struct, {
       b: { 1: d.vec3f(4, 5, 6) },
-    }) as [WriteInstruction];
+    });
 
     expect(instructions).toHaveLength(1);
     expectInstruction(instructions[0], {
@@ -108,9 +108,7 @@ describe('getPatchInstructions (no-eval / typed-binary fallback)', () => {
     });
 
     // Only patch b, leaving a out — creates a gap after start
-    const instructions = getPatchInstructions(struct, { b: d.vec3f(1, 2, 3) }) as [
-      WriteInstruction,
-    ];
+    const instructions = getPatchInstructions(struct, { b: d.vec3f(1, 2, 3) });
 
     expect(instructions).toHaveLength(1);
     expectInstruction(instructions[0], {

--- a/packages/typegpu/tests/partialIo.test.ts
+++ b/packages/typegpu/tests/partialIo.test.ts
@@ -17,7 +17,7 @@ function expectInstruction(
     expectedData: TypedArray | TypedArray[];
   },
 ): void {
-  expect(instruction.data.byteOffset).toBe(start);
+  expect(instruction.gpuOffset).toBe(start);
   expect(instruction.data.byteLength).toBe(length);
 
   const dataArrays = Array.isArray(expectedData) ? expectedData : [expectedData];

--- a/packages/typegpu/tests/partialIo.test.ts
+++ b/packages/typegpu/tests/partialIo.test.ts
@@ -196,10 +196,10 @@ describe('getPatchInstructions', () => {
       a: 3,
       c: { d: 4 },
       b: {
-        0: d.vec3f(1, 2, 3),
         1: d.vec3f(4, 5, 6),
-        2: d.vec3f(7, 8, 9),
+        0: d.vec3f(1, 2, 3),
         3: d.vec3f(10, 11, 12),
+        2: d.vec3f(7, 8, 9),
       },
     };
 
@@ -229,8 +229,8 @@ describe('getPatchInstructions', () => {
 
     const data = {
       b: {
-        0: d.vec3f(1, 2, 3),
         2: d.vec3f(7, 8, 9),
+        0: d.vec3f(1, 2, 3),
         3: d.vec3f(10, 11, 12),
       },
       c: { d: 4 },

--- a/packages/typegpu/tests/partialIo.test.ts
+++ b/packages/typegpu/tests/partialIo.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect } from 'vitest';
 import * as d from '../src/data/index.ts';
 import { offsetsForProps } from '../src/data/offsets.ts';
-import { getWriteInstructions, type WriteInstruction } from '../src/data/partialIO.ts';
+import {
+  convertPartialToPatch,
+  getPatchInstructions,
+  type WriteInstruction,
+} from '../src/data/partialIO.ts';
 import type { TypedArray } from '../src/shared/utilityTypes.ts';
 import { it } from 'typegpu-testing-utility';
 
@@ -105,9 +109,45 @@ describe('offsetsForProps', () => {
   });
 });
 
-describe('getWriteInstructions', () => {
-  it('should return correct write instructions for simple data', () => {
-    const instructions = getWriteInstructions(d.u32, 3) as [WriteInstruction];
+describe('convertPartialToPatch', () => {
+  it('should convert sparse {idx, value}[] to Record<number, T>', () => {
+    const schema = d.arrayOf(d.vec3f, 4);
+    const partial = [
+      { idx: 1, value: d.vec3f(1, 2, 3) },
+      { idx: 3, value: d.vec3f(4, 5, 6) },
+    ];
+
+    const result = convertPartialToPatch(schema, partial) as Record<number, unknown>;
+    expect(result[1]).toEqual(d.vec3f(1, 2, 3));
+    expect(result[3]).toEqual(d.vec3f(4, 5, 6));
+    expect(Object.keys(result)).toHaveLength(2);
+  });
+
+  it('should recurse into struct fields', () => {
+    const schema = d.struct({
+      a: d.u32,
+      b: d.arrayOf(d.f32, 3),
+    });
+    const partial = {
+      b: [
+        { idx: 0, value: 1.0 },
+        { idx: 2, value: 3.0 },
+      ],
+    };
+
+    const result = convertPartialToPatch(schema, partial) as Record<string, unknown>;
+    expect(result.b).toEqual({ 0: 1.0, 2: 3.0 });
+  });
+
+  it('should pass through leaves unchanged', () => {
+    expect(convertPartialToPatch(d.u32, 42)).toBe(42);
+    expect(convertPartialToPatch(d.f32, undefined)).toBeUndefined();
+  });
+});
+
+describe('getPatchInstructions', () => {
+  it('should return correct instructions for simple data', () => {
+    const instructions = getPatchInstructions(d.u32, 3) as [WriteInstruction];
 
     expect(instructions).toHaveLength(1);
 
@@ -118,7 +158,7 @@ describe('getWriteInstructions', () => {
     });
   });
 
-  it('should return correct write instructions for props', () => {
+  it('should return correct instructions for struct fields', () => {
     const struct = d.struct({
       a: d.u32,
       b: d.vec3f,
@@ -131,7 +171,7 @@ describe('getWriteInstructions', () => {
       c: { d: 4 },
     };
 
-    const instructions = getWriteInstructions(struct, data) as [WriteInstruction];
+    const instructions = getPatchInstructions(struct, data) as [WriteInstruction];
     expect(instructions).toHaveLength(1);
 
     expectInstruction(instructions[0], {
@@ -145,7 +185,7 @@ describe('getWriteInstructions', () => {
     });
   });
 
-  it('should return correct write instructions for props with arrays', () => {
+  it('should handle sparse array updates via Record<number, T>', () => {
     const struct = d.struct({
       a: d.u32,
       b: d.arrayOf(d.vec3f, 4),
@@ -155,15 +195,15 @@ describe('getWriteInstructions', () => {
     const data = {
       a: 3,
       c: { d: 4 },
-      b: [
-        { idx: 1, value: d.vec3f(4, 5, 6) },
-        { idx: 0, value: d.vec3f(1, 2, 3) },
-        { idx: 3, value: d.vec3f(10, 11, 12) },
-        { idx: 2, value: d.vec3f(7, 8, 9) },
-      ],
+      b: {
+        0: d.vec3f(1, 2, 3),
+        1: d.vec3f(4, 5, 6),
+        2: d.vec3f(7, 8, 9),
+        3: d.vec3f(10, 11, 12),
+      },
     };
 
-    const instructions = getWriteInstructions(struct, data) as [WriteInstruction];
+    const instructions = getPatchInstructions(struct, data) as [WriteInstruction];
     expect(instructions).toHaveLength(1);
 
     expectInstruction(instructions[0], {
@@ -180,7 +220,7 @@ describe('getWriteInstructions', () => {
     });
   });
 
-  it('should return correct write instructions for props with arrays and missing data', () => {
+  it('should split instructions when there is a gap', () => {
     const struct = d.struct({
       a: d.u32,
       b: d.arrayOf(d.vec3f, 4),
@@ -188,15 +228,15 @@ describe('getWriteInstructions', () => {
     });
 
     const data = {
-      b: [
-        { idx: 2, value: d.vec3f(7, 8, 9) },
-        { idx: 0, value: d.vec3f(1, 2, 3) },
-        { idx: 3, value: d.vec3f(10, 11, 12) },
-      ],
+      b: {
+        0: d.vec3f(1, 2, 3),
+        2: d.vec3f(7, 8, 9),
+        3: d.vec3f(10, 11, 12),
+      },
       c: { d: 4 },
     };
 
-    const instructions = getWriteInstructions(struct, data) as [WriteInstruction, WriteInstruction];
+    const instructions = getPatchInstructions(struct, data) as [WriteInstruction, WriteInstruction];
     expect(instructions).toHaveLength(2);
 
     expectInstruction(instructions[0], {
@@ -216,7 +256,7 @@ describe('getWriteInstructions', () => {
     });
   });
 
-  it('should return correct write instructions for arrays of structs', () => {
+  it('should handle arrays of structs with partial updates', () => {
     const Boid = d.struct({
       position: d.vec3f,
       velocity: d.vec3f,
@@ -226,15 +266,8 @@ describe('getWriteInstructions', () => {
       boids: d.arrayOf(Boid, 3),
     });
 
-    const data = [
-      {
-        idx: 1,
-        value: { position: d.vec3f(1, 2, 3) },
-      },
-    ];
-
-    const instructions = getWriteInstructions(struct, {
-      boids: data,
+    const instructions = getPatchInstructions(struct, {
+      boids: { 1: { position: d.vec3f(1, 2, 3) } },
     }) as [WriteInstruction];
 
     expect(instructions).toHaveLength(1);
@@ -246,26 +279,46 @@ describe('getWriteInstructions', () => {
     });
   });
 
-  it('should not accept invalid data', () => {
-    const struct = d.struct({
-      a: d.u32,
-      b: d.vec3f,
-      c: d.struct({ d: d.u32 }),
-    });
+  it('should handle dense array replacement', () => {
+    const array = d.arrayOf(d.u32, 3);
 
-    // @ts-expect-error
-    getWriteInstructions(struct, { a: 3, b: 4, c: 5 });
+    const instructions = getPatchInstructions(array, [100, 200, 300]) as [WriteInstruction];
+
+    expect(instructions).toHaveLength(1);
+
+    expectInstruction(instructions[0], {
+      start: 0,
+      length: 12,
+      expectedData: new Uint32Array([100, 200, 300]),
+    });
   });
 
-  it('should not merge instructions if there is a gap', () => {
+  it('should not false-positive on struct elements with idx/value fields', () => {
+    const WeirdSchema = d.struct({ idx: d.u32, value: d.f32 });
+    const array = d.arrayOf(WeirdSchema, 4);
+
+    const instructions = getPatchInstructions(array, {
+      1: { idx: 42, value: 3.14 },
+    }) as [WriteInstruction];
+
+    expect(instructions).toHaveLength(1);
+
+    expectInstruction(instructions[0], {
+      start: 8,
+      length: 8,
+      expectedData: [new Uint32Array([42]), new Float32Array([3.14])],
+    });
+  });
+
+  it('should not merge instructions for non-contiguous sparse elements', () => {
     const array = d.arrayOf(d.vec3f, 1024);
 
-    const data = Array.from({ length: 1024 })
-      .map((_, i) => i)
-      .filter((i) => i % 2 === 0)
-      .map((i) => ({ idx: i, value: d.vec3f(1, 2, 3) }));
+    const data: Record<number, unknown> = {};
+    for (let i = 0; i < 1024; i += 2) {
+      data[i] = d.vec3f(1, 2, 3);
+    }
 
-    const instructions = getWriteInstructions(array, data);
+    const instructions = getPatchInstructions(array, data);
 
     expect(instructions).toHaveLength(512);
 
@@ -279,5 +332,17 @@ describe('getWriteInstructions', () => {
         expectedData: new Float32Array([1, 2, 3]),
       });
     }
+  });
+
+  it('should handle invalid data gracefully', () => {
+    const struct = d.struct({
+      a: d.u32,
+      b: d.vec3f,
+      c: d.struct({ d: d.u32 }),
+    });
+
+    // getPatchInstructions accepts unknown, so invalid shapes just produce leaf writes
+    const instructions = getPatchInstructions(struct, { a: 3, b: 4, c: 5 });
+    expect(instructions.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
This PR:
- deprecates the `partialWrite` in favor of the new `patch` API with extended capabilities 
- simplifies internal helpers (made them non-generic since we don't really need that)
- fixed redundant per write allocation (since buffers have their own internal array buffers)

The main API differences are:
- now `patch` has similar permissiveness as the new `write` API (accepts tuples and typed arrays)
- ***finally***  can pass a full array without gymnastics
- for partial array writes we now use a record with number fields (makes it so much easier to recognize and IMO cleaner to use)

We could now move the entire `patch` API to use compiled writers everywhere (due to compiled writers handling start/end offsets) but I want to get this into the 0.11 release so for now let's say out of scope - I left most internals untouched. Now we use them for leaf values (since they handle padding better) - this is to be discussed since this means creating a writer per primitive data type

Here are benchmark results (for what they're worth):
<img width="1324" height="800" alt="image" src="https://github.com/user-attachments/assets/18f555ee-b59d-4a12-83e2-70a708e23e76" />

Important to mention that they use the old API so we are paying conversion costs for each call