### PR TITLE
fix(unplugin-typegpu): Inline magic-string-ast helpers to still support CJS-only environments

### DIFF
--- a/packages/unplugin-typegpu/package.json
+++ b/packages/unplugin-typegpu/package.json
@@ -171,7 +171,7 @@
     "@babel/types": "catalog:",
     "ast-kit": "^2.2.0",
     "defu": "^6.1.4",
-    "magic-string-ast": "^1.0.3",
+    "magic-string": "^0.30.21",
     "pathe": "^2.0.3",
     "picomatch": "^4.0.4",
     "tinyest": "workspace:~0.3.1",

--- a/packages/unplugin-typegpu/src/core/common.ts
+++ b/packages/unplugin-typegpu/src/core/common.ts
@@ -1,7 +1,7 @@
 import * as t from '@babel/types';
 import type { NodePath, TraverseOptions } from '@babel/traverse';
 import type { FilterPattern } from 'unplugin';
-import { MagicStringAST } from 'magic-string-ast';
+import MagicString from 'magic-string';
 import { transpileFn } from 'tinyest-for-wgsl';
 
 export interface Options {
@@ -105,8 +105,16 @@ export interface PluginState extends TransformMethods {
   alreadyTransformed: WeakSet<t.Node>;
 }
 
+export interface NodeLocation {
+  start?: number | null;
+  end?: number | null;
+}
+
 export interface UnpluginPluginState extends PluginState {
-  magicString: MagicStringAST;
+  magicString: MagicString;
+  slice(node: NodeLocation): string;
+  remove(node: NodeLocation): void;
+  overwrite(node: NodeLocation, content: string): void;
 }
 
 export function initPluginState(state: PluginState, methods: TransformMethods): void {

--- a/packages/unplugin-typegpu/src/core/factory.ts
+++ b/packages/unplugin-typegpu/src/core/factory.ts
@@ -1,5 +1,5 @@
 import defu from 'defu';
-import { generateTransform, MagicStringAST } from 'magic-string-ast';
+import MagicString from 'magic-string';
 import { getBabelParserOptions, getLang } from 'ast-kit';
 import type { UnpluginBuildContext, UnpluginContext, UnpluginFactory } from 'unplugin';
 import _traverse, { type NodePath } from '@babel/traverse';
@@ -15,7 +15,7 @@ import {
   getBlockScope,
 } from './common.ts';
 
-import type { Options, UnpluginPluginState, MetadatableFunction } from './common.ts';
+import type { Options, UnpluginPluginState, MetadatableFunction, NodeLocation } from './common.ts';
 
 // I love CommonJS 💔
 let traverse = _traverse;
@@ -51,7 +51,7 @@ function assignMetadata(
     ? getBlockScope(path as NodePath<t.FunctionDeclaration>)
     : undefined;
 
-  const fnCode = this.magicString.sliceNode(path.node);
+  const fnCode = this.slice(path.node);
 
   let nodeToOverride: t.Node = path.node;
   let code = fnWrapperTemplate(fnCode, metadata);
@@ -73,13 +73,15 @@ function assignMetadata(
 
   if (insertPos < (path.node.start ?? 0)) {
     for (const comment of nodeToOverride.leadingComments?.toReversed() ?? []) {
-      code = `${this.magicString.slice(comment.start ?? 0, comment.end ?? 0)}\n${code}`;
-      this.magicString.removeNode(comment);
+      if (comment) {
+        code = `${this.slice(comment)}\n${code}`;
+        this.remove(comment);
+      }
     }
-    this.magicString.removeNode(nodeToOverride);
+    this.remove(nodeToOverride);
     this.magicString.prependLeft(insertPos, code);
   } else {
-    this.magicString.overwriteNode(nodeToOverride, code);
+    this.overwrite(nodeToOverride, code);
   }
 }
 
@@ -101,9 +103,9 @@ function replaceWithAssignmentOverload(
   path: NodePath<t.AssignmentExpression>,
   runtimeFn: string,
 ): void {
-  const lhs = this.magicString.sliceNode(path.node.left);
-  const rhs = this.magicString.sliceNode(path.node.right);
-  this.magicString.overwriteNode(path.node, `${lhs} = ${runtimeFn}(${lhs}, ${rhs})`);
+  const lhs = this.slice(path.node.left);
+  const rhs = this.slice(path.node.right);
+  this.overwrite(path.node, `${lhs} = ${runtimeFn}(${lhs}, ${rhs})`);
 }
 
 function replaceWithBinaryOverload(
@@ -111,10 +113,22 @@ function replaceWithBinaryOverload(
   path: NodePath<t.BinaryExpression>,
   runtimeFn: string,
 ): void {
-  const lhs = this.magicString.sliceNode(path.node.left);
-  const rhs = this.magicString.sliceNode(path.node.right);
-  this.magicString.overwriteNode(path.node, `${runtimeFn}(${lhs}, ${rhs})`);
+  const lhs = this.slice(path.node.left);
+  const rhs = this.slice(path.node.right);
+  this.overwrite(path.node, `${runtimeFn}(${lhs}, ${rhs})`);
 }
+
+const NodeUtils = {
+  slice(this: UnpluginPluginState, node: NodeLocation): string {
+    return this.magicString.slice(node.start ?? 0, node.end ?? 0);
+  },
+  remove(this: UnpluginPluginState, node: NodeLocation): void {
+    this.magicString.remove(node.start ?? 0, node.end ?? 0);
+  },
+  overwrite(this: UnpluginPluginState, node: NodeLocation, content: string): void {
+    this.magicString.overwrite(node.start ?? 0, node.end ?? 0, content);
+  },
+};
 
 export const unpluginFactory = ((rawOptions, _meta) => {
   const options = defu(rawOptions, defaultOptions);
@@ -150,12 +164,13 @@ export const unpluginFactory = ((rawOptions, _meta) => {
           return undefined;
         }
 
-        const magicString = new MagicStringAST(code);
+        const magicString = new MagicString(code);
 
         const state = {
           filename: id,
           magicString,
           opts: options,
+          ...NodeUtils,
         } as UnpluginPluginState;
 
         initPluginState(state, {
@@ -168,7 +183,20 @@ export const unpluginFactory = ((rawOptions, _meta) => {
 
         traverse(ast, functionVisitor, undefined, state);
 
-        return generateTransform(magicString, id);
+        if (magicString.hasChanged()) {
+          return {
+            code: magicString.toString(),
+            get map() {
+              return magicString.generateMap({
+                source: id,
+                includeContent: true,
+                hires: 'boundary',
+              });
+            },
+          };
+        }
+
+        return undefined;
       },
     },
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,7 +136,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.12
+        version: 1.3.13
 
   apps/infra-benchmarks:
     devDependencies:
@@ -877,9 +877,9 @@ importers:
       defu:
         specifier: ^6.1.4
         version: 6.1.4
-      magic-string-ast:
-        specifier: ^1.0.3
-        version: 1.0.3
+      magic-string:
+        specifier: ^0.30.21
+        version: 0.30.21
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
@@ -4055,6 +4055,9 @@ packages:
   '@types/bun@1.3.12':
     resolution: {integrity: sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A==}
 
+  '@types/bun@1.3.13':
+    resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
+
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -4252,6 +4255,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-basic-ssl@2.1.0':
     resolution: {integrity: sha512-dOxxrhgyDIEUADhb/8OlV9JIqYLgos03YorAueTIeOUskLJSEsfwCByjbu98ctXitUN3znXKp0bYD/WHSudCeA==}
@@ -4802,6 +4806,9 @@ packages:
 
   bun-types@1.3.12:
     resolution: {integrity: sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA==}
+
+  bun-types@1.3.13:
+    resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
 
   bun@1.3.10:
     resolution: {integrity: sha512-S/CXaXXIyA4CMjdMkYQ4T2YMqnAn4s0ysD3mlsY4bUiOCqGlv28zck4Wd4H4kpvbekx15S9mUeLQ7Uxd0tYTLA==}
@@ -6646,10 +6653,6 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
-
-  magic-string-ast@1.0.3:
-    resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
-    engines: {node: '>=20.19.0'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -11768,9 +11771,7 @@ snapshots:
       metro-runtime: 0.83.5
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.84.1': {}
@@ -12383,6 +12384,10 @@ snapshots:
   '@types/bun@1.3.12':
     dependencies:
       bun-types: 1.3.12
+
+  '@types/bun@1.3.13':
+    dependencies:
+      bun-types: 1.3.13
 
   '@types/chai@5.2.2':
     dependencies:
@@ -13443,6 +13448,10 @@ snapshots:
       '@types/node': 24.10.0
 
   bun-types@1.3.12:
+    dependencies:
+      '@types/node': 24.10.0
+
+  bun-types@1.3.13:
     dependencies:
       '@types/node': 24.10.0
 
@@ -15441,10 +15450,6 @@ snapshots:
   lunr@2.3.9: {}
 
   lz-string@1.5.0: {}
-
-  magic-string-ast@1.0.3:
-    dependencies:
-      magic-string: 0.30.21
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
<img width="391" height="287" alt="image" src="https://github.com/user-attachments/assets/e1ac973d-18c7-4540-bec1-ce96a6f67458" />

`magic-string-ast` exports only ESM, but `magic-string` does both CJS and ESM.