### PR TITLE
fix: Keep entry function argument names as close the the originals

### DIFF
--- a/apps/typegpu-docs/tests/individual-example-tests/3d-fish.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/3d-fish.test.ts
@@ -285,11 +285,11 @@ describe('3d fish example', () => {
         @location(5) @interpolate(flat) applySeaDesaturation: u32,
       }
 
-      @vertex fn vertexShader(@location(0) _arg_modelPosition: vec3f, @location(1) _arg_modelNormal: vec3f, @location(2) _arg_textureUV: vec2f, @builtin(instance_index) _arg_instanceIndex: u32) -> vertexShader_Output {
-        let currentModelData = (&modelData[_arg_instanceIndex]);
-        var wavedVertex = PosAndNormal(_arg_modelPosition, _arg_modelNormal);
+      @vertex fn vertexShader(@location(0) modelPosition: vec3f, @location(1) modelNormal: vec3f, @location(2) textureUV: vec2f, @builtin(instance_index) instanceIndex: u32) -> vertexShader_Output {
+        let currentModelData = (&modelData[instanceIndex]);
+        var wavedVertex = PosAndNormal(modelPosition, modelNormal);
         if (((*currentModelData).applySinWave == 1u)) {
-          wavedVertex = applySinWave(_arg_instanceIndex, PosAndNormal(_arg_modelPosition, _arg_modelNormal), currentTime);
+          wavedVertex = applySinWave(instanceIndex, PosAndNormal(modelPosition, modelNormal), currentTime);
         }
         let direction = normalize((*currentModelData).direction);
         let yaw = (-(atan2(direction.z, direction.x)) + 3.141592653589793f);
@@ -302,7 +302,7 @@ describe('3d fish example', () => {
         let worldNormal = normalize(((yawMatrix * pitchMatrix) * vec4f(wavedVertex.normal, 1f)).xyz);
         let worldPositionUniform = (&worldPosition);
         let canvasPosition = ((camera.projection * camera.view) * (*worldPositionUniform));
-        return vertexShader_Output(worldPosition.xyz, worldNormal, canvasPosition, (*currentModelData).variant, _arg_textureUV, (*currentModelData).applySeaFog, (*currentModelData).applySeaDesaturation);
+        return vertexShader_Output(worldPosition.xyz, worldNormal, canvasPosition, (*currentModelData).variant, textureUV, (*currentModelData).applySeaFog, (*currentModelData).applySeaDesaturation);
       }
 
       @group(0) @binding(1) var modelTexture: texture_2d<f32>;

--- a/apps/typegpu-docs/tests/individual-example-tests/bitonic-sort.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/bitonic-sort.test.ts
@@ -33,10 +33,10 @@ describe('bitonic sort example', () => {
 
       @group(0) @binding(0) var<storage, read> src: array<u32>;
 
-      @compute @workgroup_size(256) fn copyPadKernel(@builtin(global_invocation_id) _arg_gid: vec3u, @builtin(num_workgroups) _arg_numWorkgroups: vec3u) {
-        let spanX = (_arg_numWorkgroups.x * 256u);
-        let spanY = (_arg_numWorkgroups.y * spanX);
-        let idx = ((_arg_gid.x + (_arg_gid.y * spanX)) + (_arg_gid.z * spanY));
+      @compute @workgroup_size(256) fn copyPadKernel(@builtin(global_invocation_id) gid: vec3u, @builtin(num_workgroups) numWorkgroups: vec3u) {
+        let spanX = (numWorkgroups.x * 256u);
+        let spanY = (numWorkgroups.y * spanX);
+        let idx = ((gid.x + (gid.y * spanX)) + (gid.z * spanY));
         let dstLength = params.dstLength;
         let srcLength = params.srcLength;
         if ((idx >= dstLength)) {
@@ -58,10 +58,10 @@ describe('bitonic sort example', () => {
         return (a < b);
       }
 
-      @compute @workgroup_size(256) fn bitonicStepKernel(@builtin(global_invocation_id) _arg_gid: vec3u, @builtin(num_workgroups) _arg_numWorkgroups: vec3u) {
-        let spanX = (_arg_numWorkgroups.x * 256u);
-        let spanY = (_arg_numWorkgroups.y * spanX);
-        let tid = ((_arg_gid.x + (_arg_gid.y * spanX)) + (_arg_gid.z * spanY));
+      @compute @workgroup_size(256) fn bitonicStepKernel(@builtin(global_invocation_id) gid: vec3u, @builtin(num_workgroups) numWorkgroups: vec3u) {
+        let spanX = (numWorkgroups.x * 256u);
+        let spanY = (numWorkgroups.y * spanX);
+        let tid = ((gid.x + (gid.y * spanX)) + (gid.z * spanY));
         let k = uniforms.k;
         let shift = uniforms.jShift;
         let dataLength = arrayLength(&data);
@@ -97,10 +97,10 @@ describe('bitonic sort example', () => {
 
       @group(0) @binding(0) var<storage, read> src: array<u32>;
 
-      @compute @workgroup_size(256) fn copyBackKernel(@builtin(global_invocation_id) _arg_gid: vec3u, @builtin(num_workgroups) _arg_numWorkgroups: vec3u) {
-        let spanX = (_arg_numWorkgroups.x * 256u);
-        let spanY = (_arg_numWorkgroups.y * spanX);
-        let idx = ((_arg_gid.x + (_arg_gid.y * spanX)) + (_arg_gid.z * spanY));
+      @compute @workgroup_size(256) fn copyBackKernel(@builtin(global_invocation_id) gid: vec3u, @builtin(num_workgroups) numWorkgroups: vec3u) {
+        let spanX = (numWorkgroups.x * 256u);
+        let spanY = (numWorkgroups.y * spanX);
+        let idx = ((gid.x + (gid.y * spanX)) + (gid.z * spanY));
         if ((idx < params.srcLength)) {
           dst[idx] = src[idx];
         }

--- a/apps/typegpu-docs/tests/individual-example-tests/boids.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/boids.test.ts
@@ -106,10 +106,10 @@ describe('boids example', () => {
         @location(0) color: vec4f,
       }
 
-      @vertex fn mainVert(@location(0) _arg_v: vec2f, @location(1) _arg_center: vec2f, @location(2) _arg_velocity: vec2f) -> mainVert_Output {
-        let angle = getRotationFromVelocity(_arg_velocity);
-        let rotated = rotate(_arg_v, angle);
-        let pos = vec4f((rotated + _arg_center), 0f, 1f);
+      @vertex fn mainVert(@location(0) v: vec2f, @location(1) center: vec2f, @location(2) velocity: vec2f) -> mainVert_Output {
+        let angle = getRotationFromVelocity(velocity);
+        let rotated = rotate(v, angle);
+        let pos = vec4f((rotated + center), 0f, 1f);
         let color = vec4f(((sin((colorPalette + angle)) * 0.45f) + 0.45f), 1f);
         return mainVert_Output(pos, color);
       }

--- a/apps/typegpu-docs/tests/individual-example-tests/cubemap-reflection.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/cubemap-reflection.test.ts
@@ -63,12 +63,12 @@ describe('cubemap reflection example', () => {
         return vec2u(xy, zw);
       }
 
-      @compute @workgroup_size(256, 1, 1) fn computeFn(@builtin(global_invocation_id) _arg_gid: vec3u) {
+      @compute @workgroup_size(256, 1, 1) fn computeFn(@builtin(global_invocation_id) gid: vec3u) {
         let prevVertices = (&prevVertices_1);
         let nextVertices = (&nextVertices_1);
         let smoothFlag = smoothFlag_1;
         let triangleCount = u32((f32(arrayLength(&(*prevVertices))) / 3f));
-        let triangleIndex = (_arg_gid.x + (_arg_gid.y * 65535u));
+        let triangleIndex = (gid.x + (gid.y * 65535u));
         if ((triangleIndex >= triangleCount)) {
           return;
         }
@@ -252,9 +252,9 @@ describe('cubemap reflection example', () => {
         @location(0) texCoord: vec3f,
       }
 
-      @vertex fn cubeVertexFn(@location(0) _arg_position: vec3f) -> cubeVertexFn_Output {
-        let viewPos = (camera.view * vec4f(_arg_position.xyz, 0f)).xyz;
-        return cubeVertexFn_Output((camera.projection * vec4f(viewPos, 1f)), _arg_position.xyz);
+      @vertex fn cubeVertexFn(@location(0) position: vec3f) -> cubeVertexFn_Output {
+        let viewPos = (camera.view * vec4f(position.xyz, 0f)).xyz;
+        return cubeVertexFn_Output((camera.projection * vec4f(viewPos, 1f)), position.xyz);
       }
 
       @group(1) @binding(0) var cubemap: texture_cube<f32>;
@@ -283,8 +283,8 @@ describe('cubemap reflection example', () => {
         @location(1) worldPos: vec4f,
       }
 
-      @vertex fn vertexFn(@location(0) _arg_position: vec4f, @location(1) _arg_normal: vec4f) -> vertexFn_Output {
-        return vertexFn_Output((camera.projection * (camera.view * _arg_position)), _arg_normal, _arg_position);
+      @vertex fn vertexFn(@location(0) position: vec4f, @location(1) normal: vec4f) -> vertexFn_Output {
+        return vertexFn_Output((camera.projection * (camera.view * position)), normal, position);
       }
 
       struct DirectionalLight {

--- a/apps/typegpu-docs/tests/individual-example-tests/fluid-double-buffering.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/fluid-double-buffering.test.ts
@@ -552,10 +552,10 @@ describe('fluid double buffering example', () => {
         @location(0) uv: vec2f,
       }
 
-      @vertex fn vertexMain(@builtin(vertex_index) _arg_idx: u32) -> vertexMain_Output {
+      @vertex fn vertexMain(@builtin(vertex_index) idx: u32) -> vertexMain_Output {
         let pos = array<vec2f, 4>(vec2f(1), vec2f(-1, 1), vec2f(1, -1), vec2f(-1));
         let uv = array<vec2f, 4>(vec2f(1), vec2f(0, 1), vec2f(1, 0), vec2f());
-        return vertexMain_Output(vec4f(pos[_arg_idx].x, pos[_arg_idx].y, 0f, 1f), uv[_arg_idx]);
+        return vertexMain_Output(vec4f(pos[idx].x, pos[idx].y, 0f, 1f), uv[idx]);
       }
 
       fn coordsToIndex(x: i32, y: i32) -> i32 {

--- a/apps/typegpu-docs/tests/individual-example-tests/fluid-with-atomics.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/fluid-with-atomics.test.ts
@@ -190,8 +190,8 @@ describe('fluid with atomics example', () => {
         }
       }
 
-      @compute @workgroup_size(1, 1) fn compute(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        decideWaterLevel(_arg_gid.x, _arg_gid.y);
+      @compute @workgroup_size(1, 1) fn compute(@builtin(global_invocation_id) gid: vec3u) {
+        decideWaterLevel(gid.x, gid.y);
       }
 
       @group(0) @binding(0) var<uniform> size: vec2u;
@@ -201,16 +201,16 @@ describe('fluid with atomics example', () => {
         @location(0) cell: f32,
       }
 
-      @vertex fn vertex(@location(0) _arg_squareData: vec2f, @location(1) _arg_currentStateData: u32, @builtin(instance_index) _arg_idx: u32) -> vertex_Output {
+      @vertex fn vertex(@location(0) squareData: vec2f, @location(1) currentStateData: u32, @builtin(instance_index) idx: u32) -> vertex_Output {
         let w = size.x;
         let h = size.y;
-        let gridX = (_arg_idx % w);
-        let gridY = u32((f32(_arg_idx) / f32(w)));
+        let gridX = (idx % w);
+        let gridY = u32((f32(idx) / f32(w)));
         let maxDim = max(w, h);
-        let x = (((2f * (f32(gridX) + _arg_squareData.x)) - f32(w)) / f32(maxDim));
-        let y = (((2f * (f32(gridY) + _arg_squareData.y)) - f32(h)) / f32(maxDim));
-        let cellFlags = (_arg_currentStateData >> 24u);
-        var cell = f32((_arg_currentStateData & 16777215u));
+        let x = (((2f * (f32(gridX) + squareData.x)) - f32(w)) / f32(maxDim));
+        let y = (((2f * (f32(gridY) + squareData.y)) - f32(h)) / f32(maxDim));
+        let cellFlags = (currentStateData >> 24u);
+        var cell = f32((currentStateData & 16777215u));
         if ((cellFlags == 1u)) {
           cell = -1f;
         }

--- a/apps/typegpu-docs/tests/individual-example-tests/gravity.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/gravity.test.ts
@@ -87,8 +87,8 @@ describe('gravity example', () => {
 
       @group(0) @binding(2) var<storage, read_write> outState: array<CelestialBody>;
 
-      @compute @workgroup_size(1) fn computeCollisionsShader(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let currentId = _arg_gid.x;
+      @compute @workgroup_size(1) fn computeCollisionsShader(@builtin(global_invocation_id) gid: vec3u) {
+        let currentId = gid.x;
         var current = inState[currentId];
         if ((current.destroyed == 0u)) {
           for (var otherId = 0u; (otherId < u32(celestialBodiesCount)); otherId++) {
@@ -151,9 +151,9 @@ describe('gravity example', () => {
 
       @group(1) @binding(2) var<storage, read_write> outState: array<CelestialBody>;
 
-      @compute @workgroup_size(1) fn computeGravityShader(@builtin(global_invocation_id) _arg_gid: vec3u) {
+      @compute @workgroup_size(1) fn computeGravityShader(@builtin(global_invocation_id) gid: vec3u) {
         let dt = (time.passed * time.multiplier);
-        let currentId = _arg_gid.x;
+        let currentId = gid.x;
         var current = inState[currentId];
         if ((current.destroyed == 0u)) {
           for (var otherId = 0u; (otherId < u32(celestialBodiesCount)); otherId++) {
@@ -187,9 +187,9 @@ describe('gravity example', () => {
         @location(0) texCoord: vec3f,
       }
 
-      @vertex fn skyBoxVertex(@location(0) _arg_position: vec3f) -> skyBoxVertex_Output {
-        let viewPos = (camera.view * vec4f(_arg_position, 0f)).xyz;
-        return skyBoxVertex_Output((camera.projection * vec4f(viewPos, 1f)), _arg_position.xyz);
+      @vertex fn skyBoxVertex(@location(0) position: vec3f) -> skyBoxVertex_Output {
+        let viewPos = (camera.view * vec4f(position, 0f)).xyz;
+        return skyBoxVertex_Output((camera.projection * vec4f(viewPos, 1f)), position.xyz);
       }
 
       @group(0) @binding(1) var skyBox: texture_cube<f32>;
@@ -242,12 +242,12 @@ describe('gravity example', () => {
         @location(5) ambientLightFactor: f32,
       }
 
-      @vertex fn mainVertex(@location(0) _arg_position: vec3f, @location(1) _arg_normal: vec3f, @location(2) _arg_uv: vec2f, @builtin(instance_index) _arg_instanceIndex: u32) -> mainVertex_Output {
-        let currentBody = (&celestialBodies[_arg_instanceIndex]);
-        let worldPosition = ((*currentBody).position + (_arg_position.xyz * radiusOf((*currentBody))));
+      @vertex fn mainVertex(@location(0) position: vec3f, @location(1) normal: vec3f, @location(2) uv: vec2f, @builtin(instance_index) instanceIndex: u32) -> mainVertex_Output {
+        let currentBody = (&celestialBodies[instanceIndex]);
+        let worldPosition = ((*currentBody).position + (position.xyz * radiusOf((*currentBody))));
         let camera = (&camera_1);
         let positionOnCanvas = (((*camera).projection * (*camera).view) * vec4f(worldPosition, 1f));
-        return mainVertex_Output(positionOnCanvas, _arg_uv, _arg_normal, worldPosition, (*currentBody).textureIndex, (*currentBody).destroyed, (*currentBody).ambientLightFactor);
+        return mainVertex_Output(positionOnCanvas, uv, normal, worldPosition, (*currentBody).textureIndex, (*currentBody).destroyed, (*currentBody).ambientLightFactor);
       }
 
       @group(1) @binding(0) var celestialBodyTextures: texture_2d_array<f32>;

--- a/apps/typegpu-docs/tests/individual-example-tests/log-test.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/log-test.test.ts
@@ -1448,9 +1448,9 @@ describe('console log example', () => {
         @builtin(position) pos: vec4f,
       }
 
-      @vertex fn mainVertex(@builtin(vertex_index) _arg_vertexIndex: u32) -> mainVertex_Output {
+      @vertex fn mainVertex(@builtin(vertex_index) vertexIndex: u32) -> mainVertex_Output {
         let positions = array<vec2f, 3>(vec2f(0, 0.5), vec2f(-0.5), vec2f(0.5, -0.5));
-        return mainVertex_Output(vec4f(positions[_arg_vertexIndex], 0f, 1f));
+        return mainVertex_Output(vec4f(positions[vertexIndex], 0f, 1f));
       }
 
       @group(0) @binding(0) var<storage, read_write> indexBuffer: atomic<u32>;
@@ -1501,9 +1501,9 @@ describe('console log example', () => {
         @builtin(position) pos: vec4f,
       }
 
-      @vertex fn mainVertex(@builtin(vertex_index) _arg_vertexIndex: u32) -> mainVertex_Output {
+      @vertex fn mainVertex(@builtin(vertex_index) vertexIndex: u32) -> mainVertex_Output {
         let positions = array<vec2f, 3>(vec2f(0, 0.5), vec2f(-0.5), vec2f(0.5, -0.5));
-        return mainVertex_Output(vec4f(positions[_arg_vertexIndex], 0f, 1f));
+        return mainVertex_Output(vec4f(positions[vertexIndex], 0f, 1f));
       }
 
       @group(0) @binding(0) var<storage, read_write> indexBuffer: atomic<u32>;

--- a/apps/typegpu-docs/tests/individual-example-tests/matrix-next.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/matrix-next.test.ts
@@ -47,13 +47,13 @@ describe('matrix(next) example', () => {
 
       @group(0) @binding(2) var<storage, read_write> resultMatrix: array<i32>;
 
-      @compute @workgroup_size(16, 16) fn computeSharedMemory(@builtin(local_invocation_id) _arg_lid: vec3u, @builtin(workgroup_id) _arg_wid: vec3u) {
+      @compute @workgroup_size(16, 16) fn computeSharedMemory(@builtin(local_invocation_id) lid: vec3u, @builtin(workgroup_id) wid: vec3u) {
         let dimensions = (&dimensions_1);
         let numTiles = u32((f32((((*dimensions).firstColumnCount + 16u) - 1u)) / 16f));
-        let globalRow = ((_arg_wid.x * 16u) + _arg_lid.x);
-        let globalCol = ((_arg_wid.y * 16u) + _arg_lid.y);
-        let localRow = _arg_lid.x;
-        let localCol = _arg_lid.y;
+        let globalRow = ((wid.x * 16u) + lid.x);
+        let globalCol = ((wid.y * 16u) + lid.y);
+        let localRow = lid.x;
+        let localCol = lid.y;
         let tileIdx = getTileIndex(localRow, localCol);
         var accumulatedResult = 0;
         for (var tileIndex = 0u; (tileIndex < numTiles); tileIndex++) {

--- a/apps/typegpu-docs/tests/individual-example-tests/phong-reflection.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/phong-reflection.test.ts
@@ -47,11 +47,11 @@ describe('phong reflection example', () => {
         @builtin(position) canvasPosition: vec4f,
       }
 
-      @vertex fn vertexShader(@location(0) _arg_modelPosition: vec3f, @location(1) _arg_modelNormal: vec3f) -> vertexShader_Output {
-        let worldPosition = vec4f(_arg_modelPosition, 1f);
+      @vertex fn vertexShader(@location(0) modelPosition: vec3f, @location(1) modelNormal: vec3f) -> vertexShader_Output {
+        let worldPosition = vec4f(modelPosition, 1f);
         let camera = (&cameraUniform);
         let canvasPosition = (((*camera).projection * (*camera).view) * worldPosition);
-        return vertexShader_Output(_arg_modelPosition, _arg_modelNormal, canvasPosition);
+        return vertexShader_Output(modelPosition, modelNormal, canvasPosition);
       }
 
       struct ExampleControls {

--- a/apps/typegpu-docs/tests/individual-example-tests/probability.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/probability.test.ts
@@ -60,8 +60,8 @@ describe('probability distribution plot example', () => {
         return (vNorm * pow(u, 0.33f));
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }
@@ -100,8 +100,8 @@ describe('probability distribution plot example', () => {
         return vec3f(x, y, z);
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }
@@ -141,8 +141,8 @@ describe('probability distribution plot example', () => {
         return vec3f(randInUnitCircle(), 0.5f);
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }
@@ -181,8 +181,8 @@ describe('probability distribution plot example', () => {
         return vec3f(randOnUnitCircle(), 0.5f);
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }
@@ -216,8 +216,8 @@ describe('probability distribution plot example', () => {
         return vec3f(sample(), sample(), sample());
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }
@@ -257,8 +257,8 @@ describe('probability distribution plot example', () => {
         return result;
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }
@@ -315,8 +315,8 @@ describe('probability distribution plot example', () => {
         return randInUnitHemisphere(vec3f(1.409999966621399, 1.409999966621399, 0));
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }
@@ -365,8 +365,8 @@ describe('probability distribution plot example', () => {
         return randOnUnitHemisphere(vec3f(1.409999966621399, 1.409999966621399, 0));
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }
@@ -405,8 +405,8 @@ describe('probability distribution plot example', () => {
         return vec3f(randBernoulli(0.7f));
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }
@@ -444,8 +444,8 @@ describe('probability distribution plot example', () => {
         return vec3f(randFloat01());
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }
@@ -488,8 +488,8 @@ describe('probability distribution plot example', () => {
         return vec3f(randExponential(1f));
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }
@@ -533,8 +533,8 @@ describe('probability distribution plot example', () => {
         return vec3f(randNormal(0f, 1f));
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }
@@ -577,8 +577,8 @@ describe('probability distribution plot example', () => {
         return vec3f(randCauchy(0f, 1f));
       }
 
-      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let id = _arg_gid.x;
+      @compute @workgroup_size(64) fn dataMoreWorkersFunc(@builtin(global_invocation_id) gid: vec3u) {
+        let id = gid.x;
         if ((id >= arrayLength(&samplesBuffer))) {
           return;
         }

--- a/apps/typegpu-docs/tests/individual-example-tests/slime-mold.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/slime-mold.test.ts
@@ -302,10 +302,10 @@ describe('slime mold example', () => {
         @location(0) uv: vec2f,
       }
 
-      @vertex fn fullScreenTriangle(@builtin(vertex_index) _arg_vertexIndex: u32) -> fullScreenTriangle_Output {
+      @vertex fn fullScreenTriangle(@builtin(vertex_index) vertexIndex: u32) -> fullScreenTriangle_Output {
         let pos = array<vec2f, 3>(vec2f(-1), vec2f(3, -1), vec2f(-1, 3));
         let uv = array<vec2f, 3>(vec2f(0, 1), vec2f(2, 1), vec2f(0, -1));
-        return fullScreenTriangle_Output(vec4f(pos[_arg_vertexIndex], 0f, 1f), uv[_arg_vertexIndex]);
+        return fullScreenTriangle_Output(vec4f(pos[vertexIndex], 0f, 1f), uv[vertexIndex]);
       }
 
       @group(1) @binding(0) var state: texture_2d<f32>;

--- a/apps/typegpu-docs/tests/individual-example-tests/stable-fluid.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/stable-fluid.test.ts
@@ -38,9 +38,9 @@ describe('stable-fluid example', () => {
 
       @group(0) @binding(3) var linSampler: sampler;
 
-      @compute @workgroup_size(16, 16) fn advectFn(@builtin(global_invocation_id) _arg_gid: vec3u) {
+      @compute @workgroup_size(16, 16) fn advectFn(@builtin(global_invocation_id) gid: vec3u) {
         let texSize = textureDimensions(src);
-        let pixelPos = _arg_gid.xy;
+        let pixelPos = gid.xy;
         if (((((pixelPos.x >= (texSize.x - 1u)) || (pixelPos.y >= (texSize.y - 1u))) || (pixelPos.x <= 0u)) || (pixelPos.y <= 0u))) {
           textureStore(dst, pixelPos, vec4f(0, 0, 0, 1));
           return;
@@ -86,8 +86,8 @@ describe('stable-fluid example', () => {
 
       @group(0) @binding(1) var out: texture_storage_2d<rgba16float, write>;
 
-      @compute @workgroup_size(16, 16) fn diffusionFn(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let pixelPos = vec2i(_arg_gid.xy);
+      @compute @workgroup_size(16, 16) fn diffusionFn(@builtin(global_invocation_id) gid: vec3u) {
+        let pixelPos = vec2i(gid.xy);
         let texSize = vec2i(textureDimensions(in));
         let centerVal = textureLoad(in, pixelPos, 0);
         let neighbors = getNeighbors(pixelPos, texSize);
@@ -128,8 +128,8 @@ describe('stable-fluid example', () => {
 
       @group(0) @binding(1) var div: texture_storage_2d<rgba16float, write>;
 
-      @compute @workgroup_size(16, 16) fn divergenceFn(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let pixelPos = vec2i(_arg_gid.xy);
+      @compute @workgroup_size(16, 16) fn divergenceFn(@builtin(global_invocation_id) gid: vec3u) {
+        let pixelPos = vec2i(gid.xy);
         let texSize = vec2i(textureDimensions(vel));
         let neighbors = getNeighbors(pixelPos, texSize);
         let leftVel = textureLoad(vel, neighbors[0i], 0);
@@ -167,8 +167,8 @@ describe('stable-fluid example', () => {
 
       @group(0) @binding(2) var out: texture_storage_2d<rgba16float, write>;
 
-      @compute @workgroup_size(16, 16) fn pressureFn(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let pixelPos = vec2i(_arg_gid.xy);
+      @compute @workgroup_size(16, 16) fn pressureFn(@builtin(global_invocation_id) gid: vec3u) {
+        let pixelPos = vec2i(gid.xy);
         let texSize = vec2i(textureDimensions(x));
         let neighbors = getNeighbors(pixelPos, texSize);
         let leftPressure = textureLoad(x, neighbors[0i], 0);
@@ -207,8 +207,8 @@ describe('stable-fluid example', () => {
 
       @group(0) @binding(2) var out: texture_storage_2d<rgba16float, write>;
 
-      @compute @workgroup_size(16, 16) fn projectFn(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let pixelPos = vec2i(_arg_gid.xy);
+      @compute @workgroup_size(16, 16) fn projectFn(@builtin(global_invocation_id) gid: vec3u) {
+        let pixelPos = vec2i(gid.xy);
         let texSize = vec2i(textureDimensions(vel));
         let velocity = textureLoad(vel, pixelPos, 0);
         let neighbors = getNeighbors(pixelPos, texSize);
@@ -236,9 +236,9 @@ describe('stable-fluid example', () => {
 
       @group(0) @binding(2) var dst: texture_storage_2d<rgba16float, write>;
 
-      @compute @workgroup_size(16, 16) fn advectInkFn(@builtin(global_invocation_id) _arg_gid: vec3u) {
+      @compute @workgroup_size(16, 16) fn advectInkFn(@builtin(global_invocation_id) gid: vec3u) {
         let texSize = textureDimensions(src);
-        let pixelPos = _arg_gid.xy;
+        let pixelPos = gid.xy;
         let velocity = textureLoad(vel, pixelPos, 0).xy;
         let timeStep = simParams.dt;
         let prevPos = (vec2f(pixelPos) - (timeStep * velocity));
@@ -253,10 +253,10 @@ describe('stable-fluid example', () => {
         @location(0) uv: vec2f,
       }
 
-      @vertex fn renderFn(@builtin(vertex_index) _arg_idx: u32) -> renderFn_Output {
+      @vertex fn renderFn(@builtin(vertex_index) idx: u32) -> renderFn_Output {
         let vertices = array<vec2f, 3>(vec2f(-1), vec2f(3, -1), vec2f(-1, 3));
         let texCoords = array<vec2f, 3>(vec2f(), vec2f(2, 0), vec2f(0, 2));
-        return renderFn_Output(vec4f(vertices[_arg_idx], 0f, 1f), texCoords[_arg_idx]);
+        return renderFn_Output(vec4f(vertices[idx], 0f, 1f), texCoords[idx]);
       }
 
       @group(0) @binding(0) var result: texture_2d<f32>;

--- a/apps/typegpu-docs/tests/individual-example-tests/two-boxes.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/two-boxes.test.ts
@@ -40,9 +40,9 @@ describe('two boxes example', () => {
         @location(0) color: vec4f,
       }
 
-      @vertex fn vertex(@location(0) _arg_position: vec4f, @location(1) _arg_color: vec4f) -> vertex_Output {
-        let pos = (camera.projection * (camera.view * (transform.model * _arg_position)));
-        return vertex_Output(pos, _arg_color);
+      @vertex fn vertex(@location(0) position: vec4f, @location(1) color: vec4f) -> vertex_Output {
+        let pos = (camera.projection * (camera.view * (transform.model * position)));
+        return vertex_Output(pos, color);
       }
 
       struct fragment_Input {

--- a/apps/typegpu-docs/tests/individual-example-tests/wgsl-resolution.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/wgsl-resolution.test.ts
@@ -38,10 +38,10 @@ describe('wgsl resolution example', () => {
         @location(0) color: vec4f,
       }
 
-      @vertex fn vertex_shader(@location(0) _arg_v: vec2f, @location(1) _arg_center: vec2f, @location(2) _arg_velocity: vec2f) -> vertex_shader_Output {
-        let angle = get_rotation_from_velocity_util(_arg_velocity);
-        let rotated = rotate_util(_arg_v, angle);
-        let pos = vec4f((rotated.x + _arg_center.x), (rotated.y + _arg_center.y), 0f, 1f);
+      @vertex fn vertex_shader(@location(0) v: vec2f, @location(1) center: vec2f, @location(2) velocity: vec2f) -> vertex_shader_Output {
+        let angle = get_rotation_from_velocity_util(velocity);
+        let rotated = rotate_util(v, angle);
+        let pos = vec4f((rotated.x + center.x), (rotated.y + center.y), 0f, 1f);
         let colorPalette = (&colorPalette_1);
         let color = vec4f(((sin((angle + (*colorPalette).x)) * 0.45f) + 0.45f), ((sin((angle + (*colorPalette).y)) * 0.45f) + 0.45f), ((sin((angle + (*colorPalette).z)) * 0.45f) + 0.45f), 1f);
         return vertex_shader_Output(pos, color);
@@ -75,8 +75,8 @@ describe('wgsl resolution example', () => {
 
       @group(2) @binding(1) var<storage, read_write> nextTrianglePos: array<TriangleData>;
 
-      @compute @workgroup_size(1) fn compute_shader(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let index = _arg_gid.x;
+      @compute @workgroup_size(1) fn compute_shader(@builtin(global_invocation_id) gid: vec3u) {
+        let index = gid.x;
         let currentTrianglePos = (&currentTrianglePos_1);
         let instanceInfo = (&(*currentTrianglePos)[index]);
         var separation = vec2f();

--- a/apps/typegpu-docs/tests/individual-example-tests/xor-dev-centrifuge-2.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/xor-dev-centrifuge-2.test.ts
@@ -25,9 +25,9 @@ describe('xor dev centrifuge example', () => {
         @location(0) uv: vec2f,
       }
 
-      @vertex fn vertexMain(@builtin(vertex_index) _arg_vertexIndex: u32) -> vertexMain_Output {
+      @vertex fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> vertexMain_Output {
         let pos = array<vec2f, 3>(vec2f(-1), vec2f(3, -1), vec2f(-1, 3));
-        return vertexMain_Output(vec4f(pos[_arg_vertexIndex], 0f, 1f), pos[_arg_vertexIndex]);
+        return vertexMain_Output(vec4f(pos[vertexIndex], 0f, 1f), pos[vertexIndex]);
       }
 
       struct Params {

--- a/apps/typegpu-docs/tests/individual-example-tests/xor-dev-runner.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/xor-dev-runner.test.ts
@@ -29,9 +29,9 @@ describe('xor dev runner example', () => {
         @location(0) uv: vec2f,
       }
 
-      @vertex fn vertexMain(@builtin(vertex_index) _arg_vertexIndex: u32) -> vertexMain_Output {
+      @vertex fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> vertexMain_Output {
         let pos = array<vec2f, 3>(vec2f(-1), vec2f(3, -1), vec2f(-1, 3));
-        return vertexMain_Output(vec4f(pos[_arg_vertexIndex], 0f, 1f), pos[_arg_vertexIndex]);
+        return vertexMain_Output(vec4f(pos[vertexIndex], 0f, 1f), pos[vertexIndex]);
       }
 
       @group(0) @binding(0) var<uniform> colorUniform: vec3f;

--- a/packages/typegpu/src/resolutionCtx.ts
+++ b/packages/typegpu/src/resolutionCtx.ts
@@ -573,7 +573,7 @@ export class ResolutionCtxImpl implements ResolutionCtx {
           // Create named arg snippets, then a proxy for property access routing.
           const proxyEntries: Array<{ schemaKey: string; arg: FunctionArgumentAccess }> = [];
           for (const a of positionalArgs) {
-            const argName = this.makeUniqueIdentifier(`_arg_${a.schemaKey}`, 'block');
+            const argName = this.makeUniqueIdentifier(a.schemaKey, 'block');
             const arg = createArgument(argName, a.type);
             args.push(arg);
             proxyEntries.push({ schemaKey: a.schemaKey, arg: arg.access });

--- a/packages/typegpu/tests/indent.test.ts
+++ b/packages/typegpu/tests/indent.test.ts
@@ -372,7 +372,7 @@ describe('indents', () => {
         @location(0) @interpolate(flat, either) uv: vec2f,
       }
 
-      @vertex fn someVertex(@location(0) _arg_position: vec4f, @location(1) _arg_something: vec4f) -> someVertex_Output {
+      @vertex fn someVertex(@location(0) position: vec4f, @location(1) something: vec4f) -> someVertex_Output {
         let uniBoid = (&boids);
         for (var i = 0u; (i < 1u); i++) {
           let sampled_1 = textureSample(sampled, sampler_1, vec2f(0.5), i);
@@ -384,12 +384,12 @@ describe('indents', () => {
             while (true) {
               let newPos = ((*uniBoid).position + vec4f(1, 2, 3, 4));
               if ((newPos.x > 0f)) {
-                let evenNewer = (newPos + _arg_position);
+                let evenNewer = (newPos + position);
               }
             }
           }
         }
-        return someVertex_Output(_arg_position, _arg_something.xy);
+        return someVertex_Output(position, something.xy);
       }"
     `);
   });

--- a/packages/typegpu/tests/tgslFn.test.ts
+++ b/packages/typegpu/tests/tgslFn.test.ts
@@ -176,11 +176,11 @@ describe('TGSL tgpu.fn function', () => {
         @location(0) uv: vec2f,
       }
 
-      @vertex fn vertex_fn(@builtin(vertex_index) _arg_vi: u32, @builtin(instance_index) _arg_ii: u32, @location(0) _arg_color: vec4f) -> vertex_fn_Output {
-        let vi = f32(_arg_vi);
-        let ii = f32(_arg_ii);
-        let color = _arg_color;
-        return vertex_fn_Output(vec4f(color.w, ii, vi, 1f), vec2f(color.w, vi));
+      @vertex fn vertex_fn(@builtin(vertex_index) vi: u32, @builtin(instance_index) ii: u32, @location(0) color: vec4f) -> vertex_fn_Output {
+        let vi_1 = f32(vi);
+        let ii_1 = f32(ii);
+        let color_1 = color;
+        return vertex_fn_Output(vec4f(color_1.w, ii_1, vi_1, 1f), vec2f(color_1.w, vi_1));
       }"
     `);
   });
@@ -272,8 +272,8 @@ describe('TGSL tgpu.fn function', () => {
         @location(0) uv: vec2f,
       }
 
-      @vertex fn vertex_fn(@builtin(vertex_index) _arg_vi: u32, @builtin(instance_index) _arg_ii: u32, @location(0) _arg_color: vec4f) -> vertex_fn_Output {
-        let myOutput = vertex_fn_Output(vec4f(_arg_color.w, f32(_arg_ii), f32(_arg_vi), 1f), vec2f(_arg_color.w, f32(_arg_vi)));
+      @vertex fn vertex_fn(@builtin(vertex_index) vi: u32, @builtin(instance_index) ii: u32, @location(0) color: vec4f) -> vertex_fn_Output {
+        let myOutput = vertex_fn_Output(vec4f(color.w, f32(ii), f32(vi), 1f), vec2f(color.w, f32(vi)));
         return myOutput;
       }"
     `);
@@ -293,8 +293,8 @@ describe('TGSL tgpu.fn function', () => {
       .$name('compute_fn');
 
     expect(tgpu.resolve([computeFn])).toMatchInlineSnapshot(`
-      "@compute @workgroup_size(24) fn compute_fn(@builtin(global_invocation_id) _arg_gid: vec3u) {
-        let index = _arg_gid.x;
+      "@compute @workgroup_size(24) fn compute_fn(@builtin(global_invocation_id) gid: vec3u) {
+        let index = gid.x;
         const iterationF = 0f;
         const sign_1 = 0;
         let change = vec4f();
@@ -369,13 +369,13 @@ describe('TGSL tgpu.fn function', () => {
         @location(0) out: vec4f,
       }
 
-      @fragment fn fragmentFn(@builtin(position) _arg_pos: vec4f, @builtin(sample_mask) _arg_sampleMask: u32) -> fragmentFn_Output {
-        let pos = _arg_pos;
-        var sampleMask = 0;
-        if (((_arg_sampleMask > 0u) && (pos.x > 0f))) {
-          sampleMask = 1i;
+      @fragment fn fragmentFn(@builtin(position) pos: vec4f, @builtin(sample_mask) sampleMask: u32) -> fragmentFn_Output {
+        let pos_1 = pos;
+        var sampleMask_1 = 0;
+        if (((sampleMask > 0u) && (pos_1.x > 0f))) {
+          sampleMask_1 = 1i;
         }
-        return fragmentFn_Output(u32(sampleMask), 1f, vec4f());
+        return fragmentFn_Output(u32(sampleMask_1), 1f, vec4f());
       }"
     `);
   });
@@ -412,9 +412,9 @@ describe('TGSL tgpu.fn function', () => {
         @location(0) out: vec4f,
       }
 
-      @fragment fn fragmentFn(@builtin(position) _arg_pos: vec4f, @builtin(sample_mask) _arg_sampleMask: u32) -> fragmentFn_Output {
+      @fragment fn fragmentFn(@builtin(position) pos: vec4f, @builtin(sample_mask) sampleMask: u32) -> fragmentFn_Output {
         var myOutput = fragmentFn_Output(0u, 1f, vec4f());
-        if (((_arg_sampleMask > 0u) && (_arg_pos.x > 0f))) {
+        if (((sampleMask > 0u) && (pos.x > 0f))) {
           myOutput.sampleMask = 1u;
         }
         return myOutput;
@@ -491,8 +491,8 @@ describe('TGSL tgpu.fn function', () => {
     });
 
     expect(tgpu.resolve([fragmentFn])).toMatchInlineSnapshot(`
-      "@fragment fn fragmentFn(@builtin(position) _arg_pos: vec4f) -> @location(0) vec4f {
-        return _arg_pos;
+      "@fragment fn fragmentFn(@builtin(position) pos: vec4f) -> @location(0) vec4f {
+        return pos;
       }"
     `);
   });


### PR DESCRIPTION
Frameworks like Pixi.js expect the argument to be names a certain way in order to detect them, and us adding `_arg_` to every argument name makes that impossible.