### PR TITLE
fix: Accept readonly tuples and arrays in `d.InferInput`

### DIFF
--- a/packages/typegpu/src/data/dataTypes.ts
+++ b/packages/typegpu/src/data/dataTypes.ts
@@ -51,7 +51,7 @@ export interface Disarray<out TElement extends wgsl.BaseData = wgsl.BaseData>
 
   // Type-tokens, not available at runtime
   readonly [$repr]: Infer<TElement>[];
-  readonly [$inRepr]: InferInput<TElement>[] | wgsl.TypedArrayFor<TElement>;
+  readonly [$inRepr]: readonly InferInput<TElement>[] | wgsl.TypedArrayFor<TElement>;
   readonly [$reprPartial]: { idx: number; value: InferPartial<TElement> }[] | undefined;
   readonly [$reprPatch]:
     | Record<number, InferPatch<TElement>>

--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -701,7 +701,7 @@ export interface Vec2f
 
   // Type-tokens, not available at runtime
   readonly [$repr]: v2f;
-  readonly [$inRepr]: v2f | [number, number] | Float32Array;
+  readonly [$inRepr]: v2f | readonly [number, number] | Float32Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   readonly [$validVertexSchema]: true;
@@ -726,7 +726,7 @@ export interface Vec2h
 
   // Type-tokens, not available at runtime
   readonly [$repr]: v2h;
-  readonly [$inRepr]: v2h | [number, number] | Float16Array;
+  readonly [$inRepr]: v2h | readonly [number, number] | Float16Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   readonly [$validVertexSchema]: true;
@@ -751,7 +751,7 @@ export interface Vec2i
 
   // Type-tokens, not available at runtime
   readonly [$repr]: v2i;
-  readonly [$inRepr]: v2i | [number, number] | Int32Array;
+  readonly [$inRepr]: v2i | readonly [number, number] | Int32Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   readonly [$validVertexSchema]: true;
@@ -776,7 +776,7 @@ export interface Vec2u
 
   // Type-tokens, not available at runtime
   readonly [$repr]: v2u;
-  readonly [$inRepr]: v2u | [number, number] | Uint32Array;
+  readonly [$inRepr]: v2u | readonly [number, number] | Uint32Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   readonly [$validVertexSchema]: true;
@@ -823,7 +823,7 @@ export interface Vec3f
 
   // Type-tokens, not available at runtime
   readonly [$repr]: v3f;
-  readonly [$inRepr]: v3f | [number, number, number] | Float32Array;
+  readonly [$inRepr]: v3f | readonly [number, number, number] | Float32Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   readonly [$validVertexSchema]: true;
@@ -850,7 +850,7 @@ export interface Vec3h
 
   // Type-tokens, not available at runtime
   readonly [$repr]: v3h;
-  readonly [$inRepr]: v3h | [number, number, number] | Float16Array;
+  readonly [$inRepr]: v3h | readonly [number, number, number] | Float16Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   readonly [$validVertexSchema]: true;
@@ -877,7 +877,7 @@ export interface Vec3i
 
   // Type-tokens, not available at runtime
   readonly [$repr]: v3i;
-  readonly [$inRepr]: v3i | [number, number, number] | Int32Array;
+  readonly [$inRepr]: v3i | readonly [number, number, number] | Int32Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   readonly [$validVertexSchema]: true;
@@ -904,7 +904,7 @@ export interface Vec3u
 
   // Type-tokens, not available at runtime
   readonly [$repr]: v3u;
-  readonly [$inRepr]: v3u | [number, number, number] | Uint32Array;
+  readonly [$inRepr]: v3u | readonly [number, number, number] | Uint32Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   readonly [$validVertexSchema]: true;
@@ -960,7 +960,7 @@ export interface Vec4f
 
   // Type-tokens, not available at runtime
   readonly [$repr]: v4f;
-  readonly [$inRepr]: v4f | [number, number, number, number] | Float32Array;
+  readonly [$inRepr]: v4f | readonly [number, number, number, number] | Float32Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   readonly [$validVertexSchema]: true;
@@ -991,7 +991,7 @@ export interface Vec4h
 
   // Type-tokens, not available at runtime
   readonly [$repr]: v4h;
-  readonly [$inRepr]: v4h | [number, number, number, number] | Float16Array;
+  readonly [$inRepr]: v4h | readonly [number, number, number, number] | Float16Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   readonly [$validVertexSchema]: true;
@@ -1022,7 +1022,7 @@ export interface Vec4i
 
   // Type-tokens, not available at runtime
   readonly [$repr]: v4i;
-  readonly [$inRepr]: v4i | [number, number, number, number] | Int32Array;
+  readonly [$inRepr]: v4i | readonly [number, number, number, number] | Int32Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   readonly [$validVertexSchema]: true;
@@ -1053,7 +1053,7 @@ export interface Vec4u
 
   // Type-tokens, not available at runtime
   readonly [$repr]: v4u;
-  readonly [$inRepr]: v4u | [number, number, number, number] | Uint32Array;
+  readonly [$inRepr]: v4u | readonly [number, number, number, number] | Uint32Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   readonly [$validVertexSchema]: true;
@@ -1098,7 +1098,7 @@ export interface Mat2x2f extends BaseData {
 
   // Type-tokens, not available at runtime
   readonly [$repr]: m2x2f;
-  readonly [$inRepr]: m2x2f | number[] | Float32Array;
+  readonly [$inRepr]: m2x2f | readonly number[] | Float32Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   // ---
@@ -1118,7 +1118,7 @@ export interface Mat3x3f extends BaseData {
 
   // Type-tokens, not available at runtime
   readonly [$repr]: m3x3f;
-  readonly [$inRepr]: m3x3f | number[] | Float32Array;
+  readonly [$inRepr]: m3x3f | readonly number[] | Float32Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   // ---
@@ -1138,7 +1138,7 @@ export interface Mat4x4f extends BaseData {
 
   // Type-tokens, not available at runtime
   readonly [$repr]: m4x4f;
-  readonly [$inRepr]: m4x4f | number[] | Float32Array;
+  readonly [$inRepr]: m4x4f | readonly number[] | Float32Array;
   readonly [$validStorageSchema]: true;
   readonly [$validUniformSchema]: true;
   // ---
@@ -1174,7 +1174,7 @@ export interface WgslArray<out TElement extends BaseData = BaseData> extends Bas
 
   // Type-tokens, not available at runtime
   readonly [$repr]: Infer<TElement>[];
-  readonly [$inRepr]: InferInput<TElement>[] | TypedArrayFor<TElement>;
+  readonly [$inRepr]: readonly InferInput<TElement>[] | TypedArrayFor<TElement>;
   readonly [$gpuRepr]: InferGPU<TElement>[];
   readonly [$reprPartial]: { idx: number; value: InferPartial<TElement> }[] | undefined;
   readonly [$reprPatch]:

--- a/packages/typegpu/tests/buffer.test.ts
+++ b/packages/typegpu/tests/buffer.test.ts
@@ -800,7 +800,9 @@ describe('TgpuBuffer', () => {
   }) => {
     const buffer = root.createBuffer(d.arrayOf(d.u16, 32));
 
-    expectTypeOf(buffer.write).parameter(0).toEqualTypeOf<number[] | Uint16Array | ArrayBuffer>();
+    expectTypeOf(buffer.write)
+      .parameter(0)
+      .toEqualTypeOf<number[] | readonly number[] | Uint16Array | ArrayBuffer>();
   });
 
   it('should write an arrayOf(u16) buffer from a Uint16Array', ({ root, device }) => {
@@ -821,9 +823,11 @@ describe('TgpuBuffer', () => {
 
     expectTypeOf(u32Buffer.write)
       .parameter(0)
-      .toEqualTypeOf<number[] | Uint32Array | ArrayBuffer>();
+      .toEqualTypeOf<number[] | readonly number[] | Uint32Array | ArrayBuffer>();
 
-    expectTypeOf(i32Buffer.write).parameter(0).toEqualTypeOf<number[] | Int32Array | ArrayBuffer>();
+    expectTypeOf(i32Buffer.write)
+      .parameter(0)
+      .toEqualTypeOf<number[] | readonly number[] | Int32Array | ArrayBuffer>();
   });
 
   it('should fast-path typed views when writing to arrays of atomics', ({ root, device }) => {
@@ -886,29 +890,32 @@ describe('TgpuBuffer (InferInput)', () => {
 
     expectTypeOf(vec3fBuf.write)
       .parameter(0)
-      .toEqualTypeOf<d.v3f | [number, number, number] | Float32Array | ArrayBuffer>();
+      .toEqualTypeOf<d.v3f | readonly [number, number, number] | Float32Array | ArrayBuffer>();
 
     expectTypeOf(vec2iBuf.write)
       .parameter(0)
-      .toEqualTypeOf<d.v2i | [number, number] | Int32Array | ArrayBuffer>();
+      .toEqualTypeOf<d.v2i | readonly [number, number] | Int32Array | ArrayBuffer>();
 
     expectTypeOf(mat3x3fBuf.write)
       .parameter(0)
-      .toEqualTypeOf<d.m3x3f | number[] | Float32Array | ArrayBuffer>();
+      .toEqualTypeOf<d.m3x3f | readonly number[] | Float32Array | ArrayBuffer>();
 
     expectTypeOf(mat4x4fBuf.write)
       .parameter(0)
-      .toEqualTypeOf<d.m4x4f | number[] | Float32Array | ArrayBuffer>();
+      .toEqualTypeOf<d.m4x4f | readonly number[] | Float32Array | ArrayBuffer>();
 
     expectTypeOf(arrBuf.write)
       .parameter(0)
       .toEqualTypeOf<
-        (d.v3f | [number, number, number] | Float32Array)[] | Float32Array | ArrayBuffer | d.v3f[]
+        | readonly (d.v3f | readonly [number, number, number] | Float32Array)[]
+        | Float32Array
+        | ArrayBuffer
+        | d.v3f[]
       >();
 
     expectTypeOf(scalarArrBuf.write)
       .parameter(0)
-      .toEqualTypeOf<number[] | Float32Array | ArrayBuffer>();
+      .toEqualTypeOf<number[] | readonly number[] | Float32Array | ArrayBuffer>();
   });
 
   it('should write a vec3f from a plain tuple', ({ root, device }) => {
@@ -1054,11 +1061,11 @@ describe('TgpuBuffer (.patch() with flexible inputs)', () => {
     );
 
     expectTypeOf<InferPatch<d.Vec3f>>().toEqualTypeOf<
-      d.v3f | [number, number, number] | Float32Array | undefined
+      d.v3f | readonly [number, number, number] | Float32Array | undefined
     >();
 
     expectTypeOf<InferPatch<d.Mat3x3f>>().toEqualTypeOf<
-      d.m3x3f | number[] | Float32Array | undefined
+      d.m3x3f | readonly number[] | Float32Array | undefined
     >();
 
     // Struct patch should accept flexible types for fields

--- a/packages/typegpu/tests/inferInput.test.ts
+++ b/packages/typegpu/tests/inferInput.test.ts
@@ -1,5 +1,5 @@
 import { test } from 'typegpu-testing-utility';
-import { describe, expect } from 'vitest';
+import { describe, expect, expectTypeOf } from 'vitest';
 import { d, type ValidateBufferSchema } from 'typegpu';
 
 describe('d.InferInput', () => {
@@ -9,5 +9,25 @@ describe('d.InferInput', () => {
     }
 
     expect(() => foo(d.f32, 1)).not.toThrow();
+  });
+
+  test('should accept tuples', () => {
+    expectTypeOf<[number, number, number]>().toExtend<d.InferInput<d.Vec3f>>();
+    expectTypeOf<readonly [number, number, number]>().toExtend<d.InferInput<d.Vec3f>>();
+  });
+
+  test('should accept arrays in inferred matrices', () => {
+    expectTypeOf<number[]>().toExtend<d.InferInput<d.Mat4x4f>>();
+    expectTypeOf<readonly number[]>().toExtend<d.InferInput<d.Mat4x4f>>();
+  });
+
+  test('should accept arrays in inferred arrays', () => {
+    expectTypeOf<number[]>().toExtend<d.InferInput<d.WgslArray<d.U32>>>();
+    expectTypeOf<readonly number[]>().toExtend<d.InferInput<d.WgslArray<d.U32>>>();
+  });
+
+  test('should accept arrays in inferred disarrays', () => {
+    expectTypeOf<number[]>().toExtend<d.InferInput<d.Disarray<d.U32>>>();
+    expectTypeOf<readonly number[]>().toExtend<d.InferInput<d.Disarray<d.U32>>>();
   });
 });


### PR DESCRIPTION
Did we have a reason for defining `InferInput` like this
```ts
export type InferInput<T> =
  | Infer<T>
  | (T extends { readonly [$inRepr]: infer TRepr } ? TRepr : never);
```
instead of this?
```ts
export type InferInput<T> = T extends { readonly [$inRepr]: infer TRepr } ? TRepr : Infer<T>;
```

This seems less intuitive, but there seems to be a test preventing the change: `d.Infer<T> should be assignable to d.InferInput<T>` (why?)