### PR TITLE
fix: Struct fields not suggested

### DIFF
--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -836,12 +836,12 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
   createBuffer<TData extends AnyData>(
     typeSchema: ValidateBufferSchema<TData>,
     // NoInfer is there to infer the schema type just based on the first parameter
-    initializer: (buffer: TgpuBuffer<NoInfer<TData>>) => void,
+    initial?: InferInput<NoInfer<TData>>,
   ): TgpuBuffer<TData>;
   createBuffer<TData extends AnyData>(
     typeSchema: ValidateBufferSchema<TData>,
     // NoInfer is there to infer the schema type just based on the first parameter
-    initial?: InferInput<NoInfer<TData>>,
+    initializer: (buffer: TgpuBuffer<NoInfer<TData>>) => void,
   ): TgpuBuffer<TData>;
   createBuffer<TData extends AnyData>(
     typeSchema: ValidateBufferSchema<TData>,

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -831,7 +831,7 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
    * Typed wrapper around a GPUBuffer.
    *
    * @param typeSchema The type of data that this buffer will hold.
-   * @param initial The initial value of the buffer. (optional)
+   * @param initial Either initial value of the buffer, or an initializer to execute on the mapped buffer. (optional)
    */
   createBuffer<TData extends AnyData>(
     typeSchema: ValidateBufferSchema<TData>,
@@ -860,7 +860,7 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
    * use {@link TgpuRoot.createBuffer}.
    *
    * @param typeSchema The type of data that this buffer will hold.
-   * @param initial The initial value of the buffer. (optional)
+   * @param initial Either initial value of the buffer, or an initializer to execute on the mapped buffer. (optional)
    */
   createUniform<TData extends AnyWgslData>(
     typeSchema: ValidateUniformSchema<TData>,
@@ -888,7 +888,7 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
    * use {@link TgpuRoot.createBuffer}.
    *
    * @param typeSchema The type of data that this buffer will hold.
-   * @param initial The initial value of the buffer. (optional)
+   * @param initial Either initial value of the buffer, or an initializer to execute on the mapped buffer. (optional)
    */
   createMutable<TData extends AnyWgslData>(
     typeSchema: ValidateStorageSchema<TData>,
@@ -916,7 +916,7 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
    * use {@link TgpuRoot.createBuffer}.
    *
    * @param typeSchema The type of data that this buffer will hold.
-   * @param initial The initial value of the buffer. (optional)
+   * @param initial Either initial value of the buffer, or an initializer to execute on the mapped buffer. (optional)
    */
   createReadonly<TData extends AnyWgslData>(
     typeSchema: ValidateStorageSchema<TData>,

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -836,16 +836,6 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
   createBuffer<TData extends AnyData>(
     typeSchema: ValidateBufferSchema<TData>,
     // NoInfer is there to infer the schema type just based on the first parameter
-    initial?: InferInput<NoInfer<TData>>,
-  ): TgpuBuffer<TData>;
-  createBuffer<TData extends AnyData>(
-    typeSchema: ValidateBufferSchema<TData>,
-    // NoInfer is there to infer the schema type just based on the first parameter
-    initializer: (buffer: TgpuBuffer<NoInfer<TData>>) => void,
-  ): TgpuBuffer<TData>;
-  createBuffer<TData extends AnyData>(
-    typeSchema: ValidateBufferSchema<TData>,
-    // NoInfer is there to infer the schema type just based on the first parameter
     initial?: ((buffer: TgpuBuffer<NoInfer<TData>>) => void) | InferInput<NoInfer<TData>>,
   ): TgpuBuffer<TData>;
 
@@ -874,15 +864,6 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
   createUniform<TData extends AnyWgslData>(
     typeSchema: ValidateUniformSchema<TData>,
     // NoInfer is there to infer the schema type just based on the first parameter
-    initial?: InferInput<NoInfer<TData>>,
-  ): TgpuUniform<TData>;
-  createUniform<TData extends AnyWgslData>(
-    typeSchema: ValidateUniformSchema<TData>,
-    initializer: (buffer: TgpuBuffer<NoInfer<TData>>) => void,
-  ): TgpuUniform<TData>;
-  createUniform<TData extends AnyWgslData>(
-    typeSchema: ValidateUniformSchema<TData>,
-    // NoInfer is there to infer the schema type just based on the first parameter
     initial?: ((buffer: TgpuBuffer<NoInfer<TData>>) => void) | InferInput<NoInfer<TData>>,
   ): TgpuUniform<TData>;
 
@@ -910,15 +891,6 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
   createMutable<TData extends AnyWgslData>(
     typeSchema: ValidateStorageSchema<TData>,
     // NoInfer is there to infer the schema type just based on the first parameter
-    initial?: InferInput<NoInfer<TData>>,
-  ): TgpuMutable<TData>;
-  createMutable<TData extends AnyWgslData>(
-    typeSchema: ValidateStorageSchema<TData>,
-    initializer: (buffer: TgpuBuffer<NoInfer<TData>>) => void,
-  ): TgpuMutable<TData>;
-  createMutable<TData extends AnyWgslData>(
-    typeSchema: ValidateStorageSchema<TData>,
-    // NoInfer is there to infer the schema type just based on the first parameter
     initial?: ((buffer: TgpuBuffer<NoInfer<TData>>) => void) | InferInput<NoInfer<TData>>,
   ): TgpuMutable<TData>;
 
@@ -943,15 +915,6 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
    * @param typeSchema The type of data that this buffer will hold.
    * @param initial The initial value of the buffer. (optional)
    */
-  createReadonly<TData extends AnyWgslData>(
-    typeSchema: ValidateStorageSchema<TData>,
-    // NoInfer is there to infer the schema type just based on the first parameter
-    initial?: InferInput<NoInfer<TData>>,
-  ): TgpuReadonly<TData>;
-  createReadonly<TData extends AnyWgslData>(
-    typeSchema: ValidateStorageSchema<TData>,
-    initializer: (buffer: TgpuBuffer<NoInfer<TData>>) => void,
-  ): TgpuReadonly<TData>;
   createReadonly<TData extends AnyWgslData>(
     typeSchema: ValidateStorageSchema<TData>,
     // NoInfer is there to infer the schema type just based on the first parameter

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -839,6 +839,7 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
     initial?: ((buffer: TgpuBuffer<NoInfer<TData>>) => void) | InferInput<NoInfer<TData>>,
   ): TgpuBuffer<TData>;
 
+  // This is a separate overload so that LSP does not hint `destroy()` etc when initializing with a struct.
   /**
    * Allocates memory on the GPU, allows passing data between host and shader.
    *
@@ -867,6 +868,7 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
     initial?: ((buffer: TgpuBuffer<NoInfer<TData>>) => void) | InferInput<NoInfer<TData>>,
   ): TgpuUniform<TData>;
 
+  // This is a separate overload so that LSP does not hint `destroy()` etc when initializing with a struct.
   /**
    * Allocates memory on the GPU, allows passing data between host and shader.
    * Read-only on the GPU, optimized for small data. For a general-purpose buffer,
@@ -894,6 +896,7 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
     initial?: ((buffer: TgpuBuffer<NoInfer<TData>>) => void) | InferInput<NoInfer<TData>>,
   ): TgpuMutable<TData>;
 
+  // This is a separate overload so that LSP does not hint `destroy()` etc when initializing with a struct.
   /**
    * Allocates memory on the GPU, allows passing data between host and shader.
    * Can be mutated in-place on the GPU. For a general-purpose buffer,
@@ -921,6 +924,7 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
     initial?: ((buffer: TgpuBuffer<NoInfer<TData>>) => void) | InferInput<NoInfer<TData>>,
   ): TgpuReadonly<TData>;
 
+  // This is a separate overload so that LSP does not hint `destroy()` etc when initializing with a struct.
   /**
    * Allocates memory on the GPU, allows passing data between host and shader.
    * Read-only on the GPU, optimized for large data. For a general-purpose buffer,

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -873,12 +873,12 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
    */
   createUniform<TData extends AnyWgslData>(
     typeSchema: ValidateUniformSchema<TData>,
-    initializer: (buffer: TgpuBuffer<NoInfer<TData>>) => void,
+    // NoInfer is there to infer the schema type just based on the first parameter
+    initial?: InferInput<NoInfer<TData>>,
   ): TgpuUniform<TData>;
   createUniform<TData extends AnyWgslData>(
     typeSchema: ValidateUniformSchema<TData>,
-    // NoInfer is there to infer the schema type just based on the first parameter
-    initial?: InferInput<NoInfer<TData>>,
+    initializer: (buffer: TgpuBuffer<NoInfer<TData>>) => void,
   ): TgpuUniform<TData>;
   createUniform<TData extends AnyWgslData>(
     typeSchema: ValidateUniformSchema<TData>,
@@ -909,12 +909,12 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
    */
   createMutable<TData extends AnyWgslData>(
     typeSchema: ValidateStorageSchema<TData>,
-    initializer: (buffer: TgpuBuffer<NoInfer<TData>>) => void,
+    // NoInfer is there to infer the schema type just based on the first parameter
+    initial?: InferInput<NoInfer<TData>>,
   ): TgpuMutable<TData>;
   createMutable<TData extends AnyWgslData>(
     typeSchema: ValidateStorageSchema<TData>,
-    // NoInfer is there to infer the schema type just based on the first parameter
-    initial?: InferInput<NoInfer<TData>>,
+    initializer: (buffer: TgpuBuffer<NoInfer<TData>>) => void,
   ): TgpuMutable<TData>;
   createMutable<TData extends AnyWgslData>(
     typeSchema: ValidateStorageSchema<TData>,
@@ -945,12 +945,12 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
    */
   createReadonly<TData extends AnyWgslData>(
     typeSchema: ValidateStorageSchema<TData>,
-    initializer: (buffer: TgpuBuffer<NoInfer<TData>>) => void,
+    // NoInfer is there to infer the schema type just based on the first parameter
+    initial?: InferInput<NoInfer<TData>>,
   ): TgpuReadonly<TData>;
   createReadonly<TData extends AnyWgslData>(
     typeSchema: ValidateStorageSchema<TData>,
-    // NoInfer is there to infer the schema type just based on the first parameter
-    initial?: InferInput<NoInfer<TData>>,
+    initializer: (buffer: TgpuBuffer<NoInfer<TData>>) => void,
   ): TgpuReadonly<TData>;
   createReadonly<TData extends AnyWgslData>(
     typeSchema: ValidateStorageSchema<TData>,

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -990,6 +990,18 @@ describe('TgpuBuffer (InferInput)', () => {
       Array(d.sizeOf(Schema) - countLayout.offset).fill(0),
     );
   });
+
+  it('hints initial struct props in uniforms', ({ root }) => {
+    const Boid = d.struct({ id: d.u32, prop: d.vec2u });
+    attest(() =>
+      root.createBuffer(Boid, {
+        // @ts-expect-error
+        '': undefined,
+      }),
+    ).completions({
+      '': ['id', 'prop'],
+    });
+  });
 });
 
 describe('TgpuBuffer (.patch() with flexible inputs)', () => {

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -727,7 +727,7 @@ describe('TgpuBuffer', () => {
 
     // @ts-expect-error: boolean is not allowed in buffer schemas
     attest(root.createBuffer(boolSchema)).type.errors.snap(
-      "No overload matches this call.Overload 1 of 4, '(typeSchema: \"(Error) in struct property 'b' — Bool is not host-shareable, use U32 or I32 instead\", initial?: InferInput<NoInfer<WgslStruct<{ a: U32; b: Bool; }>>> | undefined): TgpuBuffer<...>', gave the following error.Argument of type 'WgslStruct<{ a: U32; b: Bool; }>' is not assignable to parameter of type '\"(Error) in struct property 'b' — Bool is not host-shareable, use U32 or I32 instead\"'.\nOverload 2 of 4, '(typeSchema: \"(Error) in struct property 'b' — Bool is not host-shareable, use U32 or I32 instead\", initial?: InferInput<NoInfer<WgslStruct<{ a: U32; b: Bool; }>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuBuffer<...>', gave the following error.Argument of type 'WgslStruct<{ a: U32; b: Bool; }>' is not assignable to parameter of type '\"(Error) in struct property 'b' — Bool is not host-shareable, use U32 or I32 instead\"'.",
+      "Argument of type 'WgslStruct<{ a: U32; b: Bool; }>' is not assignable to parameter of type '\"(Error) in struct property 'b' — Bool is not host-shareable, use U32 or I32 instead\"'.",
     );
 
     const nestedBoolSchema = d.struct({
@@ -742,8 +742,7 @@ describe('TgpuBuffer', () => {
 
     // @ts-expect-error: boolean is not allowed in buffer schemas
     attest(root.createBuffer(nestedBoolSchema)).type.errors.snap(
-      `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) in struct property 'b' — in struct property 'd' — in struct property 'e' — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ a: U32; b: WgslStruct<...>; }>>> | undefined): TgpuBuffer<...>', gave the following error.Argument of type 'WgslStruct<{ a: U32; b: WgslStruct<{ c: F32; d: WgslStruct<{ e: Bool; }>; }>; }>' is not assignable to parameter of type '"(Error) in struct property 'b' — in struct property 'd' — in struct property 'e' — Bool is not host-shareable, use U32 or I32 instead"'.
-Overload 2 of 4, '(typeSchema: "(Error) in struct property 'b' — in struct property 'd' — in struct property 'e' — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ a: U32; b: WgslStruct<...>; }>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuBuffer<...>', gave the following error.Argument of type 'WgslStruct<{ a: U32; b: WgslStruct<{ c: F32; d: WgslStruct<{ e: Bool; }>; }>; }>' is not assignable to parameter of type '"(Error) in struct property 'b' — in struct property 'd' — in struct property 'e' — Bool is not host-shareable, use U32 or I32 instead"'.`,
+      "Argument of type 'WgslStruct<{ a: U32; b: WgslStruct<{ c: F32; d: WgslStruct<{ e: Bool; }>; }>; }>' is not assignable to parameter of type '\"(Error) in struct property 'b' — in struct property 'd' — in struct property 'e' — Bool is not host-shareable, use U32 or I32 instead\"'.",
     );
   });
 
@@ -760,8 +759,7 @@ Overload 2 of 4, '(typeSchema: "(Error) in struct property 'b' — in struct pro
 
     // @ts-expect-error
     attest(root.createBuffer(notFine)).type.errors.snap(
-      `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) in struct property 'a' — U16 is only usable inside arrays for index buffers, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ a: U16; b: U32; }>>> | undefined): TgpuBuffer<...>', gave the following error.Argument of type 'WgslStruct<{ a: U16; b: U32; }>' is not assignable to parameter of type '"(Error) in struct property 'a' — U16 is only usable inside arrays for index buffers, use U32 or I32 instead"'.
-Overload 2 of 4, '(typeSchema: "(Error) in struct property 'a' — U16 is only usable inside arrays for index buffers, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ a: U16; b: U32; }>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuBuffer<...>', gave the following error.Argument of type 'WgslStruct<{ a: U16; b: U32; }>' is not assignable to parameter of type '"(Error) in struct property 'a' — U16 is only usable inside arrays for index buffers, use U32 or I32 instead"'.`,
+      "Argument of type 'WgslStruct<{ a: U16; b: U32; }>' is not assignable to parameter of type '\"(Error) in struct property 'a' — U16 is only usable inside arrays for index buffers, use U32 or I32 instead\"'.",
     );
 
     const alsoNotFine = d.struct({
@@ -772,8 +770,7 @@ Overload 2 of 4, '(typeSchema: "(Error) in struct property 'a' — U16 is only u
 
     // @ts-expect-error
     attest(root.createBuffer(alsoNotFine)).type.errors.snap(
-      `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) in struct property 'b' — in array element — U16 is only usable inside arrays for index buffers, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ a: U32; b: WgslArray<...>; c: F32; }>>> | undefined): TgpuBuffer<...>', gave the following error.Argument of type 'WgslStruct<{ a: U32; b: WgslArray<U16>; c: F32; }>' is not assignable to parameter of type '"(Error) in struct property 'b' — in array element — U16 is only usable inside arrays for index buffers, use U32 or I32 instead"'.
-Overload 2 of 4, '(typeSchema: "(Error) in struct property 'b' — in array element — U16 is only usable inside arrays for index buffers, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ a: U32; b: WgslArray<...>; c: F32; }>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuBuffer<...>', gave the following error.Argument of type 'WgslStruct<{ a: U32; b: WgslArray<U16>; c: F32; }>' is not assignable to parameter of type '"(Error) in struct property 'b' — in array element — U16 is only usable inside arrays for index buffers, use U32 or I32 instead"'.`,
+      "Argument of type 'WgslStruct<{ a: U32; b: WgslArray<U16>; c: F32; }>' is not assignable to parameter of type '\"(Error) in struct property 'b' — in array element — U16 is only usable inside arrays for index buffers, use U32 or I32 instead\"'.",
     );
   });
 

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -988,7 +988,7 @@ describe('TgpuBuffer (InferInput)', () => {
     );
   });
 
-  it('hints initial struct props in uniforms', ({ root }) => {
+  it('hints initial struct props in buffers', ({ root }) => {
     const Boid = d.struct({ id: d.u32, prop: d.vec2u });
     attest(() =>
       root.createBuffer(Boid, {

--- a/packages/typegpu/tests/bufferShorthands.test.ts
+++ b/packages/typegpu/tests/bufferShorthands.test.ts
@@ -35,20 +35,17 @@ describe('root.createMutable', () => {
   it('does not accept non-host-shareable schemas', ({ root }) => {
     // @ts-expect-error: bool is not allowed in mutable schemas
     attest(() => root.createMutable(d.bool)).type.errors.snap(
-      `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<Bool>> | undefined): TgpuMutable<Bool>', gave the following error.Argument of type 'Bool' is not assignable to parameter of type '"(Error) Bool is not host-shareable, use U32 or I32 instead"'.
-Overload 2 of 4, '(typeSchema: "(Error) Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<Bool>> | ((buffer: TgpuBuffer<NoInfer<Bool>>) => void) | undefined): TgpuMutable<...>', gave the following error.Argument of type 'Bool' is not assignable to parameter of type '"(Error) Bool is not host-shareable, use U32 or I32 instead"'.`,
+      "Argument of type 'Bool' is not assignable to parameter of type '\"(Error) Bool is not host-shareable, use U32 or I32 instead\"'.",
     );
 
     // @ts-expect-error: bool is not allowed in mutable schemas
     attest(() => root.createMutable(d.arrayOf(d.bool, 16))).type.errors.snap(
-      `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) in array element — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslArray<Bool>>> | undefined): TgpuMutable<...>', gave the following error.Argument of type 'WgslArray<Bool>' is not assignable to parameter of type '"(Error) in array element — Bool is not host-shareable, use U32 or I32 instead"'.
-Overload 2 of 4, '(typeSchema: "(Error) in array element — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslArray<Bool>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuMutable<...>', gave the following error.Argument of type 'WgslArray<Bool>' is not assignable to parameter of type '"(Error) in array element — Bool is not host-shareable, use U32 or I32 instead"'.`,
+      "Argument of type 'WgslArray<Bool>' is not assignable to parameter of type '\"(Error) in array element — Bool is not host-shareable, use U32 or I32 instead\"'.",
     );
 
     // @ts-expect-error: bool is not allowed in mutable schemas
     attest(() => root.createMutable(d.struct({ foo: d.bool }))).type.errors.snap(
-      `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ foo: Bool; }>>> | undefined): TgpuMutable<...>', gave the following error.Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead"'.
-Overload 2 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ foo: Bool; }>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuMutable<...>', gave the following error.Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead"'.`,
+      "Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '\"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead\"'.",
     );
   });
 
@@ -62,6 +59,18 @@ Overload 2 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not
     ).completions({
       '': ['id', 'prop'],
     });
+  });
+
+  it('auto types buffer on mapped initialized in mutable', ({ root }) => {
+    const Entry = d.struct({
+      id: d.u32,
+      values: d.vec3f,
+    });
+
+    () =>
+      root.createMutable(d.arrayOf(Entry, 2), (mappedBuffer) => {
+        mappedBuffer.write([{ id: 1, values: d.vec3f() }]);
+      });
   });
 });
 
@@ -89,20 +98,17 @@ describe('root.createReadonly', () => {
   it('does not accept non-host-shareable schemas', ({ root }) => {
     // @ts-expect-error: bool is not allowed in readonly schemas
     attest(() => root.createReadonly(d.bool)).type.errors.snap(
-      `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<Bool>> | undefined): TgpuReadonly<Bool>', gave the following error.Argument of type 'Bool' is not assignable to parameter of type '"(Error) Bool is not host-shareable, use U32 or I32 instead"'.
-Overload 2 of 4, '(typeSchema: "(Error) Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<Bool>> | ((buffer: TgpuBuffer<NoInfer<Bool>>) => void) | undefined): TgpuReadonly<...>', gave the following error.Argument of type 'Bool' is not assignable to parameter of type '"(Error) Bool is not host-shareable, use U32 or I32 instead"'.`,
+      "Argument of type 'Bool' is not assignable to parameter of type '\"(Error) Bool is not host-shareable, use U32 or I32 instead\"'.",
     );
 
     // @ts-expect-error: bool is not allowed in readonly schemas
     attest(() => root.createReadonly(d.arrayOf(d.bool, 16))).type.errors.snap(
-      `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) in array element — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslArray<Bool>>> | undefined): TgpuReadonly<...>', gave the following error.Argument of type 'WgslArray<Bool>' is not assignable to parameter of type '"(Error) in array element — Bool is not host-shareable, use U32 or I32 instead"'.
-Overload 2 of 4, '(typeSchema: "(Error) in array element — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslArray<Bool>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuReadonly<...>', gave the following error.Argument of type 'WgslArray<Bool>' is not assignable to parameter of type '"(Error) in array element — Bool is not host-shareable, use U32 or I32 instead"'.`,
+      "Argument of type 'WgslArray<Bool>' is not assignable to parameter of type '\"(Error) in array element — Bool is not host-shareable, use U32 or I32 instead\"'.",
     );
 
     // @ts-expect-error: bool is not allowed in readonly schemas
     attest(() => root.createReadonly(d.struct({ foo: d.bool }))).type.errors.snap(
-      `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ foo: Bool; }>>> | undefined): TgpuReadonly<...>', gave the following error.Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead"'.
-Overload 2 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ foo: Bool; }>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuReadonly<...>', gave the following error.Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead"'.`,
+      "Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '\"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead\"'.",
     );
   });
 
@@ -116,6 +122,18 @@ Overload 2 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not
     ).completions({
       '': ['id', 'prop'],
     });
+  });
+
+  it('auto types buffer on mapped initialized in readonly', ({ root }) => {
+    const Entry = d.struct({
+      id: d.u32,
+      values: d.vec3f,
+    });
+
+    () =>
+      root.createReadonly(d.arrayOf(Entry, 2), (mappedBuffer) => {
+        mappedBuffer.write([{ id: 1, values: d.vec3f() }]);
+      });
   });
 });
 
@@ -143,20 +161,17 @@ describe('root.createUniform', () => {
   it('does not accept non-host-shareable schemas', ({ root }) => {
     // @ts-expect-error: bool is not allowed in uniform schemas
     attest(() => root.createUniform(d.bool)).type.errors.snap(
-      `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<Bool>> | undefined): TgpuUniform<Bool>', gave the following error.Argument of type 'Bool' is not assignable to parameter of type '"(Error) Bool is not host-shareable, use U32 or I32 instead"'.
-Overload 2 of 4, '(typeSchema: "(Error) Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<Bool>> | ((buffer: TgpuBuffer<NoInfer<Bool>>) => void) | undefined): TgpuUniform<...>', gave the following error.Argument of type 'Bool' is not assignable to parameter of type '"(Error) Bool is not host-shareable, use U32 or I32 instead"'.`,
+      "Argument of type 'Bool' is not assignable to parameter of type '\"(Error) Bool is not host-shareable, use U32 or I32 instead\"'.",
     );
 
     // @ts-expect-error: bool is not allowed in uniform schemas
     attest(() => root.createUniform(d.arrayOf(d.bool, 16))).type.errors.snap(
-      `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) in array element — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslArray<Bool>>> | undefined): TgpuUniform<...>', gave the following error.Argument of type 'WgslArray<Bool>' is not assignable to parameter of type '"(Error) in array element — Bool is not host-shareable, use U32 or I32 instead"'.
-Overload 2 of 4, '(typeSchema: "(Error) in array element — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslArray<Bool>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuUniform<...>', gave the following error.Argument of type 'WgslArray<Bool>' is not assignable to parameter of type '"(Error) in array element — Bool is not host-shareable, use U32 or I32 instead"'.`,
+      "Argument of type 'WgslArray<Bool>' is not assignable to parameter of type '\"(Error) in array element — Bool is not host-shareable, use U32 or I32 instead\"'.",
     );
 
     // @ts-expect-error: bool is not allowed in uniform schemas
     attest(() => root.createUniform(d.struct({ foo: d.bool }))).type.errors.snap(
-      `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ foo: Bool; }>>> | undefined): TgpuUniform<...>', gave the following error.Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead"'.
-Overload 2 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ foo: Bool; }>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuUniform<...>', gave the following error.Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead"'.`,
+      "Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '\"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead\"'.",
     );
   });
 
@@ -170,5 +185,17 @@ Overload 2 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not
     ).completions({
       '': ['id', 'prop'],
     });
+  });
+
+  it('auto types buffer on mapped initialized in uniform', ({ root }) => {
+    const Entry = d.struct({
+      id: d.u32,
+      values: d.vec3f,
+    });
+
+    () =>
+      root.createUniform(d.arrayOf(Entry, 2), (mappedBuffer) => {
+        mappedBuffer.write([{ id: 1, values: d.vec3f() }]);
+      });
   });
 });

--- a/packages/typegpu/tests/bufferShorthands.test.ts
+++ b/packages/typegpu/tests/bufferShorthands.test.ts
@@ -66,11 +66,12 @@ describe('root.createMutable', () => {
       id: d.u32,
       values: d.vec3f,
     });
+    const Entries = d.arrayOf(Entry, 2);
 
-    () =>
-      root.createMutable(d.arrayOf(Entry, 2), (mappedBuffer) => {
-        mappedBuffer.write([{ id: 1, values: d.vec3f() }]);
-      });
+    root.createMutable(Entries, (mappedBuffer) => {
+      expectTypeOf(mappedBuffer).toEqualTypeOf<TgpuBuffer<typeof Entries>>();
+      mappedBuffer.write([{ id: 1, values: d.vec3f() }]);
+    });
   });
 });
 
@@ -129,11 +130,12 @@ describe('root.createReadonly', () => {
       id: d.u32,
       values: d.vec3f,
     });
+    const Entries = d.arrayOf(Entry, 2);
 
-    () =>
-      root.createReadonly(d.arrayOf(Entry, 2), (mappedBuffer) => {
-        mappedBuffer.write([{ id: 1, values: d.vec3f() }]);
-      });
+    root.createReadonly(Entries, (mappedBuffer) => {
+      expectTypeOf(mappedBuffer).toEqualTypeOf<TgpuBuffer<typeof Entries>>();
+      mappedBuffer.write([{ id: 1, values: d.vec3f() }]);
+    });
   });
 });
 
@@ -192,10 +194,11 @@ describe('root.createUniform', () => {
       id: d.u32,
       values: d.vec3f,
     });
+    const Entries = d.arrayOf(Entry, 2);
 
-    () =>
-      root.createUniform(d.arrayOf(Entry, 2), (mappedBuffer) => {
-        mappedBuffer.write([{ id: 1, values: d.vec3f() }]);
-      });
+    root.createUniform(Entries, (mappedBuffer) => {
+      expectTypeOf(mappedBuffer).toEqualTypeOf<TgpuBuffer<typeof Entries>>();
+      mappedBuffer.write([{ id: 1, values: d.vec3f() }]);
+    });
   });
 });

--- a/packages/typegpu/tests/bufferShorthands.test.ts
+++ b/packages/typegpu/tests/bufferShorthands.test.ts
@@ -51,6 +51,18 @@ Overload 2 of 4, '(typeSchema: "(Error) in array element — Bool is not host-sh
 Overload 2 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ foo: Bool; }>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuMutable<...>', gave the following error.Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead"'.`,
     );
   });
+
+  it('hints initial struct props in mutable', ({ root }) => {
+    const Boid = d.struct({ id: d.u32, prop: d.vec2u });
+    attest(() =>
+      root.createMutable(Boid, {
+        // @ts-expect-error
+        '': undefined,
+      }),
+    ).completions({
+      '': ['id', 'prop'],
+    });
+  });
 });
 
 describe('root.createReadonly', () => {
@@ -93,6 +105,18 @@ Overload 2 of 4, '(typeSchema: "(Error) in array element — Bool is not host-sh
 Overload 2 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ foo: Bool; }>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuReadonly<...>', gave the following error.Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead"'.`,
     );
   });
+
+  it('hints initial struct props in readonly', ({ root }) => {
+    const Boid = d.struct({ id: d.u32, prop: d.vec2u });
+    attest(() =>
+      root.createReadonly(Boid, {
+        // @ts-expect-error
+        '': undefined,
+      }),
+    ).completions({
+      '': ['id', 'prop'],
+    });
+  });
 });
 
 describe('root.createUniform', () => {
@@ -134,5 +158,17 @@ Overload 2 of 4, '(typeSchema: "(Error) in array element — Bool is not host-sh
       `No overload matches this call.Overload 1 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ foo: Bool; }>>> | undefined): TgpuUniform<...>', gave the following error.Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead"'.
 Overload 2 of 4, '(typeSchema: "(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead", initial?: InferInput<NoInfer<WgslStruct<{ foo: Bool; }>>> | ((buffer: TgpuBuffer<...>) => void) | undefined): TgpuUniform<...>', gave the following error.Argument of type 'WgslStruct<{ foo: Bool; }>' is not assignable to parameter of type '"(Error) in struct property 'foo' — Bool is not host-shareable, use U32 or I32 instead"'.`,
     );
+  });
+
+  it('hints initial struct props in uniform', ({ root }) => {
+    const Boid = d.struct({ id: d.u32, prop: d.vec2u });
+    attest(() =>
+      root.createUniform(Boid, {
+        // @ts-expect-error
+        '': undefined,
+      }),
+    ).completions({
+      '': ['id', 'prop'],
+    });
   });
 });


### PR DESCRIPTION
For all 4 buffer constructors (buffer, uniform, mutable, readonly) there were 4 overloads:
1. One with init data.
2. One with an initializer.
3. One with either init data or an initializer.
4. One with a raw buffer.

The issue #2445 suggests reordering 1 and 2, though I instead removed them. 
I couldn't merge 3 and 4 because it would hint GPUBuffer methods when initializing a buffer with a struct 
