### PR TITLE
bump: tgpu-gen v0.11.0

### DIFF
--- a/packages/tgpu-gen/package.json
+++ b/packages/tgpu-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tgpu-gen",
-  "version": "0.2.0",
+  "version": "0.11.0",
   "description": "A CLI tool for automatic TypeGPU code generation.",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
We have been trying to keep the generator up to date, but never released a new version. That + having a release on npm that is released with provenance is valuable on its own.