### PR TITLE
fix: Add missing cool factor and remove explicit experimental tags

### DIFF
--- a/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/meta.json
+++ b/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Bitonic Sort",
   "category": "algorithms",
-  "tags": ["experimental", "compute"]
+  "tags": ["experimental", "compute"],
+  "coolFactor": 5
 }

--- a/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/meta.json
+++ b/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Bitonic Sort",
   "category": "algorithms",
-  "tags": ["experimental", "compute"],
+  "tags": ["compute"],
   "coolFactor": 5
 }

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles-with/meta.json
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles-with/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Render Bundles (.with API)",
   "category": "rendering",
-  "tags": ["experimental", "3d", "rasterization", "performance"],
+  "tags": ["3d", "rasterization", "performance"],
   "coolFactor": 5
 }

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles-with/meta.json
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles-with/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Render Bundles (.with API)",
   "category": "rendering",
-  "tags": ["experimental", "3d", "rasterization", "performance"]
+  "tags": ["experimental", "3d", "rasterization", "performance"],
+  "coolFactor": 5
 }

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles/meta.json
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Render Bundles",
   "category": "rendering",
-  "tags": ["experimental", "3d", "rasterization", "performance"],
+  "tags": ["3d", "rasterization", "performance"],
   "coolFactor": 5
 }

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles/meta.json
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Render Bundles",
   "category": "rendering",
-  "tags": ["experimental", "3d", "rasterization", "performance"]
+  "tags": ["experimental", "3d", "rasterization", "performance"],
+  "coolFactor": 5
 }

--- a/apps/typegpu-docs/src/examples/simple/mesh-skinning/meta.json
+++ b/apps/typegpu-docs/src/examples/simple/mesh-skinning/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Mesh Skinning",
   "category": "simple",
-  "tags": ["3d", "animation", "experimental"],
+  "tags": ["3d", "animation"],
   "coolFactor": 7
 }

--- a/apps/typegpu-docs/src/examples/simple/mesh-skinning/meta.json
+++ b/apps/typegpu-docs/src/examples/simple/mesh-skinning/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Mesh Skinning",
   "category": "simple",
-  "tags": ["rendering", "experimental"]
+  "tags": ["3d", "animation", "experimental"],
+  "coolFactor": 7
 }


### PR DESCRIPTION
Cool factor missing -> added
`experimental` tag is no longer a thing - we auto detect that from `~unstable` usage -> removed