### PR TITLE
chore: Manual publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,46 @@
+name: Publish release to npm
+on:
+  # For manual releases
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Whether to perform a dry run of the publish.
+        type: boolean
+        default: true
+
+jobs:
+  npm-build:
+    if: github.repository == 'software-mansion/TypeGPU'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write # for OIDC
+
+    concurrency:
+      group: publish-${{ github.ref }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish manual release
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          DISABLE_DRY_RUN: ${{ inputs['dry-run'] == false }}
+        run: bun scripts/publish.ts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ pnpm publish --dry-run # (if alpha, --tag alpha)
 > publishing:
 >
 > ```bash
-> SKIP_ALL_CHECKS=true pnpm publish # (if alpha, --tag alpha)
+> SKIP_TESTS=true pnpm publish # (if alpha, --tag alpha)
 > ```
 
 6. Rebase _release_ branch on _main_

--- a/apps/resolution-time/package.json
+++ b/apps/resolution-time/package.json
@@ -11,7 +11,7 @@
     "typegpu": "workspace:*"
   },
   "devDependencies": {
-    "bun": "1.3.10",
+    "bun": "catalog:",
     "unplugin-typegpu": "workspace:*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,14 +32,16 @@
     "test:browser": "vitest run --browser.enabled --project browser",
     "test:browser:watch": "vitest --browser.enabled --project browser",
     "test:coverage": "vitest --coverage run",
-    "nightly-build": "SKIP_ALL_CHECKS=true pnpm --filter typegpu --filter @typegpu/noise --filter unplugin-typegpu prepublishOnly",
+    "nightly-build": "SKIP_TESTS=true pnpm --filter typegpu --filter @typegpu/noise --filter unplugin-typegpu prepublishOnly --skip-publish-tag-check",
     "changes": "tgpu-dev-cli changes"
   },
   "devDependencies": {
     "@typegpu/tgpu-dev-cli": "workspace:*",
+    "@types/bun": "^1.3.12",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "3.1.2",
     "@webgpu/types": "catalog:types",
+    "bun": "catalog:",
     "dpdm": "^3.14.0",
     "eslint-plugin-eslint-plugin": "^7.3.2",
     "eslint-plugin-typegpu": "workspace:*",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -28,6 +28,7 @@
     }
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "types": "./dist/index.d.mts",

--- a/packages/tgpu-dev-cli/package.json
+++ b/packages/tgpu-dev-cli/package.json
@@ -19,6 +19,9 @@
     "pkg-types": "^2.1.0",
     "remeda": "^2.21.2"
   },
+  "devDependencies": {
+    "@types/node": "catalog:types"
+  },
   "engines": {
     "node": ">=12.20.0"
   },

--- a/packages/tgpu-dev-cli/prepack.mjs
+++ b/packages/tgpu-dev-cli/prepack.mjs
@@ -135,9 +135,9 @@ async function main() {
     '--skip-publish-tag-check': Boolean,
   });
 
-  const skipAllChecks = process.env.SKIP_ALL_CHECKS === 'true';
+  const skipTests = process.env.SKIP_TESTS === 'true';
 
-  if (!args['--skip-publish-tag-check'] && !skipAllChecks) {
+  if (!args['--skip-publish-tag-check']) {
     verifyPublishTag();
   }
 
@@ -200,7 +200,7 @@ async function main() {
       // First build
       ...(await Promise.allSettled([withStatusUpdate('build', $`pnpm build`)])),
       // Then the rest
-      ...(skipAllChecks
+      ...(skipTests
         ? []
         : await Promise.allSettled([
             withStatusUpdate('style', $`pnpm -w test:style`),

--- a/packages/tgpu-dev-cli/verify-publish-tag.mjs
+++ b/packages/tgpu-dev-cli/verify-publish-tag.mjs
@@ -1,9 +1,10 @@
 // @ts-check
+/// <reference types="node" />
 
 import { type } from 'arktype';
 import { readPackageJSON } from 'pkg-types';
 
-const PublishTags = /** @type {const} */ (['alpha', 'beta']);
+const PublishTags = /** @type {const} */ (['alpha', 'beta', 'rc', 'nightly']);
 
 const PublishTag = type.or(
   'undefined',
@@ -16,7 +17,7 @@ const chosenPublishTag = PublishTag.assert(process.env.npm_config_tag);
 export function verifyPublishTag() {
   let tagVerified = false;
   for (const tag of PublishTags) {
-    if (packageJSON.version?.includes(tag)) {
+    if (packageJSON.version?.includes(`-${tag}.`)) {
       if (tag !== chosenPublishTag) {
         throw new Error(
           `Publishing under a mismatched tag "${chosenPublishTag}" for version ${packageJSON.version}. Use --tag ${tag}`,

--- a/packages/tinyest-for-wgsl/package.json
+++ b/packages/tinyest-for-wgsl/package.json
@@ -1,7 +1,6 @@
 {
   "name": "tinyest-for-wgsl",
   "version": "0.3.2",
-  "private": true,
   "description": "Transforms JavaScript into its 'tinyest' form, to be used in generating equivalent (or close to) WGSL code.",
   "keywords": [
     "compute",
@@ -28,6 +27,7 @@
   "sideEffects": false,
   "exports": "./src/index.ts",
   "publishConfig": {
+    "access": "public",
     "directory": "dist",
     "exports": {
       "./package.json": "./package.json",

--- a/packages/tinyest/package.json
+++ b/packages/tinyest/package.json
@@ -1,7 +1,6 @@
 {
   "name": "tinyest",
   "version": "0.3.1",
-  "private": true,
   "description": "A compact, fast, and embeddable JavaScript AST for transpilation.",
   "keywords": [
     "ast",
@@ -20,6 +19,7 @@
   "sideEffects": false,
   "exports": "./src/index.ts",
   "publishConfig": {
+    "access": "public",
     "directory": "dist",
     "exports": {
       "./package.json": "./package.json",

--- a/packages/typegpu-color/package.json
+++ b/packages/typegpu-color/package.json
@@ -11,6 +11,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
+    "access": "public",
     "directory": "dist",
     "exports": {
       "./package.json": "./dist/package.json",

--- a/packages/typegpu-geometry/package.json
+++ b/packages/typegpu-geometry/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@typegpu/geometry",
   "version": "0.10.0",
+  "private": true,
   "description": "A set of geometry helper functions for use in WebGPU/TypeGPU apps.",
   "keywords": [],
   "license": "MIT",
@@ -11,6 +12,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
+    "access": "public",
     "directory": "dist",
     "exports": {
       "./package.json": "./dist/package.json",

--- a/packages/typegpu-gl/package.json
+++ b/packages/typegpu-gl/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@typegpu/gl",
   "version": "0.10.0-alpha.1",
+  "private": true,
   "description": "WebGL and GLSL utilities for TypeGPU",
   "keywords": [],
   "license": "MIT",
@@ -11,6 +12,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
+    "access": "public",
     "directory": "dist",
     "exports": {
       "./package.json": "./dist/package.json",

--- a/packages/typegpu-noise/package.json
+++ b/packages/typegpu-noise/package.json
@@ -11,6 +11,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
+    "access": "public",
     "directory": "dist",
     "exports": {
       "./package.json": "./dist/package.json",

--- a/packages/typegpu-sdf/package.json
+++ b/packages/typegpu-sdf/package.json
@@ -11,6 +11,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
+    "access": "public",
     "directory": "dist",
     "exports": {
       "./package.json": "./dist/package.json",

--- a/packages/typegpu-sort/package.json
+++ b/packages/typegpu-sort/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@typegpu/sort",
   "version": "0.10.0",
+  "private": true,
   "description": "GPU sorting and scanning algorithms implemented using TypeGPU.",
   "keywords": [],
   "license": "MIT",
@@ -11,6 +12,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
+    "access": "public",
     "directory": "dist",
     "exports": {
       "./package.json": "./dist/package.json",

--- a/packages/typegpu-three/package.json
+++ b/packages/typegpu-three/package.json
@@ -11,6 +11,7 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
+    "access": "public",
     "directory": "dist",
     "exports": {
       "./package.json": "./dist/package.json",

--- a/packages/typegpu/package.json
+++ b/packages/typegpu/package.json
@@ -1,7 +1,6 @@
 {
   "name": "typegpu",
   "version": "0.10.2",
-  "private": true,
   "description": "A thin layer between JS and WebGPU/WGSL that improves development experience and allows for faster iteration.",
   "keywords": [
     "compute",
@@ -51,6 +50,7 @@
     }
   },
   "publishConfig": {
+    "access": "public",
     "directory": "dist",
     "exports": {
       "./package.json": "./dist/package.json",

--- a/packages/unplugin-typegpu/package.json
+++ b/packages/unplugin-typegpu/package.json
@@ -42,6 +42,7 @@
     "./webpack": "./src/webpack.ts"
   },
   "publishConfig": {
+    "access": "public",
     "directory": "dist",
     "exports": {
       "./package.json": "./package.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ catalogs:
     arktype:
       specifier: ^2.1.22
       version: 2.1.28
+    bun:
+      specifier: 1.3.10
+      version: 1.3.10
   example:
     wgpu-matrix:
       specifier: ^3.4.0
@@ -46,7 +49,7 @@ overrides:
   rollup: ^4.60.0
   vite: 8.0.5
   '@babel/types': ^7.29.0
-  '@types/node': ^24.1.0
+  '@types/node': ^24.10.0
   typescript: npm:tsover@^5.9.11
   three: ^0.181.0
   '@typescript-eslint/utils': ^8.57.2
@@ -58,6 +61,9 @@ importers:
       '@typegpu/tgpu-dev-cli':
         specifier: workspace:*
         version: link:packages/tgpu-dev-cli
+      '@types/bun':
+        specifier: ^1.3.12
+        version: 1.3.12
       '@vitest/browser':
         specifier: ^3.2.4
         version: 3.2.4(msw@2.10.2(@types/node@24.10.0)(tsover@5.9.11))(vite@8.0.5(@types/node@24.10.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.3))(vitest@4.1.2)
@@ -67,6 +73,9 @@ importers:
       '@webgpu/types':
         specifier: catalog:types
         version: 0.1.66
+      bun:
+        specifier: 'catalog:'
+        version: 1.3.10
       dpdm:
         specifier: ^3.14.0
         version: 3.14.0
@@ -121,7 +130,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.11
+        version: 1.3.12
 
   apps/infra-benchmarks:
     devDependencies:
@@ -136,7 +145,7 @@ importers:
         version: link:../../packages/typegpu
     devDependencies:
       bun:
-        specifier: 1.3.10
+        specifier: 'catalog:'
         version: 1.3.10
       unplugin-typegpu:
         specifier: workspace:*
@@ -152,7 +161,7 @@ importers:
         version: link:../../packages/unplugin-typegpu
     devDependencies:
       '@types/node':
-        specifier: ^24.1.0
+        specifier: ^24.10.0
         version: 24.10.0
       arktype:
         specifier: 1.0.29-alpha
@@ -363,7 +372,7 @@ importers:
         specifier: ^7.20.7
         version: 7.20.7
       '@types/node':
-        specifier: ^24.1.0
+        specifier: ^24.10.0
         version: 24.10.0
       '@types/three':
         specifier: catalog:types
@@ -412,7 +421,7 @@ importers:
         version: 8.57.2(eslint@9.39.2(jiti@2.6.1))(tsover@5.9.11)
     devDependencies:
       '@types/node':
-        specifier: ^24.1.0
+        specifier: ^24.10.0
         version: 24.10.0
       '@typescript-eslint/rule-tester':
         specifier: ^8.57.2
@@ -456,6 +465,10 @@ importers:
       remeda:
         specifier: ^2.21.2
         version: 2.21.2
+    devDependencies:
+      '@types/node':
+        specifier: ^24.10.0
+        version: 24.10.0
 
   packages/tgpu-gen:
     dependencies:
@@ -540,7 +553,7 @@ importers:
         specifier: workspace:*
         version: link:../tgpu-dev-cli
       '@types/node':
-        specifier: ^24.1.0
+        specifier: ^24.10.0
         version: 24.10.0
       '@webgpu/types':
         specifier: catalog:types
@@ -719,7 +732,7 @@ importers:
         version: link:../typegpu
     devDependencies:
       '@types/node':
-        specifier: ^24.1.0
+        specifier: ^24.10.0
         version: 24.10.0
       typescript:
         specifier: npm:tsover@^5.9.11
@@ -1862,7 +1875,7 @@ packages:
     resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': ^24.1.0
+      '@types/node': ^24.10.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1871,7 +1884,7 @@ packages:
     resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': ^24.1.0
+      '@types/node': ^24.10.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1884,7 +1897,7 @@ packages:
     resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': ^24.1.0
+      '@types/node': ^24.10.0
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3525,6 +3538,9 @@ packages:
   '@types/bun@1.3.11':
     resolution: {integrity: sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==}
 
+  '@types/bun@1.3.12':
+    resolution: {integrity: sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A==}
+
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -4180,6 +4196,9 @@ packages:
 
   bun-types@1.3.11:
     resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
+
+  bun-types@1.3.12:
+    resolution: {integrity: sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA==}
 
   bun@1.3.10:
     resolution: {integrity: sha512-S/CXaXXIyA4CMjdMkYQ4T2YMqnAn4s0ysD3mlsY4bUiOCqGlv28zck4Wd4H4kpvbekx15S9mUeLQ7Uxd0tYTLA==}
@@ -5139,11 +5158,13 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:
@@ -5874,6 +5895,7 @@ packages:
 
   mathjax-full@3.2.2:
     resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
+    deprecated: Version 4 replaces this package with the scoped package @mathjax/src
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -7902,7 +7924,7 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^24.1.0
+      '@types/node': ^24.10.0
       '@vitejs/devtools': ^0.1.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
@@ -7955,7 +7977,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': ^24.1.0
+      '@types/node': ^24.10.0
       '@vitest/browser-playwright': 4.0.18
       '@vitest/browser-preview': 4.0.18
       '@vitest/browser-webdriverio': 4.0.18
@@ -7989,7 +8011,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': ^24.1.0
+      '@types/node': ^24.10.0
       '@vitest/browser-playwright': 4.1.2
       '@vitest/browser-preview': 4.1.2
       '@vitest/browser-webdriverio': 4.1.2
@@ -8175,6 +8197,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -10643,6 +10666,10 @@ snapshots:
     dependencies:
       bun-types: 1.3.11
 
+  '@types/bun@1.3.12':
+    dependencies:
+      bun-types: 1.3.12
+
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -11558,6 +11585,10 @@ snapshots:
       ieee754: 1.2.1
 
   bun-types@1.3.11:
+    dependencies:
+      '@types/node': 24.10.0
+
+  bun-types@1.3.12:
     dependencies:
       '@types/node': 24.10.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
 
 catalog:
   '@babel/types': ^7.29.0
+  bun: 1.3.10
   arktype: ^2.1.22
 
 catalogs:
@@ -21,7 +22,7 @@ catalogs:
   test:
     vitest: ^4.1.2
   types:
+    '@types/node': ^24.10.0
     '@types/three': ^0.181.0
     '@webgpu/types': ^0.1.66
-    '@types/node': ^24.1.0
     typescript: npm:tsover@^5.9.11

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+
+import { readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { $ } from 'bun';
+
+const PACKAGES_DIR = join(import.meta.dir, '../packages');
+const isDryRun = process.env.DISABLE_DRY_RUN !== 'true';
+
+function getTag(version: string): string {
+  if (version.includes('-alpha.')) return 'alpha';
+  if (version.includes('-beta.')) return 'beta';
+  if (version.includes('-rc.')) return 'rc';
+  if (version.includes('-nightly.')) return 'nightly';
+  if (!version.includes('-')) return 'latest';
+  throw new Error(`Invalid version: ${version}`);
+}
+
+async function isPublished(name: string, version: string): Promise<boolean> {
+  const encodedName = encodeURIComponent(name);
+  const response = await fetch(
+    `https://registry.npmjs.org/${encodedName}/${encodeURIComponent(version)}`,
+  );
+  return response.ok;
+}
+
+interface PackageJson {
+  name: string;
+  version: string;
+  private?: boolean;
+}
+
+async function main() {
+  const dirs = readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => join(PACKAGES_DIR, d.name));
+
+  const toPublish: Array<{
+    dir: string;
+    name: string;
+    version: string;
+    tag: string;
+  }> = [];
+
+  await Promise.all(
+    dirs.map(async (dir) => {
+      const pkgJsonPath = join(dir, 'package.json');
+      if (!existsSync(pkgJsonPath)) {
+        return;
+      }
+
+      const pkg: PackageJson = await Bun.file(pkgJsonPath).json();
+      if (pkg.private) {
+        // Skip private packages
+        return;
+      }
+
+      const { name, version } = pkg;
+
+      if (await isPublished(name, version)) {
+        console.log(`  skip  ${name}@${version} (already published)`);
+        return;
+      }
+
+      toPublish.push({ dir, name, version, tag: getTag(version) });
+    }),
+  );
+
+  if (toPublish.length === 0) {
+    console.log('\nNothing to publish.');
+    return;
+  }
+
+  console.log(`\nPackages to publish${isDryRun ? ' (dry run)' : ''}:\n`);
+
+  const nameWidth = Math.max(...toPublish.map((p) => p.name.length));
+  for (const { name, version, tag } of toPublish) {
+    console.log(`  ${name.padEnd(nameWidth)}  ${version.padEnd(20)}  tag: ${tag}`);
+  }
+
+  console.log();
+
+  for (const { dir, name, version, tag } of toPublish) {
+    console.log(`Publishing ${name}@${version} [tag: ${tag}]...`);
+
+    const args = [
+      'publish',
+      '--provenance',
+      ...(tag === 'latest' ? [] : ['--tag', tag]),
+      ...(isDryRun ? ['--dry-run'] : []),
+    ];
+
+    await $`pnpm ${args}`.cwd(dir).env({ ...process.env, SKIP_TESTS: 'true' });
+
+    console.log();
+  }
+}
+
+await main();


### PR DESCRIPTION
This workflow publishes packages that have versions not yet on NPM, and that aren't marked as "private" in their package.json file.

**Changes:**
- Renamed `SKIP_ALL_CHECKS` to `SKIP_TESTS`, as now verifying the publish tag has to be explicitly disabled

**When nothing changed**:
<img width="415" height="192" alt="image" src="https://github.com/user-attachments/assets/0255e519-b3ad-47b0-9f24-95bc46139f97" />

**Patch bump**:
<img width="405" height="213" alt="image" src="https://github.com/user-attachments/assets/5c0eb6f0-0f5e-4b89-b021-83f5ed31afb5" />
