### PR TITLE
chore: Use ^workspace: qualifier for peerDependencies against workspace packages

### DIFF
--- a/apps/treeshake-test/compareResults.ts
+++ b/apps/treeshake-test/compareResults.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { arrayOf, type } from 'arktype';
+import { type } from 'arktype';
 import * as fs from 'node:fs/promises';
 import { ResultsTable } from './resultsTable.ts';
 
@@ -11,7 +11,7 @@ const ResultRecord = type({
   size: 'number',
 });
 
-const BenchmarkResults = arrayOf(ResultRecord);
+const BenchmarkResults = ResultRecord.array();
 
 function groupResultsByTest(results: typeof BenchmarkResults.infer) {
   const grouped: Record<string, Record<string, number>> = {};

--- a/apps/treeshake-test/package.json
+++ b/apps/treeshake-test/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:types",
-    "arktype": "1.0.29-alpha",
+    "arktype": "catalog:",
     "esbuild": "^0.25.11",
     "ts-loader": "^9.5.4",
     "tsdown": "^0.15.6",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "oxfmt": "^0.35.0",
     "oxlint": "^1.57.0",
     "oxlint-tsgolint": "^0.17.4",
-    "pkg-pr-new": "^0.0.62",
+    "pkg-pr-new": "^0.0.66",
     "typescript": "catalog:types",
     "unplugin-typegpu": "workspace:*",
     "vite-imagetools": "catalog:frontend",

--- a/packages/tgpu-dev-cli/prepack.mjs
+++ b/packages/tgpu-dev-cli/prepack.mjs
@@ -91,15 +91,6 @@ async function transformPackageJSON() {
   distPackageJson.scripts = {};
   // Removing dev dependencies.
   distPackageJson.devDependencies = undefined;
-  // Removing workspace specifiers in dependencies.
-  distPackageJson.dependencies = mapValues(
-    distPackageJson.dependencies ?? {},
-    (/** @type {string} */ value) => value.replace(/^workspace:/, ''),
-  );
-  distPackageJson.peerDependencies = mapValues(
-    distPackageJson.peerDependencies ?? {},
-    (/** @type {string} */ value) => value.replace(/^workspace:/, ''),
-  );
 
   await fs.writeFile(distPackageJsonUrl, JSON.stringify(distPackageJson, undefined, 2), 'utf-8');
 }

--- a/packages/tgpu-gen/package.json
+++ b/packages/tgpu-gen/package.json
@@ -24,7 +24,7 @@
     "vitest": "catalog:test"
   },
   "peerDependencies": {
-    "typegpu": "workspace:^0.10.2"
+    "typegpu": "workspace:^"
   },
   "engines": {
     "node": ">=12.20.0"

--- a/packages/tinyest-for-wgsl/package.json
+++ b/packages/tinyest-for-wgsl/package.json
@@ -21,7 +21,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/software-mansion/TypeGPU.git"
+    "url": "git+https://github.com/software-mansion/TypeGPU.git",
+    "directory": "packages/tinyest-for-wgsl"
   },
   "type": "module",
   "sideEffects": false,

--- a/packages/tinyest/package.json
+++ b/packages/tinyest/package.json
@@ -13,7 +13,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/software-mansion/TypeGPU.git"
+    "url": "git+https://github.com/software-mansion/TypeGPU.git",
+    "directory": "packages/tinyest"
   },
   "type": "module",
   "sideEffects": false,

--- a/packages/typegpu-color/package.json
+++ b/packages/typegpu-color/package.json
@@ -40,6 +40,6 @@
     "unplugin-typegpu": "workspace:*"
   },
   "peerDependencies": {
-    "typegpu": "^0.10.2"
+    "typegpu": "workspace:^"
   }
 }

--- a/packages/typegpu-color/package.json
+++ b/packages/typegpu-color/package.json
@@ -4,6 +4,11 @@
   "description": "A set of color helper functions for use in WebGPU/TypeGPU apps.",
   "keywords": [],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/software-mansion/TypeGPU.git",
+    "directory": "packages/typegpu-color"
+  },
   "type": "module",
   "sideEffects": false,
   "exports": {

--- a/packages/typegpu-geometry/package.json
+++ b/packages/typegpu-geometry/package.json
@@ -5,6 +5,11 @@
   "description": "A set of geometry helper functions for use in WebGPU/TypeGPU apps.",
   "keywords": [],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/software-mansion/TypeGPU.git",
+    "directory": "packages/typegpu-geometry"
+  },
   "type": "module",
   "sideEffects": false,
   "exports": {

--- a/packages/typegpu-geometry/package.json
+++ b/packages/typegpu-geometry/package.json
@@ -41,6 +41,6 @@
     "unplugin-typegpu": "workspace:*"
   },
   "peerDependencies": {
-    "typegpu": "^0.10.2"
+    "typegpu": "workspace:^"
   }
 }

--- a/packages/typegpu-gl/package.json
+++ b/packages/typegpu-gl/package.json
@@ -5,6 +5,11 @@
   "description": "WebGL and GLSL utilities for TypeGPU",
   "keywords": [],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/software-mansion/TypeGPU.git",
+    "directory": "packages/typegpu-gl"
+  },
   "type": "module",
   "sideEffects": false,
   "exports": {

--- a/packages/typegpu-gl/package.json
+++ b/packages/typegpu-gl/package.json
@@ -43,6 +43,6 @@
     "unplugin-typegpu": "workspace:*"
   },
   "peerDependencies": {
-    "typegpu": "^0.10.2"
+    "typegpu": "workspace:^"
   }
 }

--- a/packages/typegpu-noise/package.json
+++ b/packages/typegpu-noise/package.json
@@ -40,6 +40,6 @@
     "unplugin-typegpu": "workspace:*"
   },
   "peerDependencies": {
-    "typegpu": "^0.10.2"
+    "typegpu": "workspace:^"
   }
 }

--- a/packages/typegpu-noise/package.json
+++ b/packages/typegpu-noise/package.json
@@ -4,6 +4,11 @@
   "description": "A set of noise/pseudo-random functions for use in WebGPU/TypeGPU apps.",
   "keywords": [],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/software-mansion/TypeGPU.git",
+    "directory": "packages/typegpu-noise"
+  },
   "type": "module",
   "sideEffects": false,
   "exports": {

--- a/packages/typegpu-sdf/package.json
+++ b/packages/typegpu-sdf/package.json
@@ -40,6 +40,6 @@
     "unplugin-typegpu": "workspace:*"
   },
   "peerDependencies": {
-    "typegpu": "^0.10.2"
+    "typegpu": "workspace:^"
   }
 }

--- a/packages/typegpu-sdf/package.json
+++ b/packages/typegpu-sdf/package.json
@@ -4,6 +4,11 @@
   "description": "A set of Signed Distance Field functions for use in WebGPU/TypeGPU apps.",
   "keywords": [],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/software-mansion/TypeGPU.git",
+    "directory": "packages/typegpu-sdf"
+  },
   "type": "module",
   "sideEffects": false,
   "exports": {

--- a/packages/typegpu-sort/package.json
+++ b/packages/typegpu-sort/package.json
@@ -5,6 +5,11 @@
   "description": "GPU sorting and scanning algorithms implemented using TypeGPU.",
   "keywords": [],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/software-mansion/TypeGPU.git",
+    "directory": "packages/typegpu-sort"
+  },
   "type": "module",
   "sideEffects": false,
   "exports": {

--- a/packages/typegpu-sort/package.json
+++ b/packages/typegpu-sort/package.json
@@ -41,6 +41,6 @@
     "unplugin-typegpu": "workspace:*"
   },
   "peerDependencies": {
-    "typegpu": "^0.10.2"
+    "typegpu": "workspace:^"
   }
 }

--- a/packages/typegpu-testing-utility/package.json
+++ b/packages/typegpu-testing-utility/package.json
@@ -3,10 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/software-mansion/TypeGPU.git"
-  },
   "type": "module",
   "exports": "./src/index.ts",
   "scripts": {

--- a/packages/typegpu-three/package.json
+++ b/packages/typegpu-three/package.json
@@ -42,6 +42,6 @@
   },
   "peerDependencies": {
     "three": ">0.126.0",
-    "typegpu": "^0.10.2"
+    "typegpu": "workspace:^"
   }
 }

--- a/packages/typegpu-three/package.json
+++ b/packages/typegpu-three/package.json
@@ -4,6 +4,11 @@
   "description": "Utilities for integrating TypeGPU with Three.js",
   "keywords": [],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/software-mansion/TypeGPU.git",
+    "directory": "packages/typegpu-three"
+  },
   "type": "module",
   "sideEffects": false,
   "exports": {

--- a/packages/typegpu/package.json
+++ b/packages/typegpu/package.json
@@ -19,7 +19,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/software-mansion/TypeGPU.git"
+    "url": "git+https://github.com/software-mansion/TypeGPU.git",
+    "directory": "packages/typegpu"
   },
   "type": "module",
   "sideEffects": false,

--- a/packages/unplugin-typegpu/package.json
+++ b/packages/unplugin-typegpu/package.json
@@ -192,6 +192,6 @@
     "typescript": "catalog:types"
   },
   "peerDependencies": {
-    "typegpu": "workspace:^0.10.2"
+    "typegpu": "workspace:^"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,8 +164,8 @@ importers:
         specifier: ^24.10.0
         version: 24.10.0
       arktype:
-        specifier: 1.0.29-alpha
-        version: 1.0.29-alpha
+        specifier: 'catalog:'
+        version: 2.1.28
       esbuild:
         specifier: ^0.25.11
         version: 0.25.12
@@ -485,7 +485,7 @@ importers:
         specifier: ^2.21.2
         version: 2.21.2
       typegpu:
-        specifier: workspace:^0.10.2
+        specifier: workspace:^
         version: link:../typegpu
       wgsl_reflect:
         specifier: git://github.com/mhawryluk/wgsl_reflect.git#85994fdc8d8a3abbb4f79baf3891e54eed0c1c63
@@ -803,7 +803,7 @@ importers:
         specifier: workspace:~0.3.2
         version: link:../tinyest-for-wgsl
       typegpu:
-        specifier: workspace:^0.10.2
+        specifier: workspace:^
         version: link:../typegpu
       unplugin:
         specifier: ^3.0.0
@@ -4066,9 +4066,6 @@ packages:
 
   arkregex@0.0.4:
     resolution: {integrity: sha512-biS/FkvSwQq59TZ453piUp8bxMui11pgOMV9WHAnli1F8o0ayNCZzUwQadL/bGIUic5TkS/QlPcyMuI8ZIwedQ==}
-
-  arktype@1.0.29-alpha:
-    resolution: {integrity: sha512-glMLgVhIQRSkR3tymiS+POAcWVJH09sfrgic0jHnyFL8BlhHAJZX2BzdImU9zYr1y9NBqy+U93ZNrRTHXsKRDw==}
 
   arktype@2.1.28:
     resolution: {integrity: sha512-LVZqXl2zWRpNFnbITrtFmqeqNkPPo+KemuzbGSY6jvJwCb4v8NsDzrWOLHnQgWl26TkJeWWcUNUeBpq2Mst1/Q==}
@@ -11350,8 +11347,6 @@ snapshots:
   arkregex@0.0.4:
     dependencies:
       '@ark/util': 0.56.0
-
-  arktype@1.0.29-alpha: {}
 
   arktype@2.1.28:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,8 +98,8 @@ importers:
         specifier: ^0.17.4
         version: 0.17.4
       pkg-pr-new:
-        specifier: ^0.0.62
-        version: 0.0.62
+        specifier: ^0.0.66
+        version: 0.0.66
       typescript:
         specifier: npm:tsover@^5.9.11
         version: tsover@5.9.11
@@ -843,17 +843,17 @@ importers:
 
 packages:
 
-  '@actions/core@1.11.1':
-    resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
+  '@actions/core@3.0.0':
+    resolution: {integrity: sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==}
 
-  '@actions/exec@1.1.1':
-    resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
+  '@actions/exec@3.0.0':
+    resolution: {integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==}
 
-  '@actions/http-client@2.2.3':
-    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
+  '@actions/http-client@4.0.0':
+    resolution: {integrity: sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==}
 
-  '@actions/io@1.1.3':
-    resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
+  '@actions/io@3.0.2':
+    resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1712,10 +1712,6 @@ packages:
 
   '@expressive-code/plugin-text-markers@0.41.7':
     resolution: {integrity: sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw==}
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@floating-ui/core@1.7.1':
     resolution: {integrity: sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==}
@@ -6446,8 +6442,8 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  pkg-pr-new@0.0.62:
-    resolution: {integrity: sha512-K2jtf1PLCJJFDimQIpasPXDdnRTZSYPy36Ldz+QhMpLz2YN1Wi0ZQkomVt5Wi3NdBZcYuYGXekyFWfJ6fAHYjg==}
+  pkg-pr-new@0.0.66:
+    resolution: {integrity: sha512-t+rZ2DY9Bp7v2NSFZciqChb6DGPdo9YhQeuW/GSdMsUx634gnqe+baJq2ZQgVtXaIxUbnPPBmtFJb6qnQ0uVUA==}
     hasBin: true
 
   pkg-types@1.3.1:
@@ -7680,10 +7676,6 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-
   undici@6.23.0:
     resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
     engines: {node: '>=18.17'}
@@ -8349,21 +8341,21 @@ packages:
 
 snapshots:
 
-  '@actions/core@1.11.1':
+  '@actions/core@3.0.0':
     dependencies:
-      '@actions/exec': 1.1.1
-      '@actions/http-client': 2.2.3
+      '@actions/exec': 3.0.0
+      '@actions/http-client': 4.0.0
 
-  '@actions/exec@1.1.1':
+  '@actions/exec@3.0.0':
     dependencies:
-      '@actions/io': 1.1.3
+      '@actions/io': 3.0.2
 
-  '@actions/http-client@2.2.3':
+  '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 5.29.0
+      undici: 6.23.0
 
-  '@actions/io@1.1.3': {}
+  '@actions/io@3.0.2': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -9192,8 +9184,6 @@ snapshots:
   '@expressive-code/plugin-text-markers@0.41.7':
     dependencies:
       '@expressive-code/core': 0.41.7
-
-  '@fastify/busboy@2.1.1': {}
 
   '@floating-ui/core@1.7.1':
     dependencies:
@@ -14342,9 +14332,9 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  pkg-pr-new@0.0.62:
+  pkg-pr-new@0.0.66:
     dependencies:
-      '@actions/core': 1.11.1
+      '@actions/core': 3.0.0
       '@jsdevtools/ez-spawn': 3.0.4
       '@octokit/action': 6.1.0
       ignore: 5.3.2
@@ -15793,10 +15783,6 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@7.16.0: {}
-
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
 
   undici@6.23.0: {}
 


### PR DESCRIPTION
This makes it so that we no longer need to update them manually on each release 🎉

I inspected the tarball that gets sent to npm, and this is the generated package.json for `typegpu-noise`:

```jsonc
{
  "name": "@typegpu/noise",
  "version": "0.10.0",
  "description": "A set of noise/pseudo-random functions for use in WebGPU/TypeGPU apps.",
  "keywords": [],
  "license": "MIT",
  "type": "module",
  "sideEffects": false,
  "exports": {
    "./package.json": "./package.json",
    ".": {
      "types": "./index.d.ts",
      "module": "./index.mjs",
      "import": "./index.mjs",
      "default": "./index.cjs"
    }
  },
  "peerDependencies": {
    // Updated peer dependency to proper range! 🎉
    "typegpu": "^0.10.2"
  },
  "main": "./index.mjs",
  "types": "./index.d.ts",
  "private": false,
  "dependencies": {},
  "scripts": {}
}
```

`pnpm` takes care of replacing `workspace:` with the appropriate version.