### PR TITLE
impr: Infix dispatch handling

### DIFF
--- a/packages/typegpu/src/core/function/comptime.ts
+++ b/packages/typegpu/src/core/function/comptime.ts
@@ -2,7 +2,7 @@ import { WgslTypeError } from '../../errors.ts';
 import { setName, type TgpuNamable } from '../../shared/meta.ts';
 import { $getNameForward, $gpuCallable, $internal } from '../../shared/symbols.ts';
 import { coerceToSnippet } from '../../tgsl/generationHelpers.ts';
-import { type DualFn, isKnownAtComptime } from '../../types.ts';
+import { type DualFn, isKnownAtComptime, NormalState } from '../../types.ts';
 
 type AnyFn = (...args: never[]) => unknown;
 
@@ -48,7 +48,7 @@ export function comptime<T extends (...args: never[]) => unknown>(func: T): Tgpu
   impl.toString = () => 'comptime';
   impl[$getNameForward] = func;
   impl[$gpuCallable] = {
-    call(_ctx, args) {
+    call(ctx, args) {
       if (!args.every((s) => isKnownAtComptime(s))) {
         throw new WgslTypeError(
           `Called comptime function with runtime-known values: ${args
@@ -58,7 +58,12 @@ export function comptime<T extends (...args: never[]) => unknown>(func: T): Tgpu
         );
       }
 
-      return coerceToSnippet(func(...(args.map((s) => s.value) as never[])));
+      ctx.pushMode(new NormalState());
+      try {
+        return coerceToSnippet(func(...(args.map((s) => s.value) as never[])));
+      } finally {
+        ctx.popMode();
+      }
     },
   };
   impl.$name = (label: string) => {

--- a/packages/typegpu/src/data/dataTypes.ts
+++ b/packages/typegpu/src/data/dataTypes.ts
@@ -30,7 +30,6 @@ import type { Snippet } from './snippet.ts';
 import type { PackedData } from './vertexFormatData.ts';
 import * as wgsl from './wgslTypes.ts';
 import type { WgslComparisonSampler, WgslSampler } from './sampler.ts';
-import type { ResolutionCtx } from '../types.ts';
 import type { BaseData } from './wgslTypes.ts';
 
 /**
@@ -236,22 +235,6 @@ export type AnyConcreteData = Exclude<
 
 export const UnknownData = Symbol('UNKNOWN');
 export type UnknownData = typeof UnknownData;
-
-export class InfixDispatch {
-  readonly name: string;
-  readonly lhs: Snippet;
-  readonly operator: (ctx: ResolutionCtx, args: [lhs: Snippet, rhs: Snippet]) => Snippet;
-
-  constructor(
-    name: string,
-    lhs: Snippet,
-    operator: (ctx: ResolutionCtx, args: [lhs: Snippet, rhs: Snippet]) => Snippet,
-  ) {
-    this.name = name;
-    this.lhs = lhs;
-    this.operator = operator;
-  }
-}
 
 export class MatrixColumnsAccess {
   readonly matrix: Snippet;

--- a/packages/typegpu/src/data/index.ts
+++ b/packages/typegpu/src/data/index.ts
@@ -5,48 +5,20 @@
 // NOTE: This is a barrel file, internal files should not import things from this file
 
 import { Operator } from 'tsover-runtime';
-import { type InfixOperator, infixOperators } from '../tgsl/accessProp.ts';
 import { MatBase } from './matrix.ts';
 import { VecBase } from './vectorImpl.ts';
-
-function assignInfixOperator<T extends typeof VecBase | typeof MatBase>(
-  object: T,
-  operator: InfixOperator,
-  operatorSymbol: symbol,
-) {
-  // oxlint-disable-next-line typescript/no-explicit-any -- anything is possible
-  const proto = object.prototype as any;
-  const opImpl = infixOperators[operator] as (lhs: unknown, rhs: unknown) => unknown;
-
-  proto[operator] = function (this: unknown, other: unknown): unknown {
-    return opImpl(this, other);
-  };
-
-  proto[operatorSymbol] = (lhs: unknown, rhs: unknown): unknown => {
-    return opImpl(lhs, rhs);
-  };
-}
+import { assignInfixOperator } from '../tgsl/infixDispatch.ts';
 
 assignInfixOperator(VecBase, 'add', Operator.plus);
+assignInfixOperator(MatBase, 'add', Operator.plus);
 assignInfixOperator(VecBase, 'sub', Operator.minus);
+assignInfixOperator(MatBase, 'sub', Operator.minus);
 assignInfixOperator(VecBase, 'mul', Operator.star);
+assignInfixOperator(MatBase, 'mul', Operator.star);
 assignInfixOperator(VecBase, 'div', Operator.slash);
 assignInfixOperator(VecBase, 'mod', Operator.percent);
-assignInfixOperator(MatBase, 'add', Operator.plus);
-assignInfixOperator(MatBase, 'sub', Operator.minus);
-assignInfixOperator(MatBase, 'mul', Operator.star);
-
-// bitShift does not yet have tsover operator symbol
-{
-  // oxlint-disable-next-line typescript/no-explicit-any -- anything is possible
-  const proto = VecBase.prototype as any;
-  proto.bitShiftLeft = function (this: unknown, other: unknown) {
-    return (infixOperators.bitShiftLeft as (a: unknown, b: unknown) => unknown)(this, other);
-  };
-  proto.bitShiftRight = function (this: unknown, other: unknown) {
-    return (infixOperators.bitShiftRight as (a: unknown, b: unknown) => unknown)(this, other);
-  };
-}
+assignInfixOperator(VecBase, 'bitShiftLeft', Symbol()); // bitShift does not yet have tsover operator symbol
+assignInfixOperator(VecBase, 'bitShiftRight', Symbol()); // bitShift does not yet have tsover operator symbol
 
 export { bool, f16, f32, i32, u16, u32 } from './numeric.ts';
 export {

--- a/packages/typegpu/src/std/environment.ts
+++ b/packages/typegpu/src/std/environment.ts
@@ -1,0 +1,61 @@
+import { comptime } from '../core/function/comptime.ts';
+import { getExecMode, getResolutionCtx } from '../execMode.ts';
+import { $gpuCallable } from '../shared/symbols.ts';
+import { coerceToSnippet } from '../tgsl/generationHelpers.ts';
+import type { DualFn } from '../types.ts';
+
+const impl = (() => false) as DualFn<() => boolean>;
+impl.toString = () => 'isBeingTranspiled';
+impl[$gpuCallable] = {
+  call(_ctx, _args) {
+    return coerceToSnippet(true);
+  },
+};
+
+/**
+ * Returns `true` when the direct callee is being transpiled for GPU, otherwise `false`.
+ *
+ * @example
+ * const f = () => {
+ *   'use gpu';
+ *   return isBeingTranspiled() ? 1 : 0;
+ * };
+ *
+ * f(); // returns 0, but resolved WGSL looks like this:
+ *
+ * fn f() -> i32 {
+ *   return 1;
+ * }
+ *
+ * @note
+ * Inside `comptime`, `lazy` or `simulate`, it always returns `false`.
+ */
+export const isBeingTranspiled = impl;
+
+/**
+ * Returns `wgsl` if invoked during the resolution process; otherwise, returns `undefined`.
+ *
+ * @example
+ * const f = () => {
+ *   'use gpu';
+ *   return getTargetShaderLanguage() === 'wgsl';
+ * };
+ *
+ * f(); // returns false, but resolved WGSL looks like this:
+ *
+ * fn f() -> bool {
+ *   return true;
+ * }
+ *
+ * @note
+ * Inside `lazy`, it always returns `wgsl`.
+ * Inside `simulate`, it always returns `undefined`.
+ * Inside `comptime`, it returns `wgsl` if called during the resolution process; otherwise, `undefined`.
+ */
+export const getTargetShaderLanguage = comptime((() => {
+  const ctx = getResolutionCtx();
+  if (!ctx) {
+    return undefined;
+  }
+  return getExecMode().type !== 'simulate' ? 'wgsl' : undefined;
+}) as () => string | undefined);

--- a/packages/typegpu/src/std/index.ts
+++ b/packages/typegpu/src/std/index.ts
@@ -189,3 +189,5 @@ export { extensionEnabled } from './extensions.ts';
 export { bitcastU32toF32, bitcastU32toI32 } from './bitcast.ts';
 
 export { range } from './range.ts';
+
+export { isBeingTranspiled, getTargetShaderLanguage } from './environment.ts';

--- a/packages/typegpu/src/tgsl/accessProp.ts
+++ b/packages/typegpu/src/tgsl/accessProp.ts
@@ -1,13 +1,7 @@
 import { stitch } from '../core/resolve/stitch.ts';
 import { AutoStruct } from '../data/autoStruct.ts';
 import { EntryInputRouter } from '../core/function/entryInputRouter.ts';
-import {
-  InfixDispatch,
-  isUnstruct,
-  MatrixColumnsAccess,
-  undecorate,
-  UnknownData,
-} from '../data/dataTypes.ts';
+import { isUnstruct, MatrixColumnsAccess, undecorate, UnknownData } from '../data/dataTypes.ts';
 import { bool, f16, f32, i32, u32 } from '../data/numeric.ts';
 import { derefSnippet } from '../data/ref.ts';
 import { isSnippet, snip, type Snippet } from '../data/snippet.ts';
@@ -36,10 +30,9 @@ import {
   isWgslArray,
   isWgslStruct,
 } from '../data/wgslTypes.ts';
-import { $gpuCallable } from '../shared/symbols.ts';
-import { add, bitShiftLeft, bitShiftRight, div, mod, mul, sub } from '../std/operators.ts';
 import { isKnownAtComptime } from '../types.ts';
 import { coerceToSnippet, numericLiteralToSnippet } from './generationHelpers.ts';
+import { InfixDispatch, infixOperators, type InfixOperatorName } from './infixDispatch.ts';
 
 const infixKinds = [
   'vec2f',
@@ -58,18 +51,6 @@ const infixKinds = [
   'mat3x3f',
   'mat4x4f',
 ];
-
-export const infixOperators = {
-  add,
-  sub,
-  mul,
-  div,
-  mod,
-  bitShiftLeft,
-  bitShiftRight,
-} as const;
-
-export type InfixOperator = keyof typeof infixOperators;
 
 type SwizzleableType = 'f' | 'h' | 'i' | 'u' | 'b';
 type SwizzleLength = 1 | 2 | 3 | 4;
@@ -109,9 +90,9 @@ const swizzleLenToType: Record<SwizzleableType, Record<SwizzleLength, BaseData>>
 
 export function accessProp(target: Snippet, propName: string): Snippet | undefined {
   if (infixKinds.includes((target.dataType as BaseData).type) && propName in infixOperators) {
-    const operator = infixOperators[propName as InfixOperator];
+    const operator = infixOperators[propName as InfixOperatorName];
     return snip(
-      new InfixDispatch(propName, target, operator[$gpuCallable].call.bind(operator)),
+      new InfixDispatch(target, operator),
       UnknownData,
       /* origin */ target.origin,
       target.possibleSideEffects,
@@ -202,15 +183,12 @@ export function accessProp(target: Snippet, propName: string): Snippet | undefin
   }
 
   const propLength = propName.length;
-  if (isVec(target.dataType) && propLength >= 1 && propLength <= 4) {
-    const isXYZW = /^[xyzw]+$/.test(propName);
-    const isRGBA = /^[rgba]+$/.test(propName);
-
-    if (!isXYZW && !isRGBA) {
-      // Not a valid swizzle
-      return undefined;
-    }
-
+  if (
+    isVec(target.dataType) &&
+    propLength >= 1 &&
+    propLength <= 4 &&
+    /^[xyzw]+$|^[rgba]+$/.test(propName)
+  ) {
     const swizzleTypeChar = target.dataType.type.includes('bool')
       ? 'b'
       : (target.dataType.type[4] as SwizzleableType);

--- a/packages/typegpu/src/tgsl/infixDispatch.ts
+++ b/packages/typegpu/src/tgsl/infixDispatch.ts
@@ -1,0 +1,75 @@
+import type { MatBase } from '../data/matrix.ts';
+import { type Snippet } from '../data/snippet.ts';
+import type { VecBase } from '../data/vectorImpl.ts';
+import type { AnyMatInstance, AnyNumericVecInstance } from '../data/wgslTypes.ts';
+import { inCodegenMode } from '../execMode.ts';
+import { add, bitShiftLeft, bitShiftRight, div, mod, mul, sub } from '../std/operators.ts';
+
+export const infixOperators = {
+  add,
+  sub,
+  mul,
+  div,
+  mod,
+  bitShiftLeft,
+  bitShiftRight,
+} as const;
+
+type Numeric = number | AnyNumericVecInstance | AnyMatInstance;
+
+export type InfixOperatorName = keyof typeof infixOperators;
+export type InfixOperator = (typeof infixOperators)[InfixOperatorName];
+
+/**
+ * InfixDispatch is only used in codegen mode.
+ * `lhs` may either be Numeric or Snippet.
+ * @example
+ * const external = d.vec2u(1);
+ * const fn = () => {
+ *    'use gpu';
+ *    external.mul(2); // lhs is Numeric
+ *    d.vec2u(1).mul(2) // lhs is a snippet
+ * }
+ */
+export class InfixDispatch {
+  readonly lhs: Snippet | Numeric;
+  readonly operator: InfixOperator;
+
+  constructor(lhs: Snippet | Numeric, operator: InfixOperator) {
+    this.lhs = lhs;
+    this.operator = operator;
+  }
+}
+
+export function isInfixDispatch(o: unknown): o is InfixDispatch {
+  return o instanceof InfixDispatch;
+}
+
+/**
+ * This function is used on vec/mat prototypes.
+ * This is done in runtime in order to avoid a circular dependency.
+ */
+export function assignInfixOperator<T extends typeof VecBase | typeof MatBase>(
+  base: T,
+  operator: InfixOperatorName,
+  operatorSymbol: symbol,
+) {
+  const opImpl = infixOperators[operator];
+
+  Object.defineProperty(base.prototype, operatorSymbol, { value: opImpl });
+
+  // Returning this from a getter will work as if this was a vector/matrix's method.
+  function jsInfixDispatchFor(this: unknown, arg: unknown) {
+    // operator will perform all necessary type checks
+    return opImpl(this as never, arg as never);
+  }
+
+  Object.defineProperty(base.prototype, operator, {
+    get() {
+      if (inCodegenMode()) {
+        return new InfixDispatch(this, opImpl);
+      }
+      return jsInfixDispatchFor;
+    },
+  });
+}

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -1,7 +1,7 @@
 import * as tinyest from 'tinyest';
 import { stitch } from '../core/resolve/stitch.ts';
 import { arrayOf } from '../data/array.ts';
-import { type AnyData, InfixDispatch, UnknownData, unptr } from '../data/dataTypes.ts';
+import { type AnyData, UnknownData, unptr } from '../data/dataTypes.ts';
 import { bool, i32, u32 } from '../data/numeric.ts';
 import { vec2u, vec3u, vec4u } from '../data/vector.ts';
 import {
@@ -47,6 +47,7 @@ import { stringifyNode } from '../shared/tseynit.ts';
 import type { FunctionDefinitionOptions } from './shaderGenerator_members.ts';
 import { getAttributesString } from '../data/attributes.ts';
 import { validSelectBranchTypes } from '../std/boolean.ts';
+import { isInfixDispatch } from './infixDispatch.ts';
 
 const { NodeTypeCatalog: NODE } = tinyest;
 
@@ -585,15 +586,16 @@ ${this.ctx.pre}}`;
         );
       }
 
-      if (callee.value instanceof InfixDispatch) {
-        // Infix operator dispatch.
+      if (isInfixDispatch(callee.value)) {
         if (!argNodes[0]) {
           throw new WgslTypeError(
-            `An infix operator '${callee.value.name}' was called without any arguments`,
+            `An infix operator '${getName(callee.value.operator)}' was called without any arguments`,
           );
         }
+        const lhs = coerceToSnippet(callee.value.lhs);
         const rhs = this._expression(argNodes[0]);
-        return callee.value.operator(this.ctx, [callee.value.lhs, rhs]);
+        const callable = callee.value.operator[$gpuCallable];
+        return callable.call(this.ctx, [lhs, rhs]);
       }
 
       if ((callee.value === _ref || callee.value === unroll) && argNodes[0]) {

--- a/packages/typegpu/tests/std/environment.test.ts
+++ b/packages/typegpu/tests/std/environment.test.ts
@@ -1,0 +1,172 @@
+import { it } from 'typegpu-testing-utility';
+import { expect, describe } from 'vitest';
+
+import tgpu, { d, std } from 'typegpu';
+
+describe('isBeingTranspiled', () => {
+  it('returns false top level', () => {
+    expect(std.isBeingTranspiled()).toBe(false);
+  });
+
+  it('returns true during function resolution', () => {
+    const f = () => {
+      'use gpu';
+      if (std.isBeingTranspiled()) {
+        return 7;
+      } else {
+        return -7;
+      }
+    };
+
+    expect(tgpu.resolve([f])).toMatchInlineSnapshot(`
+      "fn f() -> i32 {
+        {
+          return 7;
+        }
+      }"
+    `);
+  });
+
+  it('returns false inside comptime', () => {
+    const checkTranspilation = tgpu.comptime(std.isBeingTranspiled);
+    expect(checkTranspilation()).toBe(false);
+
+    const f = () => {
+      'use gpu';
+      const _transpilation = checkTranspilation();
+    };
+
+    expect(tgpu.resolve([f])).toMatchInlineSnapshot(`
+      "fn f() {
+        const _transpilation = false;
+      }"
+    `);
+
+    expect(checkTranspilation()).toBe(false);
+  });
+
+  it('returns false inside lazy', () => {
+    const checkTranspilation = tgpu.lazy(std.isBeingTranspiled);
+
+    const f = () => {
+      'use gpu';
+      const _transpilation = checkTranspilation.$;
+    };
+
+    expect(tgpu.resolve([f])).toMatchInlineSnapshot(`
+      "fn f() {
+        const _transpilation = false;
+      }"
+    `);
+  });
+
+  it('returns false inside simulate', () => {
+    const counter = tgpu.privateVar(d.u32, 0);
+
+    const result = tgpu['~unstable'].simulate(() => {
+      if (!std.isBeingTranspiled()) {
+        counter.$ += 1;
+      }
+      return counter.$;
+    });
+
+    expect(result.value).toBe(1);
+  });
+
+  it('correctly branches during js execution', () => {
+    const f = () => {
+      'use gpu';
+      if (std.isBeingTranspiled()) {
+        return 7;
+      } else {
+        return -7;
+      }
+    };
+
+    expect(f()).toBe(-7);
+  });
+});
+
+describe('getTargetShaderLanguage', () => {
+  it('returns undefined top level', () => {
+    expect(std.getTargetShaderLanguage()).toBe(undefined);
+  });
+
+  it('returns `wgsl` during function resolution', () => {
+    const f = () => {
+      'use gpu';
+      if (std.getTargetShaderLanguage() === 'wgsl') {
+        return 7;
+      } else {
+        return -7;
+      }
+    };
+
+    expect(tgpu.resolve([f])).toMatchInlineSnapshot(`
+      "fn f() -> i32 {
+        {
+          return 7;
+        }
+      }"
+    `);
+  });
+
+  it('returns undefined inside comptime outside of resolution and `wgsl` during function resolution', () => {
+    const checkTranspilation = tgpu.comptime(std.getTargetShaderLanguage);
+    expect(checkTranspilation()).toBe(undefined);
+
+    const f = () => {
+      'use gpu';
+      const _transpilation = checkTranspilation() === 'wgsl';
+    };
+
+    expect(tgpu.resolve([f])).toMatchInlineSnapshot(`
+      "fn f() {
+        const _transpilation = true;
+      }"
+    `);
+
+    expect(checkTranspilation()).toBe(undefined);
+  });
+
+  it('returns `wgsl` inside lazy', () => {
+    const checkTranspilation = tgpu.lazy(std.getTargetShaderLanguage);
+
+    const f = () => {
+      'use gpu';
+      const _transpilation = checkTranspilation.$ === 'wgsl';
+    };
+
+    expect(tgpu.resolve([f])).toMatchInlineSnapshot(`
+      "fn f() {
+        const _transpilation = true;
+      }"
+    `);
+  });
+
+  it('returns undefined inside simulate', () => {
+    const counter = tgpu.privateVar(d.u32, 0);
+
+    const result = tgpu['~unstable'].simulate(() => {
+      if (std.getTargetShaderLanguage() !== 'wgsl') {
+        counter.$ += 1;
+      }
+      return counter.$;
+    });
+
+    expect(result.value).toBe(1);
+  });
+
+  it('correctly branches during js execution', () => {
+    const f = () => {
+      'use gpu';
+      if (std.getTargetShaderLanguage() === 'wgsl') {
+        return 7;
+      } else {
+        return -7;
+      }
+    };
+
+    expect(f()).toBe(-7);
+  });
+});

--- a/packages/typegpu/tests/swizzleMixedValidation.test.ts
+++ b/packages/typegpu/tests/swizzleMixedValidation.test.ts
@@ -71,7 +71,7 @@ describe('Mixed swizzle validation', () => {
         return mixed;
       };
 
-      // The resolution should fail because accessProp returns undefined for mixed swizzles
+      // The resolution should fail because accessProp won't match any prop and will return undefined
       expect(() => tgpu.resolve([main])).toThrowErrorMatchingInlineSnapshot(`
         [Error: Resolution of the following tree failed:
         - <root>

--- a/packages/typegpu/tests/tgsl/infixOperators.test.ts
+++ b/packages/typegpu/tests/tgsl/infixOperators.test.ts
@@ -3,7 +3,7 @@ import tgpu, { d } from '../../src/index.js';
 import { it } from 'typegpu-testing-utility';
 
 describe('wgslGenerator', () => {
-  it('resolves add infix operator', () => {
+  it('resolves add infix operator in comptime', () => {
     const testFn = tgpu.fn([])(() => {
       const v1 = d.vec4f().add(1);
       const v2 = d.vec3f(2).add(d.vec3f(1, 2, 3));
@@ -23,7 +23,7 @@ describe('wgslGenerator', () => {
     `);
   });
 
-  it('resolves sub infix operator', () => {
+  it('resolves sub infix operator in comptime', () => {
     const testFn = tgpu.fn([])(() => {
       const v1 = d.vec4f().sub(1);
       const v2 = d.vec3f().sub(d.vec3f(1, 2, 3));
@@ -43,7 +43,7 @@ describe('wgslGenerator', () => {
     `);
   });
 
-  it('resolves mul infix operator', () => {
+  it('resolves mul infix operator in comptime', () => {
     const testFn = tgpu.fn([])(() => {
       const v1 = d.vec2f(2).mul(3);
       const v2 = d.vec3f(2).mul(d.vec3f(2, 3, 4));
@@ -70,53 +70,7 @@ describe('wgslGenerator', () => {
     `);
   });
 
-  it('resolves mul infix operator on a function return value', () => {
-    const getVec = tgpu.fn(
-      [],
-      d.vec3f,
-    )(() => {
-      'use gpu';
-      return d.vec3f(1, 2, 3);
-    });
-
-    const testFn = tgpu.fn([])(() => {
-      'use gpu';
-      const v1 = getVec().mul(getVec());
-    });
-
-    expect(tgpu.resolve([testFn])).toMatchInlineSnapshot(`
-      "fn getVec() -> vec3f {
-        return vec3f(1, 2, 3);
-      }
-
-      fn testFn() {
-        let v1 = (getVec() * getVec());
-      }"
-    `);
-  });
-
-  it('resolves mul infix operator on a struct property', () => {
-    const Struct = d.struct({ vec: d.vec3f });
-
-    const testFn = tgpu.fn([])(() => {
-      'use gpu';
-      const s = Struct({ vec: d.vec3f() });
-      const v1 = s.vec.mul(s.vec);
-    });
-
-    expect(tgpu.resolve([testFn])).toMatchInlineSnapshot(`
-      "struct Struct {
-        vec: vec3f,
-      }
-
-      fn testFn() {
-        let s = Struct(vec3f());
-        let v1 = (s.vec * s.vec);
-      }"
-    `);
-  });
-
-  it('resolves div infix operator', () => {
+  it('resolves div infix operator in comptime', () => {
     const testFn = tgpu.fn([])(() => {
       const v1 = d.vec4f(1).div(2);
       const v2 = d.vec3f(6).div(d.vec3f(1, 2, 3));
@@ -132,7 +86,7 @@ describe('wgslGenerator', () => {
     `);
   });
 
-  it('resolves mod infix operator', () => {
+  it('resolves mod infix operator in comptime', () => {
     const testFn = tgpu.fn([])(() => {
       const v1 = d.vec4f(11).mod(2);
       const v2 = d.vec3f(13.5).mod(d.vec3f(1, 2, 10));
@@ -146,39 +100,138 @@ describe('wgslGenerator', () => {
     `);
   });
 
-  it('resolves add infix operator on uniform vector', ({ root }) => {
+  it('resolves mul infix operator on a runtime variable', () => {
+    const testFn = () => {
+      'use gpu';
+      const v1 = d.vec2f(1, 2);
+      return v1.mul(2).mul(3);
+    };
+
+    expect(testFn()).toStrictEqual(d.vec2f(6, 12));
+    expect(tgpu.resolve([testFn])).toMatchInlineSnapshot(`
+      "fn testFn() -> vec2f {
+        let v1 = vec2f(1, 2);
+        return ((v1 * 2f) * 3f);
+      }"
+    `);
+  });
+
+  it('resolves mul infix operator on a function return value', () => {
+    const getVec = () => {
+      'use gpu';
+      return d.vec3f(1, 2, 3);
+    };
+
+    const testFn = () => {
+      'use gpu';
+      return getVec().mul(getVec()).mul(2);
+    };
+
+    expect(testFn()).toStrictEqual(d.vec3f(2, 8, 18));
+    expect(tgpu.resolve([testFn])).toMatchInlineSnapshot(`
+      "fn getVec() -> vec3f {
+        return vec3f(1, 2, 3);
+      }
+
+      fn testFn() -> vec3f {
+        return ((getVec() * getVec()) * 2f);
+      }"
+    `);
+  });
+
+  it('resolves mul infix operator on a struct property', () => {
+    const Struct = d.struct({ vec: d.vec3f });
+
+    const testFn = () => {
+      'use gpu';
+      const s = Struct({ vec: d.vec3f(2) });
+      return s.vec.mul(s.vec).mul(2);
+    };
+
+    expect(testFn()).toStrictEqual(d.vec3f(8));
+    expect(tgpu.resolve([testFn])).toMatchInlineSnapshot(`
+      "struct Struct {
+        vec: vec3f,
+      }
+
+      fn testFn() -> vec3f {
+        let s = Struct(vec3f(2));
+        return ((s.vec * s.vec) * 2f);
+      }"
+    `);
+  });
+
+  it('resolves mul infix operator on uniform vector', ({ root }) => {
     const fooUniform = root.createUniform(d.vec3f);
-    const barUniform = root.createUniform(d.vec3f);
 
     const testFn = tgpu.fn([])(() => {
-      const v1 = fooUniform.$.add(2); // lhs
-      const v2 = d.vec3f(1, 2, 3).add(barUniform.$); // rhs
-      const v3 = fooUniform.$.add(barUniform.$);
+      const v1 = fooUniform.$.mul(2); // lhs
+      const v2 = d.vec3f(1, 2, 3).mul(fooUniform.$); // rhs
+      const v3 = fooUniform.$.mul(fooUniform.$).mul(2);
     });
 
     expect(tgpu.resolve([testFn])).toMatchInlineSnapshot(`
       "@group(0) @binding(0) var<uniform> fooUniform: vec3f;
 
-      @group(0) @binding(1) var<uniform> barUniform: vec3f;
-
       fn testFn() {
-        let v1 = (fooUniform + 2f);
-        let v2 = (vec3f(1, 2, 3) + barUniform);
-        let v3 = (fooUniform + barUniform);
+        let v1 = (fooUniform * 2f);
+        let v2 = (vec3f(1, 2, 3) * fooUniform);
+        let v3 = ((fooUniform * fooUniform) * 2f);
       }"
     `);
   });
 
-  it('precomputes adds on known values', () => {
-    const testFn = tgpu.fn([])(() => {
-      const v1 = d.vec3f(1, 2, 3).add(5);
-      const v2 = d.vec3f(1, 2, 3).add(d.vec3f(3, 2, 1));
-    });
+  it('resolves mul infix operator on external', () => {
+    const v = d.vec3f(2);
 
+    const testFn = () => {
+      'use gpu';
+      const v1 = v.mul(2); // lhs
+      const v2 = d.vec3f(3).mul(v); // rhs
+      const v3 = v.mul(v).mul(4);
+      return v1.add(v2).add(v3);
+    };
+
+    expect(testFn()).toStrictEqual(d.vec3f(26));
     expect(tgpu.resolve([testFn])).toMatchInlineSnapshot(`
-      "fn testFn() {
-        let v1 = vec3f(6, 7, 8);
-        let v2 = vec3f(4);
+      "fn testFn() -> vec3f {
+        let v1 = vec3f(4);
+        let v2 = vec3f(6);
+        let v3 = vec3f(16);
+        return ((v1 + v2) + v3);
+      }"
+    `);
+  });
+
+  it('resolves mul infix operator on accessors', () => {
+    const vAccess = tgpu.accessor(d.vec2i, d.vec2i(1, 2));
+
+    const main = () => {
+      'use gpu';
+      return vAccess.$.mul(2).mul(3);
+    };
+
+    // expect(main()).toMatchInlineSnapshot(d.vec2i(6, 12));
+    expect(tgpu.resolve([main])).toMatchInlineSnapshot(`
+      "fn main() -> vec2i {
+        return vec2i(6, 12);
+      }"
+    `);
+  });
+
+  it('correctly casts types', () => {
+    const main = () => {
+      'use gpu';
+      const a = d.u32(1);
+      const b = d.vec3f(2);
+      return b.mul(a);
+    };
+
+    expect(tgpu.resolve([main])).toMatchInlineSnapshot(`
+      "fn main() -> vec3f {
+        const a = 1u;
+        let b = vec3f(2);
+        return (b * f32(a));
       }"
     `);
   });


### PR DESCRIPTION
Prerequisite for #2425

This PR changes the way infix dispach is handled in preparation for externals like `{ 'vec' : { 'mul': /* getter */ vec.mul } }`