### PR TITLE
explore: f32 by default

### DIFF
--- a/packages/typegpu/src/data/numeric.ts
+++ b/packages/typegpu/src/data/numeric.ts
@@ -125,6 +125,16 @@ export const i32: I32 = Object.assign(i32Cast, {
   type: 'i32',
 }) as unknown as I32;
 
+export type f32 = number;
+// export type f32 = number & {
+//   __brand: 'f32';
+//   [Symbol.operatorPlus](lhs: f32 | number, rhs: f32 | number): f32;
+//   [Symbol.operatorMinus](lhs: f32 | number, rhs: f32 | number): f32;
+//   [Symbol.operatorStar](lhs: f32 | number, rhs: f32 | number): f32;
+//   [Symbol.operatorSlash](lhs: f32 | number, rhs: f32 | number): f32;
+//   [Symbol.operatorPercent](lhs: f32 | number, rhs: f32 | number): f32;
+// };
+
 const f32Cast = callableSchema({
   name: 'f32',
   schema: () => f32,

--- a/packages/typegpu/src/tgsl/generationHelpers.ts
+++ b/packages/typegpu/src/tgsl/generationHelpers.ts
@@ -54,7 +54,7 @@ export function concretize<T extends BaseData>(type: T): T | F32 | I32 {
   }
 
   if (type.type === 'abstractInt') {
-    return i32;
+    return f32;
   }
 
   return type;

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -1150,14 +1150,15 @@ ${this.ctx.pre}else ${alternate}`;
         }
       }
 
-      const snippet = this.blockVariable(varType, rawId, concretize(dataType), eq.origin);
-      const rhsSnippet = tryConvertSnippet(this.ctx, eq, dataType, false);
+      const concreteDataType = concretize(dataType);
+      const snippet = this.blockVariable(varType, rawId, concreteDataType, eq.origin);
+      const rhsSnippet = tryConvertSnippet(this.ctx, eq, concreteDataType, false);
       const rhsStr = this.ctx.resolve(rhsSnippet.value, rhsSnippet.dataType).value;
       return this.emitVarDecl(
         this.ctx.pre,
         varType,
         snippet.value as string,
-        concretize(dataType),
+        concreteDataType,
         rhsStr,
       );
     }


### PR DESCRIPTION
Ideas:

Coerce `abstractInt` to `f32` by default, with a few exceptions:
- In the head of a `for` loop: `i32` by default
- (maybe) Whenever a value is post-incremented, retroactively set the default to `i32`
- (maybe) We can warn people if they use unwrapped numeric literals in for loops