### PR TITLE
fix: Remove iterator helpers

### DIFF
--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -882,12 +882,10 @@ ${this.ctx.pre}}`;
     const scope = this.ctx.topFunctionScope;
     invariant(scope, 'Expected function scope to be present');
     const replacements = Object.fromEntries(
-      scope.placeholderForVariable
-        .entries()
-        .map(([variable, placeholder]) => [
-          placeholder,
-          scope.modifiedVariables.has(variable) ? 'var' : 'let',
-        ]),
+      [...scope.placeholderForVariable.entries()].map(([variable, placeholder]) => [
+        placeholder,
+        scope.modifiedVariables.has(variable) ? 'var' : 'let',
+      ]),
     );
     if (Object.keys(replacements).length > 0) {
       const regex = new RegExp(Object.keys(replacements).join('|'), 'gi');

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "${configDir}/dist",
     "declaration": true,
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ES2024", "DOM"],
     "emitDeclarationOnly": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
Older environments may not support the latest ECMAScript features
- Also set the lib to `es2024` to avoid future mishaps