### PR TITLE
feat(@typepgu/gl): Generate GLSL function signature

### DIFF
--- a/packages/typegpu-gl/src/glOptions.ts
+++ b/packages/typegpu-gl/src/glOptions.ts
@@ -1,0 +1,7 @@
+import glslGenerator from './glslGenerator.ts';
+
+export function GLOptions() {
+  return {
+    unstable_shaderGenerator: glslGenerator,
+  };
+}

--- a/packages/typegpu-gl/src/glOptions.ts
+++ b/packages/typegpu-gl/src/glOptions.ts
@@ -1,0 +1,7 @@
+import glslGenerator from './glslGenerator.ts';
+
+export function glOptions() {
+  return {
+    unstable_shaderGenerator: glslGenerator,
+  };
+}

--- a/packages/typegpu-gl/src/glslGenerator.ts
+++ b/packages/typegpu-gl/src/glslGenerator.ts
@@ -1,10 +1,17 @@
-import { d, ShaderGenerator, WgslGenerator } from 'typegpu';
+import { NodeTypeCatalog as NODE } from 'tinyest';
+import type { Return } from 'tinyest';
+import tgpu, { d, ShaderGenerator, WgslGenerator } from 'typegpu';
+
+type ResolutionCtx = ShaderGenerator.ResolutionCtx;
+
+const UnknownData: typeof ShaderGenerator.UnknownData = ShaderGenerator.UnknownData;
 
 // ----------
 // WGSL → GLSL type name mapping
 // ----------
 
 const WGSL_TO_GLSL_TYPE: Record<string, string> = {
+  void: 'void',
   f32: 'float',
   u32: 'uint',
   i32: 'int',
@@ -38,12 +45,42 @@ export function translateWgslTypeToGlsl(wgslType: string): string {
 }
 
 /**
+ * Resolves a struct and adds its declaration to the resolution context.
+ * @param ctx - The resolution context.
+ * @param struct - The struct to resolve.
+ *
+ * @returns The resolved struct name.
+ */
+function resolveStruct(ctx: ResolutionCtx, struct: d.WgslStruct) {
+  const id = ctx.makeUniqueIdentifier(ShaderGenerator.getName(struct), 'global');
+
+  ctx.addDeclaration(`\
+struct ${id} {
+${Object.entries(struct.propTypes)
+  .map(([prop, type]) => `  ${ctx.resolve(type).value} ${prop};\n`)
+  .join('')}\
+};`);
+
+  return id;
+}
+
+const gl_PositionSnippet = tgpu['~unstable'].rawCodeSnippet('gl_Position', d.vec4f, 'private');
+
+interface EntryFnState {
+  structPropToVarMap: Record<string, string>;
+  outVars: { varName: string; propName: string }[];
+}
+
+/**
  * A GLSL ES 3.0 shader generator that extends WgslGenerator.
  * Overrides `dataType` to emit GLSL type names instead of WGSL ones,
  * and overrides variable declaration emission to use `type name = rhs` syntax.
  */
 export class GlslGenerator extends WgslGenerator {
-  public override typeAnnotation(data: d.BaseData): string {
+  #functionType: ShaderGenerator.TgpuShaderStage | 'normal' | undefined;
+  #entryFnState: EntryFnState | undefined;
+
+  override typeAnnotation(data: d.BaseData): string {
     // For WGSL identity types (scalars, vectors, common matrices), map to GLSL directly.
     if (!d.isLooseData(data)) {
       const glslName = WGSL_TO_GLSL_TYPE[data.type];
@@ -52,20 +89,153 @@ export class GlslGenerator extends WgslGenerator {
       }
     }
 
+    if (d.isWgslStruct(data)) {
+      return resolveStruct(this.ctx, data);
+    }
+
     // For all other types (structs, arrays, etc.) delegate to WGSL resolution.
     return super.typeAnnotation(data);
   }
 
-  protected override emitVarDecl(
-    pre: string,
+  override _emitVarDecl(
     _keyword: 'var' | 'let' | 'const',
     name: string,
     dataType: d.BaseData | ShaderGenerator.UnknownData,
     rhsStr: string,
   ): string {
-    const glslTypeName =
-      dataType !== ShaderGenerator.UnknownData ? this.typeAnnotation(dataType) : 'auto';
-    return `${pre}${glslTypeName} ${name} = ${rhsStr};`;
+    const glslTypeName = dataType !== UnknownData ? this.ctx.resolve(dataType).value : 'auto';
+    return `${this.ctx.pre}${glslTypeName} ${name} = ${rhsStr};`;
+  }
+
+  override _return(statement: Return): string {
+    const exprNode = statement[1];
+
+    if (exprNode === undefined) {
+      // Default behavior
+      return super._return(statement);
+    }
+
+    if (this.#functionType !== 'normal') {
+      // oxlint-disable-next-line no-non-null-assertion
+      const entryFnState = this.#entryFnState!;
+      const expectedReturnType = this.ctx.topFunctionReturnType;
+
+      if (typeof exprNode === 'object' && exprNode[0] === NODE.objectExpr) {
+        const transformed = Object.entries(exprNode[1]).map(([prop, rhsNode]) => {
+          let name: string | undefined = entryFnState.structPropToVarMap[prop];
+          if (name === undefined) {
+            if (
+              prop === '$position' ||
+              (expectedReturnType &&
+                d.isWgslStruct(expectedReturnType) &&
+                expectedReturnType.propTypes[prop] === d.builtin.position)
+            ) {
+              name = 'gl_Position';
+            } else {
+              name = this.ctx.makeUniqueIdentifier(prop, 'global');
+              entryFnState.outVars.push({ varName: name, propName: prop });
+            }
+            entryFnState.structPropToVarMap[prop] = name;
+          }
+          const rhsExpr = this._expression(rhsNode);
+          const type = rhsExpr.dataType as d.BaseData;
+
+          const snippet = tgpu['~unstable'].rawCodeSnippet(name, type as d.AnyData, 'private');
+
+          return {
+            name,
+            snippet,
+            assignment: [NODE.assignmentExpr, name, '=', rhsNode],
+          } as const;
+        });
+
+        const block = super._block(
+          [NODE.block, [...transformed.map((t) => t.assignment), [NODE.return]]],
+          Object.fromEntries(
+            transformed.map(({ name, snippet }) => {
+              return [name, snippet.$] as const;
+            }),
+          ),
+        );
+
+        return `${this.ctx.pre}${block}`;
+      } else {
+        // Resolving the expression to inspect it's type
+        // We will resolve it again as part of the modifed statement
+        const expr = expectedReturnType
+          ? this._typedExpression(exprNode, expectedReturnType)
+          : this._expression(exprNode);
+
+        if (expr.dataType === UnknownData) {
+          // Unknown data type, don't know what to do
+          return super._return(statement);
+        }
+
+        if (expr.dataType.type.startsWith('vec')) {
+          const block = super._block(
+            [NODE.block, [[NODE.assignmentExpr, 'gl_Position', '=', exprNode], [NODE.return]]],
+            { gl_Position: gl_PositionSnippet.$ },
+          );
+
+          return `${this.ctx.pre}${block}`;
+        }
+      }
+    }
+
+    return super._return(statement);
+  }
+
+  override functionDefinition(options: ShaderGenerator.FunctionDefinitionOptions): string {
+    if (options.functionType !== 'normal') {
+      this.ctx.reserveIdentifier('gl_Position', 'global');
+    }
+
+    // Function body
+    let lastFunctionType = this.#functionType;
+    this.#functionType = options.functionType;
+    if (options.functionType !== 'normal') {
+      if (this.#entryFnState) {
+        throw new Error('Cannot nest entry functions');
+      }
+      this.#entryFnState = { structPropToVarMap: {}, outVars: [] };
+    }
+
+    try {
+      const body = this._block(options.body);
+
+      // Only after generating the body can we determine the return type
+      const returnType = options.determineReturnType();
+
+      if (options.functionType !== 'normal') {
+        // oxlint-disable-next-line no-non-null-assertion
+        const entryFnState = this.#entryFnState!;
+        if (d.isWgslStruct(returnType)) {
+          for (const { varName, propName } of entryFnState.outVars) {
+            const dataType = returnType.propTypes[propName];
+            if (dataType && d.isDecorated(dataType)) {
+              const location = (dataType.attribs as d.AnyAttribute[]).find(
+                (a) => a.type === '@location',
+              )?.params[0];
+              this.ctx.addDeclaration(`layout(location = ${location}) out ${varName};`);
+            }
+          }
+        }
+        return `void main() ${body}`;
+      }
+
+      const argList = options.args
+        // Stripping out unused arguments in entry functions
+        .filter((arg) => arg.used || options.functionType === 'normal')
+        .map((arg) => {
+          return `${this.ctx.resolve(arg.decoratedType).value} ${arg.name}`;
+        })
+        .join(', ');
+
+      return `${this.ctx.resolve(returnType).value} ${options.name}(${argList}) ${body}`;
+    } finally {
+      this.#functionType = lastFunctionType;
+      this.#entryFnState = undefined;
+    }
   }
 }
 

--- a/packages/typegpu-gl/src/glslGenerator.ts
+++ b/packages/typegpu-gl/src/glslGenerator.ts
@@ -1,10 +1,17 @@
-import { d, ShaderGenerator, WgslGenerator } from 'typegpu';
+import { NodeTypeCatalog as NODE } from 'tinyest';
+import type { Return } from 'tinyest';
+import tgpu, { d, ShaderGenerator, WgslGenerator } from 'typegpu';
+
+type ResolutionCtx = ShaderGenerator.ResolutionCtx;
+
+const UnknownData: typeof ShaderGenerator.UnknownData = ShaderGenerator.UnknownData;
 
 // ----------
 // WGSL → GLSL type name mapping
 // ----------
 
 const WGSL_TO_GLSL_TYPE: Record<string, string> = {
+  void: 'void',
   f32: 'float',
   u32: 'uint',
   i32: 'int',
@@ -38,12 +45,42 @@ export function translateWgslTypeToGlsl(wgslType: string): string {
 }
 
 /**
+ * Resolves a struct and adds its declaration to the resolution context.
+ * @param ctx - The resolution context.
+ * @param struct - The struct to resolve.
+ *
+ * @returns The resolved struct name.
+ */
+function resolveStruct(ctx: ResolutionCtx, struct: d.WgslStruct) {
+  const id = ctx.makeUniqueIdentifier(ShaderGenerator.getName(struct), 'global');
+
+  ctx.addDeclaration(`\
+struct ${id} {
+${Object.entries(struct.propTypes)
+  .map(([prop, type]) => `  ${ctx.resolve(type).value} ${prop};\n`)
+  .join('')}\
+};`);
+
+  return id;
+}
+
+const gl_PositionSnippet = tgpu['~unstable'].rawCodeSnippet('gl_Position', d.vec4f, 'private');
+
+interface EntryFnState {
+  structPropToVarMap: Record<string, string>;
+  outVars: { varName: string; propName: string }[];
+}
+
+/**
  * A GLSL ES 3.0 shader generator that extends WgslGenerator.
  * Overrides `dataType` to emit GLSL type names instead of WGSL ones,
  * and overrides variable declaration emission to use `type name = rhs` syntax.
  */
 export class GlslGenerator extends WgslGenerator {
-  public override typeAnnotation(data: d.BaseData): string {
+  #functionType: ShaderGenerator.TgpuShaderStage | 'normal' | undefined;
+  #entryFnState: EntryFnState | undefined;
+
+  override typeAnnotation(data: d.BaseData): string {
     // For WGSL identity types (scalars, vectors, common matrices), map to GLSL directly.
     if (!d.isLooseData(data)) {
       const glslName = WGSL_TO_GLSL_TYPE[data.type];
@@ -52,20 +89,153 @@ export class GlslGenerator extends WgslGenerator {
       }
     }
 
+    if (d.isWgslStruct(data)) {
+      return resolveStruct(this.ctx, data);
+    }
+
     // For all other types (structs, arrays, etc.) delegate to WGSL resolution.
     return super.typeAnnotation(data);
   }
 
-  protected override emitVarDecl(
-    pre: string,
+  override _emitVarDecl(
     _keyword: 'var' | 'let' | 'const',
     name: string,
     dataType: d.BaseData | ShaderGenerator.UnknownData,
     rhsStr: string,
   ): string {
-    const glslTypeName =
-      dataType !== ShaderGenerator.UnknownData ? this.typeAnnotation(dataType) : 'auto';
-    return `${pre}${glslTypeName} ${name} = ${rhsStr};`;
+    const glslTypeName = dataType !== UnknownData ? this.ctx.resolve(dataType).value : 'auto';
+    return `${this.ctx.pre}${glslTypeName} ${name} = ${rhsStr};`;
+  }
+
+  override _returnStatement(statement: Return): string {
+    const exprNode = statement[1];
+
+    if (exprNode === undefined) {
+      // Default behavior
+      return super._returnStatement(statement);
+    }
+
+    if (this.#functionType !== 'normal') {
+      // oxlint-disable-next-line no-non-null-assertion
+      const entryFnState = this.#entryFnState!;
+      const expectedReturnType = this.ctx.topFunctionReturnType;
+
+      if (typeof exprNode === 'object' && exprNode[0] === NODE.objectExpr) {
+        const transformed = Object.entries(exprNode[1]).map(([prop, rhsNode]) => {
+          let name: string | undefined = entryFnState.structPropToVarMap[prop];
+          if (name === undefined) {
+            if (
+              prop === '$position' ||
+              (expectedReturnType &&
+                d.isWgslStruct(expectedReturnType) &&
+                expectedReturnType.propTypes[prop] === d.builtin.position)
+            ) {
+              name = 'gl_Position';
+            } else {
+              name = this.ctx.makeUniqueIdentifier(prop, 'global');
+              entryFnState.outVars.push({ varName: name, propName: prop });
+            }
+            entryFnState.structPropToVarMap[prop] = name;
+          }
+          const rhsExpr = this._expression(rhsNode);
+          const type = rhsExpr.dataType as d.BaseData;
+
+          const snippet = tgpu['~unstable'].rawCodeSnippet(name, type as d.AnyData, 'private');
+
+          return {
+            name,
+            snippet,
+            assignment: [NODE.assignmentExpr, name, '=', rhsNode],
+          } as const;
+        });
+
+        const block = super._block(
+          [NODE.block, [...transformed.map((t) => t.assignment), [NODE.return]]],
+          Object.fromEntries(
+            transformed.map(({ name, snippet }) => {
+              return [name, snippet.$] as const;
+            }),
+          ),
+        );
+
+        return `${this.ctx.pre}${block}`;
+      } else {
+        // Resolving the expression to inspect it's type
+        // We will resolve it again as part of the modifed statement
+        const expr = expectedReturnType
+          ? this._typedExpression(exprNode, expectedReturnType)
+          : this._expression(exprNode);
+
+        if (expr.dataType === UnknownData) {
+          // Unknown data type, don't know what to do
+          return super._returnStatement(statement);
+        }
+
+        if (expr.dataType.type.startsWith('vec')) {
+          const block = super._block(
+            [NODE.block, [[NODE.assignmentExpr, 'gl_Position', '=', exprNode], [NODE.return]]],
+            { gl_Position: gl_PositionSnippet.$ },
+          );
+
+          return `${this.ctx.pre}${block}`;
+        }
+      }
+    }
+
+    return super._returnStatement(statement);
+  }
+
+  override functionDefinition(options: ShaderGenerator.FunctionDefinitionOptions): string {
+    if (options.functionType !== 'normal') {
+      this.ctx.reserveIdentifier('gl_Position', 'global');
+    }
+
+    // Function body
+    let lastFunctionType = this.#functionType;
+    this.#functionType = options.functionType;
+    if (options.functionType !== 'normal') {
+      if (this.#entryFnState) {
+        throw new Error('Cannot nest entry functions');
+      }
+      this.#entryFnState = { structPropToVarMap: {}, outVars: [] };
+    }
+
+    try {
+      const body = this._block(options.body);
+
+      // Only after generating the body can we determine the return type
+      const returnType = options.determineReturnType();
+
+      if (options.functionType !== 'normal') {
+        // oxlint-disable-next-line no-non-null-assertion
+        const entryFnState = this.#entryFnState!;
+        if (d.isWgslStruct(returnType)) {
+          for (const { varName, propName } of entryFnState.outVars) {
+            const dataType = returnType.propTypes[propName];
+            if (dataType && d.isDecorated(dataType)) {
+              const location = (dataType.attribs as d.AnyAttribute[]).find(
+                (a) => a.type === '@location',
+              )?.params[0];
+              this.ctx.addDeclaration(`layout(location = ${location}) out ${varName};`);
+            }
+          }
+        }
+        return `void main() ${body}`;
+      }
+
+      const argList = options.args
+        // Stripping out unused arguments in entry functions
+        .filter((arg) => arg.used || options.functionType === 'normal')
+        .map((arg) => {
+          return `${this.ctx.resolve(arg.decoratedType).value} ${arg.name}`;
+        })
+        .join(', ');
+
+      return `${this.ctx.resolve(returnType).value} ${options.name}(${argList}) ${body}`;
+    } finally {
+      this.#functionType = lastFunctionType;
+      this.#entryFnState = undefined;
+    }
   }
 }
 

--- a/packages/typegpu-gl/src/index.ts
+++ b/packages/typegpu-gl/src/index.ts
@@ -1,2 +1,3 @@
 export { initWithGL } from './initWithGL.ts';
 export { initWithGLFallback } from './initWithGLFallback.ts';
+export { glOptions } from './glOptions.ts';

--- a/packages/typegpu-gl/src/index.ts
+++ b/packages/typegpu-gl/src/index.ts
@@ -1,2 +1,3 @@
 export { initWithGL } from './initWithGL.ts';
 export { initWithGLFallback } from './initWithGLFallback.ts';
+export { GLOptions } from './glOptions.ts';

--- a/packages/typegpu-gl/tests/glslGenerator.test.ts
+++ b/packages/typegpu-gl/tests/glslGenerator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import tgpu, { d } from 'typegpu';
-import glslGenerator, { translateWgslTypeToGlsl } from '../src/glslGenerator.ts';
+import { GLOptions } from '@typegpu/gl';
+import { translateWgslTypeToGlsl } from '../src/glslGenerator.ts';
 
 describe('translateWgslTypeToGlsl', () => {
   it('translates scalar types', () => {
@@ -48,18 +49,14 @@ describe('translateWgslTypeToGlsl', () => {
 
 describe('GlslGenerator - variable declarations', () => {
   it('generates GLSL-style variable declarations for JS function', () => {
-    // 'use gpu' function - uses the TGSL code generation path, which calls functionDefinition
-    const fragFn = tgpu.fragmentFn({
-      in: { uv: d.vec2f },
-      out: d.vec4f,
-    })((input) => {
+    const main = () => {
       'use gpu';
       // A variable that uses a vector type
-      const color = d.vec4f(input.uv[0], input.uv[1], 0, 1);
+      const color = d.vec4f(1, 0, 0, 1);
       return color;
-    });
+    };
 
-    const result = tgpu.resolveWithContext([fragFn], { unstable_shaderGenerator: glslGenerator });
+    const result = tgpu.resolveWithContext([main], GLOptions());
     // Should contain the resolved function code
     expect(result.code).toBeDefined();
     expect(result.code.length).toBeGreaterThan(0);
@@ -78,28 +75,36 @@ describe('GlslGenerator - variable declarations', () => {
       return d.vec4f(x, 0, 0, 1);
     });
 
-    const result = tgpu.resolveWithContext([fragFn], { unstable_shaderGenerator: glslGenerator });
+    const result = tgpu.resolveWithContext([fragFn], GLOptions());
     expect(result.code).toBeDefined();
     // Variable declaration for f32 should be `float`
     expect(result.code).toContain('float ');
   });
 });
 
-describe('GlslGenerator - functionDefinition post-processing', () => {
-  it('translates WGSL type constructor calls in JS function body to GLSL', () => {
-    const fragFn = tgpu.fragmentFn({
-      in: { uv: d.vec2f },
-      out: d.vec4f,
-    })((input) => {
+describe('GlslGenerator - function definitions', () => {
+  it('generates proper function signatures', () => {
+    function add(a: number, b: number) {
       'use gpu';
-      return d.vec4f(input.uv[0], 0.0, 0.0, 1.0);
-    });
+      return a + b;
+    }
 
-    const result = tgpu.resolveWithContext([fragFn], { unstable_shaderGenerator: glslGenerator });
-    // vec4f(...) in the body should become vec4(...)
-    expect(result.code).toContain('vec4(');
-    // Should not contain the WGSL-style constructor in the body
-    expect(result.code).not.toMatch(/\bvec4f\s*\(/);
+    function main() {
+      'use gpu';
+      return add(1.5, 1.2);
+    }
+
+    const result = tgpu.resolveWithContext([main], GLOptions());
+
+    expect(result.code).toMatchInlineSnapshot(`
+      "float add(float a, float b) {
+        return (a + b);
+      }
+
+      float main() {
+        return add(1.5f, 1.2f);
+      }"
+    `);
   });
 
   it('translates vec3f to vec3 in function body', () => {
@@ -111,10 +116,43 @@ describe('GlslGenerator - functionDefinition post-processing', () => {
       return d.vec4f(color[0], color[1], color[2], 1.0);
     });
 
-    const result = tgpu.resolveWithContext([fragFn], { unstable_shaderGenerator: glslGenerator });
+    const result = tgpu.resolveWithContext([fragFn], GLOptions());
     expect(result.code).toContain('vec3(');
     expect(result.code).not.toMatch(/\bvec3f\s*\(/);
     expect(result.code).toContain('vec4(');
+  });
+
+  it('generates proper struct definition', () => {
+    const Boid = d.struct({
+      pos: d.vec3f,
+      vel: d.vec3f,
+    });
+
+    function createBoid() {
+      'use gpu';
+      return Boid({ pos: d.vec3f(), vel: d.vec3f(0, 1, 0) });
+    }
+
+    function main() {
+      'use gpu';
+      const boid = createBoid();
+    }
+
+    const result = tgpu.resolve([main], GLOptions());
+    expect(result).toMatchInlineSnapshot(`
+      "struct Boid {
+        vec3 pos;
+        vec3 vel;
+      };
+
+      Boid createBoid() {
+        return Boid(vec3(), vec3(0, 1, 0));
+      }
+
+      void main() {
+        Boid boid = createBoid();
+      }"
+    `);
   });
 });
 
@@ -127,7 +165,7 @@ describe('GlslGenerator - entry point generation with JS functions', () => {
       return Out({ pos: d.vec4f(0.0, 0.0, 0.0, 1.0) });
     });
 
-    const result = tgpu.resolveWithContext([vertFn], { unstable_shaderGenerator: glslGenerator });
+    const result = tgpu.resolveWithContext([vertFn], GLOptions());
     expect(result.code).toBeDefined();
     expect(result.code.length).toBeGreaterThan(0);
     // The body should have translated type names
@@ -136,11 +174,47 @@ describe('GlslGenerator - entry point generation with JS functions', () => {
 
     expect(result.code).toMatchInlineSnapshot(`
       "struct vertFn_Output {
-        @builtin(position) pos: vec4,
-      }
+        vec4 pos;
+      };
 
-      @vertex fn vertFn() -> vertFn_Output {
+      void main() {
         return vertFn_Output(vec4(0, 0, 0, 1));
+      }"
+    `);
+  });
+
+  it('resolves a vertex function returning a builtin and varying', () => {
+    const vertFn = tgpu.vertexFn({
+      out: {
+        position: d.builtin.position,
+        uv: d.vec2f,
+      },
+    })(() => {
+      'use gpu';
+      const position = d.vec4f();
+      const uv = d.vec2f();
+
+      // NOTE: Don't wrap when assigning variables
+      // is valid and allowed at most once
+      return {
+        position: d.vec4f(position),
+        uv: d.vec2f(uv),
+      };
+    });
+
+    const result = tgpu.resolve([vertFn], GLOptions());
+
+    expect(result).toMatchInlineSnapshot(`
+      "layout(location = 0) out uv_1;
+
+      void main() {
+        vec4 position = vec4();
+        vec2 uv = vec2();
+        {
+          gl_Position = position;
+          uv_1 = uv;
+          return;
+        }
       }"
     `);
   });
@@ -150,18 +224,24 @@ describe('GlslGenerator - entry point generation with JS functions', () => {
       out: d.vec4f,
     })(() => {
       'use gpu';
+      // This variable should get renamed to not conflict with
+      // the global.
+      const gl_Position = 1;
       return d.vec4f(1.0, 0.0, 0.0, 1.0);
     });
 
-    const result = tgpu.resolveWithContext([fragFn], { unstable_shaderGenerator: glslGenerator });
+    const result = tgpu.resolveWithContext([fragFn], GLOptions());
     expect(result.code).toBeDefined();
-    // The body should have translated vec4f → vec4
     expect(result.code).toContain('vec4(');
     expect(result.code).not.toMatch(/\bvec4f\s*\(/);
 
     expect(result.code).toMatchInlineSnapshot(`
-      "@fragment fn fragFn() -> @location(0) vec4 {
-        return vec4(1, 0, 0, 1);
+      "void main() {
+        int gl_Position_1 = 1;
+        {
+          gl_Position = vec4(1, 0, 0, 1);
+          return;
+        }
       }"
     `);
   });

--- a/packages/typegpu-gl/tests/glslGenerator.test.ts
+++ b/packages/typegpu-gl/tests/glslGenerator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import tgpu, { d } from 'typegpu';
-import glslGenerator, { translateWgslTypeToGlsl } from '../src/glslGenerator.ts';
+import { glOptions } from '@typegpu/gl';
+import { translateWgslTypeToGlsl } from '../src/glslGenerator.ts';
 
 describe('translateWgslTypeToGlsl', () => {
   it('translates scalar types', () => {
@@ -48,18 +49,14 @@ describe('translateWgslTypeToGlsl', () => {
 
 describe('GlslGenerator - variable declarations', () => {
   it('generates GLSL-style variable declarations for JS function', () => {
-    // 'use gpu' function - uses the TGSL code generation path, which calls functionDefinition
-    const fragFn = tgpu.fragmentFn({
-      in: { uv: d.vec2f },
-      out: d.vec4f,
-    })((input) => {
+    const main = () => {
       'use gpu';
       // A variable that uses a vector type
-      const color = d.vec4f(input.uv[0], input.uv[1], 0, 1);
+      const color = d.vec4f(1, 0, 0, 1);
       return color;
-    });
+    };
 
-    const result = tgpu.resolveWithContext([fragFn], { unstable_shaderGenerator: glslGenerator });
+    const result = tgpu.resolveWithContext([main], glOptions());
     // Should contain the resolved function code
     expect(result.code).toBeDefined();
     expect(result.code.length).toBeGreaterThan(0);
@@ -78,28 +75,36 @@ describe('GlslGenerator - variable declarations', () => {
       return d.vec4f(x, 0, 0, 1);
     });
 
-    const result = tgpu.resolveWithContext([fragFn], { unstable_shaderGenerator: glslGenerator });
+    const result = tgpu.resolveWithContext([fragFn], glOptions());
     expect(result.code).toBeDefined();
     // Variable declaration for f32 should be `float`
     expect(result.code).toContain('float ');
   });
 });
 
-describe('GlslGenerator - functionDefinition post-processing', () => {
-  it('translates WGSL type constructor calls in JS function body to GLSL', () => {
-    const fragFn = tgpu.fragmentFn({
-      in: { uv: d.vec2f },
-      out: d.vec4f,
-    })((input) => {
+describe('GlslGenerator - function definitions', () => {
+  it('generates proper function signatures', () => {
+    function add(a: number, b: number) {
       'use gpu';
-      return d.vec4f(input.uv[0], 0.0, 0.0, 1.0);
-    });
+      return a + b;
+    }
 
-    const result = tgpu.resolveWithContext([fragFn], { unstable_shaderGenerator: glslGenerator });
-    // vec4f(...) in the body should become vec4(...)
-    expect(result.code).toContain('vec4(');
-    // Should not contain the WGSL-style constructor in the body
-    expect(result.code).not.toMatch(/\bvec4f\s*\(/);
+    function main() {
+      'use gpu';
+      return add(1.5, 1.2);
+    }
+
+    const result = tgpu.resolveWithContext([main], glOptions());
+
+    expect(result.code).toMatchInlineSnapshot(`
+      "float add(float a, float b) {
+        return (a + b);
+      }
+
+      float main() {
+        return add(1.5f, 1.2f);
+      }"
+    `);
   });
 
   it('translates vec3f to vec3 in function body', () => {
@@ -111,10 +116,43 @@ describe('GlslGenerator - functionDefinition post-processing', () => {
       return d.vec4f(color[0], color[1], color[2], 1.0);
     });
 
-    const result = tgpu.resolveWithContext([fragFn], { unstable_shaderGenerator: glslGenerator });
+    const result = tgpu.resolveWithContext([fragFn], glOptions());
     expect(result.code).toContain('vec3(');
     expect(result.code).not.toMatch(/\bvec3f\s*\(/);
     expect(result.code).toContain('vec4(');
+  });
+
+  it('generates proper struct definition', () => {
+    const Boid = d.struct({
+      pos: d.vec3f,
+      vel: d.vec3f,
+    });
+
+    function createBoid() {
+      'use gpu';
+      return Boid({ pos: d.vec3f(), vel: d.vec3f(0, 1, 0) });
+    }
+
+    function main() {
+      'use gpu';
+      const boid = createBoid();
+    }
+
+    const result = tgpu.resolve([main], glOptions());
+    expect(result).toMatchInlineSnapshot(`
+      "struct Boid {
+        vec3 pos;
+        vec3 vel;
+      };
+
+      Boid createBoid() {
+        return Boid(vec3(), vec3(0, 1, 0));
+      }
+
+      void main() {
+        Boid boid = createBoid();
+      }"
+    `);
   });
 });
 
@@ -127,7 +165,7 @@ describe('GlslGenerator - entry point generation with JS functions', () => {
       return Out({ pos: d.vec4f(0.0, 0.0, 0.0, 1.0) });
     });
 
-    const result = tgpu.resolveWithContext([vertFn], { unstable_shaderGenerator: glslGenerator });
+    const result = tgpu.resolveWithContext([vertFn], glOptions());
     expect(result.code).toBeDefined();
     expect(result.code.length).toBeGreaterThan(0);
     // The body should have translated type names
@@ -136,11 +174,47 @@ describe('GlslGenerator - entry point generation with JS functions', () => {
 
     expect(result.code).toMatchInlineSnapshot(`
       "struct vertFn_Output {
-        @builtin(position) pos: vec4,
-      }
+        vec4 pos;
+      };
 
-      @vertex fn vertFn() -> vertFn_Output {
+      void main() {
         return vertFn_Output(vec4(0, 0, 0, 1));
+      }"
+    `);
+  });
+
+  it('resolves a vertex function returning a builtin and varying', () => {
+    const vertFn = tgpu.vertexFn({
+      out: {
+        position: d.builtin.position,
+        uv: d.vec2f,
+      },
+    })(() => {
+      'use gpu';
+      const position = d.vec4f();
+      const uv = d.vec2f();
+
+      // NOTE: Don't wrap when assigning variables
+      // is valid and allowed at most once
+      return {
+        position: d.vec4f(position),
+        uv: d.vec2f(uv),
+      };
+    });
+
+    const result = tgpu.resolve([vertFn], glOptions());
+
+    expect(result).toMatchInlineSnapshot(`
+      "layout(location = 0) out uv_1;
+
+      void main() {
+        vec4 position = vec4();
+        vec2 uv = vec2();
+        {
+          gl_Position = position;
+          uv_1 = uv;
+          return;
+        }
       }"
     `);
   });
@@ -150,18 +224,24 @@ describe('GlslGenerator - entry point generation with JS functions', () => {
       out: d.vec4f,
     })(() => {
       'use gpu';
+      // This variable should get renamed to not conflict with
+      // the global.
+      const gl_Position = 1;
       return d.vec4f(1.0, 0.0, 0.0, 1.0);
     });
 
-    const result = tgpu.resolveWithContext([fragFn], { unstable_shaderGenerator: glslGenerator });
+    const result = tgpu.resolveWithContext([fragFn], glOptions());
     expect(result.code).toBeDefined();
-    // The body should have translated vec4f → vec4
     expect(result.code).toContain('vec4(');
     expect(result.code).not.toMatch(/\bvec4f\s*\(/);
 
     expect(result.code).toMatchInlineSnapshot(`
-      "@fragment fn fragFn() -> @location(0) vec4 {
-        return vec4(1, 0, 0, 1);
+      "void main() {
+        int gl_Position_1 = 1;
+        {
+          gl_Position = vec4(1, 0, 0, 1);
+          return;
+        }
       }"
     `);
   });

--- a/packages/typegpu/src/core/function/fnCore.ts
+++ b/packages/typegpu/src/core/function/fnCore.ts
@@ -206,8 +206,10 @@ export function createFnCore(
 
       // generate wgsl string
 
-      const { code, returnType: actualReturnType } = ctx.fnToWgsl({
+      const { code, returnType: actualReturnType } = ctx.resolveFunction({
         functionType,
+        name: id,
+        workgroupSize,
         argTypes,
         entryInput,
         params: ast.params,
@@ -216,16 +218,7 @@ export function createFnCore(
         externalMap,
       });
 
-      let attributes = '';
-      if (functionType === 'compute') {
-        attributes = `@compute @workgroup_size(${workgroupSize?.join(', ')}) `;
-      } else if (functionType === 'vertex') {
-        attributes = `@vertex `;
-      } else if (functionType === 'fragment') {
-        attributes = `@fragment `;
-      }
-
-      ctx.addDeclaration(`${attributes}fn ${id}${code}`);
+      ctx.addDeclaration(code);
 
       return snip(id, actualReturnType, /* origin */ 'runtime');
     },

--- a/packages/typegpu/src/core/function/fnCore.ts
+++ b/packages/typegpu/src/core/function/fnCore.ts
@@ -196,8 +196,10 @@ export function createFnCore(
 
       // generate wgsl string
 
-      const { code, returnType: actualReturnType } = ctx.fnToWgsl({
+      const { code, returnType: actualReturnType } = ctx.resolveFunction({
         functionType,
+        name: id,
+        workgroupSize,
         argTypes,
         entryInput,
         params: ast.params,
@@ -206,7 +208,7 @@ export function createFnCore(
         externalMap,
       });
 
-      ctx.addDeclaration(`${attributes}fn ${id}${code}`);
+      ctx.addDeclaration(code);
 
       return snip(id, actualReturnType, /* origin */ 'runtime');
     },

--- a/packages/typegpu/src/resolutionCtx.ts
+++ b/packages/typegpu/src/resolutionCtx.ts
@@ -40,7 +40,7 @@ import type {
   BlockScopeLayer,
   ExecMode,
   ExecState,
-  FnToWgslOptions,
+  ResolveFunctionOptions,
   FunctionArgumentAccess,
   FunctionScopeLayer,
   ItemLayer,
@@ -526,7 +526,7 @@ export class ResolutionCtxImpl implements ResolutionCtx {
     return this.#logGenerator.logResources;
   }
 
-  fnToWgsl(options: FnToWgslOptions): { code: string; returnType: BaseData } {
+  resolveFunction(options: ResolveFunctionOptions): { code: string; returnType: BaseData } {
     try {
       const scope = this._itemStateStack.pushFunctionScope(
         options.functionType,
@@ -649,6 +649,8 @@ export class ResolutionCtxImpl implements ResolutionCtx {
 
       const code = this.gen.functionDefinition({
         functionType: options.functionType,
+        name: options.name,
+        workgroupSize: options.workgroupSize,
         args,
         body: options.body,
         determineReturnType: () => {

--- a/packages/typegpu/src/resolutionCtx.ts
+++ b/packages/typegpu/src/resolutionCtx.ts
@@ -40,7 +40,7 @@ import type {
   BlockScopeLayer,
   ExecMode,
   ExecState,
-  FnToWgslOptions,
+  ResolveFunctionOptions,
   FunctionArgumentAccess,
   FunctionScopeLayer,
   ItemLayer,
@@ -532,7 +532,7 @@ export class ResolutionCtxImpl implements ResolutionCtx {
     return this.#logGenerator.logResources;
   }
 
-  fnToWgsl(options: FnToWgslOptions): { code: string; returnType: BaseData } {
+  resolveFunction(options: ResolveFunctionOptions): { code: string; returnType: BaseData } {
     try {
       const scope = this._itemStateStack.pushFunctionScope(
         options.functionType,
@@ -655,6 +655,8 @@ export class ResolutionCtxImpl implements ResolutionCtx {
 
       const code = this.gen.functionDefinition({
         functionType: options.functionType,
+        name: options.name,
+        workgroupSize: options.workgroupSize,
         args,
         body: options.body,
         determineReturnType: () => {

--- a/packages/typegpu/src/tgsl/shaderGenerator_members.ts
+++ b/packages/typegpu/src/tgsl/shaderGenerator_members.ts
@@ -3,12 +3,15 @@ import type { BaseData } from '../data/wgslTypes.ts';
 import type { FunctionArgument, TgpuShaderStage } from '../types.ts';
 
 export { UnknownData } from '../data/dataTypes.ts';
+export { getName } from '../shared/meta.ts';
 
 // types
-export type { ResolutionCtx, FunctionArgument } from '../types.ts';
+export type { ResolutionCtx, FunctionArgument, TgpuShaderStage } from '../types.ts';
 
 export interface FunctionDefinitionOptions {
   readonly functionType: 'normal' | TgpuShaderStage;
+  readonly name: string;
+  readonly workgroupSize?: readonly number[] | undefined;
   readonly args: readonly FunctionArgument[];
   readonly body: Block;
 

--- a/packages/typegpu/src/tgsl/shaderGenerator_members.ts
+++ b/packages/typegpu/src/tgsl/shaderGenerator_members.ts
@@ -3,14 +3,17 @@ import type { BaseData } from '../data/wgslTypes.ts';
 import type { FunctionArgument, TgpuShaderStage } from '../types.ts';
 
 export { UnknownData } from '../data/dataTypes.ts';
+export { getName } from '../shared/meta.ts';
 
 // types
-export type { ResolutionCtx, FunctionArgument } from '../types.ts';
+export type { ResolutionCtx, FunctionArgument, TgpuShaderStage } from '../types.ts';
 export type { Snippet } from '../data/snippet.ts';
 export type { Origin } from '../data/snippet.ts';
 
 export interface FunctionDefinitionOptions {
   readonly functionType: 'normal' | TgpuShaderStage;
+  readonly name: string;
+  readonly workgroupSize?: readonly number[] | undefined;
   readonly args: readonly FunctionArgument[];
   readonly body: Block;
 

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -293,14 +293,13 @@ ${this.ctx.pre}}`;
     return snippet;
   }
 
-  protected emitVarDecl(
-    pre: string,
+  public _emitVarDecl(
     keyword: 'var' | 'let' | 'const',
     name: string,
     _dataType: wgsl.BaseData | UnknownData,
     rhsStr: string,
   ): string {
-    return `${pre}${keyword} ${name} = ${rhsStr};`;
+    return `${this.ctx.pre}${keyword} ${name} = ${rhsStr};`;
   }
 
   public _identifier(id: string): Snippet {
@@ -901,7 +900,7 @@ ${this.ctx.pre}}`;
     // Function body
     const body = this._block(options.body);
 
-    // Function header
+    // Only after generating the body can we determine the return type
     const returnType = options.determineReturnType();
 
     const argList = options.args
@@ -917,7 +916,16 @@ ${this.ctx.pre}}`;
         ? `(${argList}) -> ${getAttributesString(returnType)}${this.ctx.resolve(returnType).value} `
         : `(${argList}) `;
 
-    return `${head}${body}`;
+    let attributes = '';
+    if (options.functionType === 'compute') {
+      attributes = `@compute @workgroup_size(${options.workgroupSize?.join(', ')}) `;
+    } else if (options.functionType === 'vertex') {
+      attributes = `@vertex `;
+    } else if (options.functionType === 'fragment') {
+      attributes = `@fragment `;
+    }
+
+    return `${attributes}fn ${options.name}${head}${body}`;
   }
 
   /**
@@ -939,6 +947,75 @@ ${this.ctx.pre}}`;
     return snip(stitch`${this.ctx.resolve(schema).value}(${args})`, schema, 'runtime');
   }
 
+  public _returnStatement(statement: tinyest.Return): string {
+    const returnNode = statement[1];
+
+    if (returnNode !== undefined) {
+      const expectedReturnType = this.ctx.topFunctionReturnType;
+      let returnSnippet = expectedReturnType
+        ? this._typedExpression(returnNode, expectedReturnType)
+        : this._expression(returnNode);
+
+      if (returnSnippet.value instanceof RefOperator) {
+        throw new WgslTypeError(
+          stitch`Cannot return references, returning '${returnSnippet.value.snippet}'`,
+        );
+      }
+
+      // Arguments cannot be returned from functions without copying. A simple example why is:
+      // const identity = (x) => {
+      //   'use gpu';
+      //   return x;
+      // };
+      //
+      // const foo = (arg: d.v3f) => {
+      //   'use gpu';
+      //   const marg = identity(arg);
+      //   marg.x = 1; // 'marg's origin would be 'runtime', so we wouldn't be able to track this misuse.
+      // };
+      if (
+        returnSnippet.origin === 'argument' &&
+        !wgsl.isNaturallyEphemeral(returnSnippet.dataType) &&
+        // Only restricting this use in non-entry functions, as the function
+        // is giving up ownership of all references anyway.
+        this.ctx.topFunctionScope?.functionType === 'normal'
+      ) {
+        throw new WgslTypeError(
+          stitch`Cannot return references to arguments, returning '${returnSnippet}'. Copy the argument before returning it.`,
+        );
+      }
+
+      if (
+        !expectedReturnType &&
+        !isEphemeralSnippet(returnSnippet) &&
+        returnSnippet.origin !== 'this-function'
+      ) {
+        const str = this.ctx.resolve(returnSnippet.value, returnSnippet.dataType).value;
+        const typeStr = this.ctx.resolve(unptr(returnSnippet.dataType)).value;
+        throw new WgslTypeError(
+          `'return ${str};' is invalid, cannot return references.
+-----
+Try 'return ${typeStr}(${str});' instead.
+-----`,
+        );
+      }
+
+      returnSnippet = tryConvertSnippet(
+        this.ctx,
+        returnSnippet,
+        unptr(returnSnippet.dataType) as wgsl.AnyWgslData,
+        false,
+      );
+
+      invariant(returnSnippet.dataType !== UnknownData, 'Return type should be known');
+
+      this.ctx.reportReturnType(returnSnippet.dataType);
+      return stitch`${this.ctx.pre}return ${returnSnippet};`;
+    }
+
+    return `${this.ctx.pre}return;`;
+  }
+
   public _statement(statement: tinyest.Statement): string {
     if (typeof statement === 'string') {
       const id = this._identifier(statement);
@@ -952,72 +1029,7 @@ ${this.ctx.pre}}`;
     }
 
     if (statement[0] === NODE.return) {
-      const returnNode = statement[1];
-
-      if (returnNode !== undefined) {
-        const expectedReturnType = this.ctx.topFunctionReturnType;
-        let returnSnippet = expectedReturnType
-          ? this._typedExpression(returnNode, expectedReturnType)
-          : this._expression(returnNode);
-
-        if (returnSnippet.value instanceof RefOperator) {
-          throw new WgslTypeError(
-            stitch`Cannot return references, returning '${returnSnippet.value.snippet}'`,
-          );
-        }
-
-        // Arguments cannot be returned from functions without copying. A simple example why is:
-        // const identity = (x) => {
-        //   'use gpu';
-        //   return x;
-        // };
-        //
-        // const foo = (arg: d.v3f) => {
-        //   'use gpu';
-        //   const marg = identity(arg);
-        //   marg.x = 1; // 'marg's origin would be 'runtime', so we wouldn't be able to track this misuse.
-        // };
-        if (
-          returnSnippet.origin === 'argument' &&
-          !wgsl.isNaturallyEphemeral(returnSnippet.dataType) &&
-          // Only restricting this use in non-entry functions, as the function
-          // is giving up ownership of all references anyway.
-          this.ctx.topFunctionScope?.functionType === 'normal'
-        ) {
-          throw new WgslTypeError(
-            stitch`Cannot return references to arguments, returning '${returnSnippet}'. Copy the argument before returning it.`,
-          );
-        }
-
-        if (
-          !expectedReturnType &&
-          !isEphemeralSnippet(returnSnippet) &&
-          returnSnippet.origin !== 'this-function'
-        ) {
-          const str = this.ctx.resolve(returnSnippet.value, returnSnippet.dataType).value;
-          const typeStr = this.ctx.resolve(unptr(returnSnippet.dataType)).value;
-          throw new WgslTypeError(
-            `'return ${str};' is invalid, cannot return references.
------
-Try 'return ${typeStr}(${str});' instead.
------`,
-          );
-        }
-
-        returnSnippet = tryConvertSnippet(
-          this.ctx,
-          returnSnippet,
-          unptr(returnSnippet.dataType) as wgsl.AnyWgslData,
-          false,
-        );
-
-        invariant(returnSnippet.dataType !== UnknownData, 'Return type should be known');
-
-        this.ctx.reportReturnType(returnSnippet.dataType);
-        return stitch`${this.ctx.pre}return ${returnSnippet};`;
-      }
-
-      return `${this.ctx.pre}return;`;
+      return this._returnStatement(statement);
     }
 
     if (statement[0] === NODE.if) {
@@ -1165,13 +1177,7 @@ ${this.ctx.pre}else ${alternate}`;
       const snippet = this.blockVariable(varType, rawId, concretize(dataType), eq.origin);
       const rhsSnippet = tryConvertSnippet(this.ctx, eq, dataType, false);
       const rhsStr = this.ctx.resolve(rhsSnippet.value, rhsSnippet.dataType).value;
-      return this.emitVarDecl(
-        this.ctx.pre,
-        varType,
-        snippet.value as string,
-        concretize(dataType),
-        rhsStr,
-      );
+      return this._emitVarDecl(varType, snippet.value as string, concretize(dataType), rhsStr);
     }
 
     if (statement[0] === NODE.block) {

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -210,7 +210,7 @@ export class WgslGenerator implements ShaderGenerator {
     return this.#ctx;
   }
 
-  public _block([_, statements]: tinyest.Block, externalMap?: ExternalMap): string {
+  protected _block([_, statements]: tinyest.Block, externalMap?: ExternalMap): string {
     this.ctx.pushBlockScope();
 
     if (externalMap) {
@@ -235,7 +235,7 @@ ${this.ctx.pre}}`;
     }
   }
 
-  public _blockStatement(block: tinyest.Block, externalMap?: ExternalMap): string {
+  protected _blockStatement(block: tinyest.Block, externalMap?: ExternalMap): string {
     return `${this.ctx.pre}${this._block(block, externalMap)}`;
   }
 
@@ -255,17 +255,16 @@ ${this.ctx.pre}}`;
    * Creates a variable declaration string.
    * `keyword` may be a placeholder filled in later.
    */
-  protected emitVarDecl(
-    pre: string,
+  protected _emitVarDecl(
     keyword: 'var' | 'let' | 'const' | `#VAR_${number}#`,
     name: string,
     _dataType: wgsl.BaseData | UnknownData,
     rhsStr: string,
   ): string {
-    return `${pre}${keyword} ${name} = ${rhsStr};`;
+    return `${this.ctx.pre}${keyword} ${name} = ${rhsStr};`;
   }
 
-  public _identifier(id: string): Snippet {
+  protected _identifier(id: string): Snippet {
     if (!id) {
       throw new Error('Cannot resolve an empty identifier');
     }
@@ -286,7 +285,7 @@ ${this.ctx.pre}}`;
    * A wrapper for `generateExpression` that updates `ctx.expectedType`
    * and tries to convert the result when it does not match the expected type.
    */
-  public _typedExpression(
+  protected _typedExpression(
     expression: tinyest.Expression,
     expectedType: wgsl.BaseData | wgsl.BaseData[],
   ) {
@@ -307,7 +306,7 @@ ${this.ctx.pre}}`;
     }
   }
 
-  public _expression(expression: tinyest.Expression): Snippet {
+  protected _expression(expression: tinyest.Expression): Snippet {
     if (typeof expression === 'string') {
       return this._identifier(expression);
     }
@@ -862,7 +861,7 @@ ${this.ctx.pre}}`;
       );
     }
 
-    // Function header
+    // Only after generating the body can we determine the return type
     const returnType = options.determineReturnType();
 
     const argList = options.args
@@ -878,7 +877,19 @@ ${this.ctx.pre}}`;
         ? `(${argList}) -> ${getAttributesString(returnType)}${this.ctx.resolve(returnType).value} `
         : `(${argList}) `;
 
-    return `${head}${body}`;
+    let attributes = '';
+    if (options.functionType === 'compute') {
+      if (!options.workgroupSize) {
+        throw new Error('Compute shaders must have a workgroup size');
+      }
+      attributes = `@compute @workgroup_size(${options.workgroupSize.join(', ')}) `;
+    } else if (options.functionType === 'vertex') {
+      attributes = `@vertex `;
+    } else if (options.functionType === 'fragment') {
+      attributes = `@fragment `;
+    }
+
+    return `${attributes}fn ${options.name}${head}${body}`;
   }
 
   /**
@@ -900,7 +911,7 @@ ${this.ctx.pre}}`;
     return snip(stitch`${this.ctx.resolve(schema).value}(${args})`, schema, 'runtime');
   }
 
-  public _return(statement: tinyest.Return): string {
+  protected _return(statement: tinyest.Return): string {
     const returnNode = statement[1];
 
     if (returnNode !== undefined) {
@@ -972,7 +983,7 @@ Try 'return ${typeStr}(${str});' instead.
     return `${this.ctx.pre}return;`;
   }
 
-  public _letStatement(statement: tinyest.Let): string {
+  protected _letStatement(statement: tinyest.Let): string {
     const [_, rawId, eqNode] = statement;
 
     if (eqNode === undefined) {
@@ -1040,10 +1051,10 @@ Try 'return ${typeStr}(${str});' instead.
     const emittedVarType = `#VAR_${scope.placeholderForVariable.size}#` as const;
     scope.placeholderForVariable.set(snippet, emittedVarType);
 
-    return this.emitVarDecl(this.ctx.pre, emittedVarType, snippet.value, concreteType, rhsStr);
+    return this._emitVarDecl(emittedVarType, snippet.value, concreteType, rhsStr);
   }
 
-  public _constStatement(statement: tinyest.Const) {
+  protected _constStatement(statement: tinyest.Const) {
     const [_, rawId, eqNode] = statement;
 
     if (eqNode === undefined) {
@@ -1158,10 +1169,10 @@ Try 'return ${typeStr}(${str});' instead.
       emittedVarType = varType;
     }
 
-    return this.emitVarDecl(this.ctx.pre, emittedVarType, snippet.value, concreteType, rhsStr);
+    return this._emitVarDecl(emittedVarType, snippet.value, concreteType, rhsStr);
   }
 
-  public _statement(statement: tinyest.Statement): string {
+  protected _statement(statement: tinyest.Statement): string {
     if (typeof statement === 'string') {
       const id = this._identifier(statement);
       const resolved = id.value && this.ctx.resolve(id.value).value;

--- a/packages/typegpu/src/types.ts
+++ b/packages/typegpu/src/types.ts
@@ -76,8 +76,10 @@ export type Wgsl = Eventual<string | number | boolean | ResolvableObject>;
 
 export type TgpuShaderStage = 'compute' | 'vertex' | 'fragment';
 
-export interface FnToWgslOptions {
+export interface ResolveFunctionOptions {
   functionType: 'normal' | TgpuShaderStage;
+  workgroupSize?: readonly number[] | undefined;
+  name: string;
   argTypes: BaseData[];
   /**
    * The return type of the function. If undefined, the type should be inferred
@@ -313,7 +315,7 @@ export interface ResolutionCtx {
    */
   resolveSnippet(snippet: Snippet): ResolvedSnippet;
 
-  fnToWgsl(options: FnToWgslOptions): {
+  resolveFunction(options: ResolveFunctionOptions): {
     code: string;
     returnType: BaseData;
   };

--- a/packages/typegpu/src/types.ts
+++ b/packages/typegpu/src/types.ts
@@ -76,8 +76,10 @@ export type Wgsl = Eventual<string | number | boolean | ResolvableObject>;
 
 export type TgpuShaderStage = 'compute' | 'vertex' | 'fragment';
 
-export interface FnToWgslOptions {
+export interface ResolveFunctionOptions {
   functionType: 'normal' | TgpuShaderStage;
+  workgroupSize?: readonly number[] | undefined;
+  name: string;
   argTypes: BaseData[];
   /**
    * The return type of the function. If undefined, the type should be inferred
@@ -321,7 +323,7 @@ export interface ResolutionCtx {
    */
   resolveSnippet(snippet: Snippet): ResolvedSnippet;
 
-  fnToWgsl(options: FnToWgslOptions): {
+  resolveFunction(options: ResolveFunctionOptions): {
     code: string;
     returnType: BaseData;
   };


### PR DESCRIPTION
This PR builds upon the previous `GlslGenerator` functionality by adding:
- GLSL function signature generation
- GLSL struct generation
- Primitive handling of `out` inter-stage variables in entry functions.