### PR TITLE
fix: Add missing unplugin-typegpu/rolldown-browser entrypoint

### DIFF
--- a/packages/unplugin-typegpu/src/babel.ts
+++ b/packages/unplugin-typegpu/src/babel.ts
@@ -2,7 +2,7 @@ import type { NodePath, TraverseOptions } from '@babel/traverse';
 import defu from 'defu';
 import { transpileFn } from 'tinyest-for-wgsl';
 import { FORMAT_VERSION } from 'tinyest';
-import { t } from './core/babel-types.ts';
+import * as t from '@babel/types';
 import {
   type PluginState,
   defaultOptions,

--- a/packages/unplugin-typegpu/src/core/babel-types.ts
+++ b/packages/unplugin-typegpu/src/core/babel-types.ts
@@ -1,5 +1,0 @@
-// oxlint-disable-next-line import/no-unassigned-import -- imported for side effects
-import './polyfill-process.ts';
-
-import * as t from '@babel/types';
-export { t };

--- a/packages/unplugin-typegpu/src/core/common.ts
+++ b/packages/unplugin-typegpu/src/core/common.ts
@@ -1,4 +1,4 @@
-import { t } from './babel-types.ts';
+import * as t from '@babel/types';
 import type { NodePath, TraverseOptions } from '@babel/traverse';
 import type { FilterPattern } from 'unplugin';
 import { MagicStringAST } from 'magic-string-ast';

--- a/packages/unplugin-typegpu/src/core/factory.ts
+++ b/packages/unplugin-typegpu/src/core/factory.ts
@@ -6,7 +6,7 @@ import _traverse, { type NodePath } from '@babel/traverse';
 import { FORMAT_VERSION } from 'tinyest';
 import { transpileFn } from 'tinyest-for-wgsl';
 import * as parser from '@babel/parser';
-import { t } from './babel-types.ts';
+import * as t from '@babel/types';
 import {
   defaultOptions,
   earlyPruneRegex,

--- a/packages/unplugin-typegpu/src/core/polyfill-process.ts
+++ b/packages/unplugin-typegpu/src/core/polyfill-process.ts
@@ -1,8 +1,0 @@
-// The babel plugin can be imported in a browser, which doesn't have `process` defined
-if (typeof globalThis.process === 'undefined') {
-  // oxlint-disable-next-line typescript/no-explicit-any
-  (globalThis.process as any) = {};
-}
-if (typeof globalThis.process.env === 'undefined') {
-  globalThis.process.env = {};
-}

--- a/packages/unplugin-typegpu/tsdown.config.ts
+++ b/packages/unplugin-typegpu/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     'src/esbuild.ts',
     'src/farm.ts',
     'src/rolldown.ts',
+    'src/rolldown-browser.ts',
     'src/rspack.ts',
     'src/vite.ts',
     'src/webpack.ts',


### PR DESCRIPTION
The process polyfill was not taking any effect anyway, as the order of imports can be mangled by bundlers. We can ask the users of unplugin-typegpu/babel in the browser to polyfill instead.

Tracking docs for this here: #2428 