### PR TITLE
feat: Limited support for the runtime ternary operator

### DIFF
--- a/apps/typegpu-docs/tests/individual-example-tests/game-of-life.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/game-of-life.test.ts
@@ -53,7 +53,7 @@ describe('game of life example', () => {
 
       fn wrappedCallback(x: u32, y: u32, _arg_2: u32) {
         randSeed2(((vec2f(f32(x), f32(y)) / f32(gameSizeUniform)) * timeUniform));
-        textureStore(next, vec2u(x, y), vec4u(u32(select(0, 1, (randFloat01() > 0.5f))), 0u, 0u, 0u));
+        textureStore(next, vec2u(x, y), vec4u(u32(select(0i, 1i, (randFloat01() > 0.5f))), 0u, 0u, 0u));
       }
 
       @compute @workgroup_size(16, 16, 1) fn mainCompute(@builtin(global_invocation_id) id: vec3u) {
@@ -146,7 +146,7 @@ describe('game of life example', () => {
         let current_1 = readTile(lx, ly);
         let neighbors = countNeighborsInTile(lx, ly);
         let nextAlive = golNextState((current_1 != 0u), neighbors);
-        textureStore(next, gid.xy, vec4u(u32(select(0, 1, nextAlive)), 0u, 0u, 0u));
+        textureStore(next, gid.xy, vec4u(u32(select(0i, 1i, nextAlive)), 0u, 0u, 0u));
       }
 
       @group(0) @binding(0) var<uniform> gameSizeUniform: u32;
@@ -199,7 +199,7 @@ describe('game of life example', () => {
         let current_1 = readTile(lx, ly);
         let neighbors = countNeighborsInTile(lx, ly);
         let nextAlive = golNextState((current_1 != 0u), neighbors);
-        textureStore(next, gid.xy, vec4u(u32(select(0, 1, nextAlive)), 0u, 0u, 0u));
+        textureStore(next, gid.xy, vec4u(u32(select(0i, 1i, nextAlive)), 0u, 0u, 0u));
       }
 
       struct fullScreenTriangle_Output {

--- a/apps/typegpu-docs/tests/individual-example-tests/jelly-switch.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/jelly-switch.test.ts
@@ -390,7 +390,7 @@ describe('jelly switch example', () => {
         let ndc = vec2f(((_arg_0.uv.x * 2f) - 1f), -(((_arg_0.uv.y * 2f) - 1f)));
         let ray = getRay(ndc);
         let color = rayMarch(ray.origin, ray.direction, _arg_0.uv);
-        let exposure = select(1.5, 2., (darkModeUniform == 1u));
+        let exposure = select(1.5f, 2f, (darkModeUniform == 1u));
         return vec4f(tanh((color.rgb * exposure)), 1f);
       }
 

--- a/apps/typegpu-docs/tests/individual-example-tests/probability.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/probability.test.ts
@@ -251,7 +251,7 @@ describe('probability distribution plot example', () => {
         let face = u32((sample() * 6f));
         let axis = (face % 3u);
         var result = vec3f();
-        result[axis] = f32(select(0, 1, (face > 2u)));
+        result[axis] = f32(select(0i, 1i, (face > 2u)));
         result[((axis + 1u) % 3u)] = sample();
         result[((axis + 2u) % 3u)] = sample();
         return result;

--- a/apps/typegpu-docs/tests/individual-example-tests/ripple-cube.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/ripple-cube.test.ts
@@ -262,7 +262,7 @@ describe('ripple-cube example', () => {
         const cellSize = 0.0047169811320754715;
         let p = ((vec3f(f32(x), f32(y), f32(z)) + 0.5f) * cellSize);
         let r = (timeUniform * 0.15f);
-        let iterCount = select(5, 11, (extendedRippleUniform == 1u));
+        let iterCount = select(5i, 11i, (extendedRippleUniform == 1u));
         var shellD = 1e+10f;
         for (var ix = 0; (ix < iterCount); ix++) {
           for (var iy = 0; (iy < iterCount); iy++) {

--- a/packages/typegpu/src/core/function/createCallableSchema.ts
+++ b/packages/typegpu/src/core/function/createCallableSchema.ts
@@ -1,4 +1,10 @@
-import { type MapValueToSnippet, type ResolvedSnippet, snip } from '../../data/snippet.ts';
+import {
+  type MapValueToSnippet,
+  noSideEffects,
+  type ResolvedSnippet,
+  snip,
+  type Snippet,
+} from '../../data/snippet.ts';
 import { type BaseData, isPtr } from '../../data/wgslTypes.ts';
 import { setName } from '../../shared/meta.ts';
 import { $gpuCallable } from '../../shared/symbols.ts';
@@ -51,10 +57,11 @@ export function callableSchema<T extends AnyFn>(options: CallableSchemaOptions<T
         return tryConvertSnippet(ctx, s, argType, false);
       }) as MapValueToSnippet<Parameters<T>>;
 
+      let result: Snippet;
       if (converted.every((s) => isKnownAtComptime(s))) {
         ctx.pushMode(new NormalState());
         try {
-          return snip(
+          result = snip(
             options.normalImpl(...(converted.map((s) => s.value) as never[])),
             options.schema(),
             // Functions give up ownership of their return value
@@ -63,9 +70,14 @@ export function callableSchema<T extends AnyFn>(options: CallableSchemaOptions<T
         } finally {
           ctx.popMode('normal');
         }
+      } else {
+        result = options.codegenImpl(ctx, converted);
       }
 
-      return options.codegenImpl(ctx, converted);
+      if (!args.some((a) => a.possibleSideEffects)) {
+        return noSideEffects(result);
+      }
+      return result;
     },
   };
 

--- a/packages/typegpu/src/core/slot/accessor.ts
+++ b/packages/typegpu/src/core/slot/accessor.ts
@@ -119,7 +119,7 @@ abstract class AccessorBase<
     try {
       // Doing a deep copy each time so that we don't have to deal with refs
       const cloned = schemaCallWrapper(this.schema, value);
-      return snip(cloned, this.schema, 'constant');
+      return snip(cloned, this.schema, 'constant', /* possibleSideEffects */ false);
     } finally {
       ctx.popMode('normal');
     }

--- a/packages/typegpu/src/data/snippet.ts
+++ b/packages/typegpu/src/data/snippet.ts
@@ -92,6 +92,7 @@ export interface Snippet {
    */
   readonly dataType: BaseData | UnknownData;
   readonly origin: Origin;
+  readonly possibleSideEffects: boolean;
 }
 
 export interface ResolvedSnippet extends Snippet {
@@ -105,11 +106,18 @@ class SnippetImpl implements Snippet {
   readonly value: unknown;
   readonly dataType: BaseData | UnknownData;
   readonly origin: Origin;
+  readonly possibleSideEffects: boolean;
 
-  constructor(value: unknown, dataType: BaseData | UnknownData, origin: Origin) {
+  constructor(
+    value: unknown,
+    dataType: BaseData | UnknownData,
+    origin: Origin,
+    possibleSideEffects: boolean,
+  ) {
     this.value = value;
     this.dataType = dataType;
     this.origin = origin;
+    this.possibleSideEffects = possibleSideEffects;
   }
 }
 
@@ -121,12 +129,23 @@ export function isSnippetNumeric(snippet: Snippet) {
   return isNumericSchema(snippet.dataType);
 }
 
-export function snip(value: string, dataType: BaseData, origin: Origin): ResolvedSnippet;
-export function snip(value: unknown, dataType: BaseData | UnknownData, origin: Origin): Snippet;
+export function snip(
+  value: string,
+  dataType: BaseData,
+  origin: Origin,
+  possibleSideEffects?: boolean,
+): ResolvedSnippet;
 export function snip(
   value: unknown,
   dataType: BaseData | UnknownData,
   origin: Origin,
+  possibleSideEffects?: boolean,
+): Snippet;
+export function snip(
+  value: unknown,
+  dataType: BaseData | UnknownData,
+  origin: Origin,
+  possibleSideEffects: boolean = true,
 ): Snippet | ResolvedSnippet {
   if (DEV && isSnippet(value)) {
     // An early error, but not worth checking every time in production
@@ -138,5 +157,30 @@ export function snip(
     // We don't care about attributes in snippet land, so we discard that information.
     undecorate(dataType as BaseData),
     origin,
+    possibleSideEffects,
   );
+}
+
+export function withDataType(
+  dataType: BaseData | UnknownData,
+  snippet: ResolvedSnippet,
+): ResolvedSnippet;
+export function withDataType(dataType: BaseData | UnknownData, snippet: Snippet): Snippet;
+export function withDataType(dataType: BaseData | UnknownData, snippet: Snippet): Snippet {
+  return new SnippetImpl(snippet.value, dataType, snippet.origin, snippet.possibleSideEffects);
+}
+
+export function withSideEffects(
+  possibleSideEffects: boolean,
+  snippet: ResolvedSnippet,
+): ResolvedSnippet;
+export function withSideEffects(possibleSideEffects: boolean, snippet: Snippet): Snippet;
+export function withSideEffects(possibleSideEffects: boolean, snippet: Snippet): Snippet {
+  return new SnippetImpl(snippet.value, snippet.dataType, snippet.origin, possibleSideEffects);
+}
+
+export function noSideEffects(snippet: ResolvedSnippet): ResolvedSnippet;
+export function noSideEffects(snippet: Snippet): Snippet;
+export function noSideEffects(snippet: Snippet): Snippet {
+  return withSideEffects(/* possibleSideEffects */ false, snippet);
 }

--- a/packages/typegpu/src/std/boolean.ts
+++ b/packages/typegpu/src/std/boolean.ts
@@ -1,8 +1,24 @@
 import { dualImpl } from '../core/function/dualImpl.ts';
 import { stitch } from '../core/resolve/stitch.ts';
-import { bool, f32 } from '../data/numeric.ts';
+import { bool, f16, f32, i32, u32 } from '../data/numeric.ts';
 import { isSnippetNumeric, snip } from '../data/snippet.ts';
-import { vec2b, vec3b, vec4b } from '../data/vector.ts';
+import {
+  vec2b,
+  vec2f,
+  vec2h,
+  vec2i,
+  vec2u,
+  vec3b,
+  vec3f,
+  vec3h,
+  vec3i,
+  vec3u,
+  vec4b,
+  vec4f,
+  vec4h,
+  vec4i,
+  vec4u,
+} from '../data/vector.ts';
 import { VectorOps } from '../data/vectorOps.ts';
 import {
   type AnyBooleanVecInstance,
@@ -374,6 +390,29 @@ function cpuSelect<T extends number | boolean | AnyVecInstance>(
   );
 }
 
+export const validSelectBranchTypes: AnyWgslData[] = [
+  f32,
+  f16,
+  i32,
+  u32,
+  bool,
+  vec2f,
+  vec3f,
+  vec4f,
+  vec2h,
+  vec3h,
+  vec4h,
+  vec2i,
+  vec3i,
+  vec4i,
+  vec2u,
+  vec3u,
+  vec4u,
+  vec2b,
+  vec3b,
+  vec4b,
+];
+
 /**
  * Returns `t` if `cond` is `true`, and `f` otherwise.
  * Component-wise if `cond` is a vector.
@@ -386,9 +425,27 @@ function cpuSelect<T extends number | boolean | AnyVecInstance>(
 export const select = dualImpl({
   name: 'select',
   signature: (f, t, cond) => {
-    const [uf, ut] = unify([f, t]) ?? ([f, t] as const);
+    const [uf, ut] = unify([f, t], validSelectBranchTypes) ?? ([f, t] as const);
     return { argTypes: [uf, ut, cond], returnType: uf };
   },
   normalImpl: cpuSelect,
-  codegenImpl: (_ctx, [f, t, cond]) => stitch`select(${f}, ${t}, ${cond})`,
+  codegenImpl: (ctx, [f, t, cond]) => {
+    const result = stitch`select(${f}, ${t}, ${cond})`;
+    if (
+      !validSelectBranchTypes.includes(f.dataType as AnyWgslData) ||
+      !validSelectBranchTypes.includes(t.dataType as AnyWgslData)
+    ) {
+      throw new Error(
+        `'${result}' is invalid, std.select requires both branches to be either scalars or vectors.`,
+      );
+    }
+    if (f.dataType !== t.dataType) {
+      const fStr = ctx.resolve(f.dataType);
+      const tStr = ctx.resolve(t.dataType);
+      throw new Error(
+        `'${result}' is invalid, std.select requires both branches to be the same type, got [${fStr.value}, ${tStr.value}].`,
+      );
+    }
+    return result;
+  },
 });

--- a/packages/typegpu/src/tgsl/accessIndex.ts
+++ b/packages/typegpu/src/tgsl/accessIndex.ts
@@ -1,7 +1,8 @@
 import { stitch } from '../core/resolve/stitch.ts';
 import { isDisarray, MatrixColumnsAccess } from '../data/dataTypes.ts';
 import { derefSnippet } from '../data/ref.ts';
-import { type Origin, snip, type Snippet } from '../data/snippet.ts';
+import { snip } from '../data/snippet.ts';
+import type { Origin, Snippet } from '../data/snippet.ts';
 import { vec2f, vec3f, vec4f } from '../data/vector.ts';
 import { type BaseData, isPtr, isVec, isWgslArray, isWgslStruct } from '../data/wgslTypes.ts';
 import { isKnownAtComptime } from '../types.ts';
@@ -51,6 +52,7 @@ export function accessIndex(target: Snippet, indexArg: Snippet | number): Snippe
         : stitch`${target}[${index}]`,
       elementType,
       /* origin */ origin,
+      target.possibleSideEffects || index.possibleSideEffects,
     );
   }
 
@@ -63,6 +65,7 @@ export function accessIndex(target: Snippet, indexArg: Snippet | number): Snippe
         : stitch`${target}[${index}]`,
       target.dataType.primitive,
       /* origin */ target.origin,
+      target.possibleSideEffects || index.possibleSideEffects,
     );
   }
 
@@ -79,7 +82,12 @@ export function accessIndex(target: Snippet, indexArg: Snippet | number): Snippe
         (target.value.matrix.dataType as BaseData).type as keyof typeof indexableTypeToResult
       ];
 
-    return snip(stitch`${target.value.matrix}[${index}]`, propType, /* origin */ target.origin);
+    return snip(
+      stitch`${target.value.matrix}[${index}]`,
+      propType,
+      /* origin */ target.origin,
+      target.possibleSideEffects || index.possibleSideEffects,
+    );
   }
 
   // matrix

--- a/packages/typegpu/src/tgsl/accessProp.ts
+++ b/packages/typegpu/src/tgsl/accessProp.ts
@@ -8,7 +8,7 @@ import {
   undecorate,
   UnknownData,
 } from '../data/dataTypes.ts';
-import { abstractInt, bool, f16, f32, i32, u32 } from '../data/numeric.ts';
+import { bool, f16, f32, i32, u32 } from '../data/numeric.ts';
 import { derefSnippet } from '../data/ref.ts';
 import { isSnippet, snip, type Snippet } from '../data/snippet.ts';
 import {
@@ -39,7 +39,7 @@ import {
 import { $gpuCallable } from '../shared/symbols.ts';
 import { add, bitShiftLeft, bitShiftRight, div, mod, mul, sub } from '../std/operators.ts';
 import { isKnownAtComptime } from '../types.ts';
-import { coerceToSnippet } from './generationHelpers.ts';
+import { coerceToSnippet, numericLiteralToSnippet } from './generationHelpers.ts';
 
 const infixKinds = [
   'vec2f',
@@ -114,20 +114,31 @@ export function accessProp(target: Snippet, propName: string): Snippet | undefin
       new InfixDispatch(propName, target, operator[$gpuCallable].call.bind(operator)),
       UnknownData,
       /* origin */ target.origin,
+      target.possibleSideEffects,
     );
   }
 
   if (isWgslArray(target.dataType) && propName === 'length') {
     if (target.dataType.elementCount === 0) {
       // Dynamically-sized array
-      return snip(stitch`arrayLength(&${target})`, u32, /* origin */ 'runtime');
+      return snip(
+        stitch`arrayLength(&${target})`,
+        u32,
+        /* origin */ 'runtime',
+        target.possibleSideEffects,
+      );
     }
 
-    return snip(target.dataType.elementCount, abstractInt, /* origin */ 'constant');
+    return numericLiteralToSnippet(target.dataType.elementCount);
   }
 
   if (isMat(target.dataType) && propName === 'columns') {
-    return snip(new MatrixColumnsAccess(target), UnknownData, /* origin */ target.origin);
+    return snip(
+      new MatrixColumnsAccess(target),
+      UnknownData,
+      /* origin */ target.origin,
+      target.possibleSideEffects,
+    );
   }
 
   if (isWgslStruct(target.dataType) || isUnstruct(target.dataType)) {
@@ -137,7 +148,12 @@ export function accessProp(target: Snippet, propName: string): Snippet | undefin
     }
     propType = undecorate(propType);
 
-    return snip(stitch`${target}.${propName}`, propType, /* origin */ target.origin);
+    return snip(
+      stitch`${target}.${propName}`,
+      propType,
+      /* origin */ target.origin,
+      target.possibleSideEffects,
+    );
   }
 
   if (target.dataType instanceof AutoStruct) {
@@ -145,7 +161,12 @@ export function accessProp(target: Snippet, propName: string): Snippet | undefin
     if (!result) {
       return undefined;
     }
-    return snip(stitch`${target}.${result.prop}`, result.type, 'argument');
+    return snip(
+      stitch`${target}.${result.prop}`,
+      result.type,
+      'argument',
+      target.possibleSideEffects,
+    );
   }
 
   if (target.dataType instanceof EntryInputRouter) {
@@ -175,7 +196,8 @@ export function accessProp(target: Snippet, propName: string): Snippet | undefin
   if (isVec(target.dataType)) {
     // Example: d.vec3f().kind === 'vec3f'
     if (propName === 'kind') {
-      return snip(target.dataType.type, UnknownData, 'constant');
+      // The snippet has no side-effects
+      return snip(target.dataType.type, UnknownData, 'constant', /* possibleSideEffects */ false);
     }
   }
 
@@ -209,6 +231,7 @@ export function accessProp(target: Snippet, propName: string): Snippet | undefin
         : target.origin === 'constant' || target.origin === 'constant-immutable-def'
           ? 'constant'
           : 'runtime',
+      target.possibleSideEffects,
     );
   }
 

--- a/packages/typegpu/src/tgsl/conversion.ts
+++ b/packages/typegpu/src/tgsl/conversion.ts
@@ -3,7 +3,7 @@ import { UnknownData } from '../data/dataTypes.ts';
 import { undecorate } from '../data/dataTypes.ts';
 import { derefSnippet, RefOperator } from '../data/ref.ts';
 import { schemaCallWrapperGPU } from '../data/schemaCallWrapper.ts';
-import { snip, type Snippet } from '../data/snippet.ts';
+import { snip, withDataType, type Snippet } from '../data/snippet.ts';
 import {
   type AbstractFloat,
   type AnyWgslData,
@@ -245,12 +245,7 @@ function applyActionToSnippet(
       return snippet;
     }
 
-    return snip(
-      snippet.value,
-      targetType,
-      // if it was a ref, then it's still a ref
-      /* origin */ snippet.origin,
-    );
+    return withDataType(targetType, snippet);
   }
 
   switch (action.action) {

--- a/packages/typegpu/src/tgsl/generationHelpers.ts
+++ b/packages/typegpu/src/tgsl/generationHelpers.ts
@@ -1,7 +1,8 @@
 import { UnknownData } from '../data/dataTypes.ts';
 import { abstractFloat, abstractInt, bool, f32, i32 } from '../data/numeric.ts';
 import { isRef } from '../data/ref.ts';
-import { isAlias, isSnippet, type ResolvedSnippet, snip, type Snippet } from '../data/snippet.ts';
+import { isAlias, isSnippet, snip } from '../data/snippet.ts';
+import type { ResolvedSnippet, Snippet } from '../data/snippet.ts';
 import {
   type AnyWgslData,
   type BaseData,
@@ -27,7 +28,7 @@ import type { SupportedLogOp } from './consoleLog/types.ts';
 
 export function numericLiteralToSnippet(value: number): Snippet {
   if (value >= 2 ** 63 || value < -(2 ** 63)) {
-    return snip(value, abstractFloat, /* origin */ 'constant');
+    return snip(value, abstractFloat, /* origin */ 'constant', /* possibleSideEffects */ false);
   }
   // WGSL AbstractInt uses 64-bit precision, but JS numbers are only safe up to 2^53 - 1.
   // Warn when values exceed this range to prevent precision loss.
@@ -37,9 +38,9 @@ export function numericLiteralToSnippet(value: number): Snippet {
         `The integer ${value} exceeds the safe integer range and may have lost precision.`,
       );
     }
-    return snip(value, abstractInt, /* origin */ 'constant');
+    return snip(value, abstractInt, /* origin */ 'constant', /* possibleSideEffects */ false);
   }
-  return snip(value, abstractFloat, /* origin */ 'constant');
+  return snip(value, abstractFloat, /* origin */ 'constant', /* possibleSideEffects */ false);
 }
 
 export function concretize<T extends BaseData>(type: T): T | F32 | I32 {
@@ -113,7 +114,12 @@ export function coerceToSnippet(value: unknown): Snippet {
   }
 
   if (isVecInstance(value) || isMatInstance(value)) {
-    return snip(value, WORKAROUND_getSchema(value), /* origin */ 'constant');
+    return snip(
+      value,
+      WORKAROUND_getSchema(value),
+      /* origin */ 'constant',
+      /* possibleSideEffects */ false,
+    );
   }
 
   if (
@@ -125,7 +131,7 @@ export function coerceToSnippet(value: unknown): Snippet {
     value === null
   ) {
     // Nothing representable in WGSL as-is, so unknown
-    return snip(value, UnknownData, /* origin */ 'constant');
+    return snip(value, UnknownData, /* origin */ 'constant', /* possibleSideEffects */ false);
   }
 
   if (typeof value === 'number') {
@@ -133,10 +139,10 @@ export function coerceToSnippet(value: unknown): Snippet {
   }
 
   if (typeof value === 'boolean') {
-    return snip(value, bool, /* origin */ 'constant');
+    return snip(value, bool, /* origin */ 'constant', /* possibleSideEffects */ false);
   }
 
-  return snip(value, UnknownData, /* origin */ 'constant');
+  return snip(value, UnknownData, /* origin */ 'constant', /* possibleSideEffects */ false);
 }
 
 /**

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -46,6 +46,7 @@ import { isTgpuRange } from '../std/range.ts';
 import { stringifyNode } from '../shared/tseynit.ts';
 import type { FunctionDefinitionOptions } from './shaderGenerator_members.ts';
 import { getAttributesString } from '../data/attributes.ts';
+import { validSelectBranchTypes } from '../std/boolean.ts';
 
 const { NodeTypeCatalog: NODE } = tinyest;
 
@@ -804,13 +805,29 @@ ${this.ctx.pre}}`;
 
     if (expression[0] === NODE.conditionalExpr) {
       // ternary operator
-      const [_, test, consequent, alternative] = expression;
-      const testExpression = this._expression(test);
-      if (isKnownAtComptime(testExpression)) {
-        return testExpression.value ? this._expression(consequent) : this._expression(alternative);
+      const [_, testNode, consequentNode, alternativeNode] = expression;
+      const test = this._expression(testNode);
+
+      if (isKnownAtComptime(test)) {
+        return test.value ? this._expression(consequentNode) : this._expression(alternativeNode);
       } else {
-        throw new Error(
-          `Ternary operator '${stringifyNode(expression)}' is invalid, because only comptime-known checks are supported. For runtime checks, please use 'std.select' or if/else statements.`,
+        const consequent = this._expression(consequentNode);
+        const alternative = this._expression(alternativeNode);
+        const [con, alt] =
+          convertToCommonType(this.ctx, [consequent, alternative], validSelectBranchTypes) ?? [];
+
+        if (!con || !alt || consequent.possibleSideEffects || alternative.possibleSideEffects) {
+          throw new Error(
+            `Ternary operator '${stringifyNode(expression)}' is invalid. For more complex branching, please use 'std.select' or if/else statements.`,
+          );
+        }
+
+        return snip(
+          stitch`select(${alt}, ${con}, ${test})`,
+          con.dataType,
+          'runtime',
+          // this select has side-effects only if the condition has side-effects
+          test.possibleSideEffects,
         );
       }
     }
@@ -1007,6 +1024,8 @@ Try 'return ${typeStr}(${str});' instead.
       this.ctx.makeUniqueIdentifier(rawId, 'block'),
       concreteType,
       /* origin */ 'local-def',
+      // Accessing variable declarations is side-effect free.
+      /* possibleSideEffects */ false,
     );
     this.ctx.defineVariable(rawId, snippet);
 
@@ -1121,6 +1140,8 @@ Try 'return ${typeStr}(${str});' instead.
       this.ctx.makeUniqueIdentifier(rawId, 'block'),
       concreteType,
       /* origin */ varOrigin,
+      // Accessing variable declarations is side-effect free.
+      /* possibleSideEffects */ false,
     );
     this.ctx.defineVariable(rawId, snippet);
 

--- a/packages/typegpu/tests/tgsl/generationHelpers.test.ts
+++ b/packages/typegpu/tests/tgsl/generationHelpers.test.ts
@@ -27,27 +27,33 @@ describe('generationHelpers', () => {
 
   describe('numericLiteralToSnippet', () => {
     it('should convert numeric literals to correct snippets', () => {
-      expect(numericLiteralToSnippet(1)).toEqual(snip(1, abstractInt, /* origin */ 'constant'));
+      expect(numericLiteralToSnippet(1)).toEqual(
+        snip(1, abstractInt, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
 
       expect(numericLiteralToSnippet(1.1)).toEqual(
-        snip(1.1, abstractFloat, /* origin */ 'constant'),
+        snip(1.1, abstractFloat, /* origin */ 'constant', /* possibleSideEffects */ false),
       );
 
       expect(numericLiteralToSnippet(1e10)).toEqual(
-        snip(1e10, abstractInt, /* origin */ 'constant'),
+        snip(1e10, abstractInt, /* origin */ 'constant', /* possibleSideEffects */ false),
       );
 
       expect(numericLiteralToSnippet(0.5)).toEqual(
-        snip(0.5, abstractFloat, /* origin */ 'constant'),
+        snip(0.5, abstractFloat, /* origin */ 'constant', /* possibleSideEffects */ false),
       );
 
-      expect(numericLiteralToSnippet(-45)).toEqual(snip(-45, abstractInt, /* origin */ 'constant'));
+      expect(numericLiteralToSnippet(-45)).toEqual(
+        snip(-45, abstractInt, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
 
       expect(numericLiteralToSnippet(0x1a)).toEqual(
-        snip(0x1a, abstractInt, /* origin */ 'constant'),
+        snip(0x1a, abstractInt, /* origin */ 'constant', /* possibleSideEffects */ false),
       );
 
-      expect(numericLiteralToSnippet(0b101)).toEqual(snip(5, abstractInt, /* origin */ 'constant'));
+      expect(numericLiteralToSnippet(0b101)).toEqual(
+        snip(5, abstractInt, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
     });
   });
 
@@ -127,21 +133,39 @@ describe('generationHelpers', () => {
     const arr = arrayOf(f32, 2);
 
     it('coerces JS numbers', () => {
-      expect(coerceToSnippet(1)).toEqual(snip(1, abstractInt, /* origin */ 'constant'));
-      expect(coerceToSnippet(2.5)).toEqual(snip(2.5, abstractFloat, /* origin */ 'constant'));
-      expect(coerceToSnippet(-10)).toEqual(snip(-10, abstractInt, /* origin */ 'constant'));
-      expect(coerceToSnippet(0.0)).toEqual(snip(0, abstractInt, /* origin */ 'constant'));
+      expect(coerceToSnippet(1)).toEqual(
+        snip(1, abstractInt, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
+      expect(coerceToSnippet(2.5)).toEqual(
+        snip(2.5, abstractFloat, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
+      expect(coerceToSnippet(-10)).toEqual(
+        snip(-10, abstractInt, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
+      expect(coerceToSnippet(0.0)).toEqual(
+        snip(0, abstractInt, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
     });
 
     it('coerces JS booleans', () => {
-      expect(coerceToSnippet(true)).toEqual(snip(true, bool, /* origin */ 'constant'));
-      expect(coerceToSnippet(false)).toEqual(snip(false, bool, /* origin */ 'constant'));
+      expect(coerceToSnippet(true)).toEqual(
+        snip(true, bool, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
+      expect(coerceToSnippet(false)).toEqual(
+        snip(false, bool, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
     });
 
     it(`coerces schemas to UnknownData (as they're not instance types)`, () => {
-      expect(coerceToSnippet(f32)).toEqual(snip(f32, UnknownData, /* origin */ 'constant'));
-      expect(coerceToSnippet(vec3i)).toEqual(snip(vec3i, UnknownData, /* origin */ 'constant'));
-      expect(coerceToSnippet(arr)).toEqual(snip(arr, UnknownData, /* origin */ 'constant'));
+      expect(coerceToSnippet(f32)).toEqual(
+        snip(f32, UnknownData, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
+      expect(coerceToSnippet(vec3i)).toEqual(
+        snip(vec3i, UnknownData, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
+      expect(coerceToSnippet(arr)).toEqual(
+        snip(arr, UnknownData, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
     });
 
     it('coerces arrays to unknown', () => {
@@ -165,14 +189,22 @@ describe('generationHelpers', () => {
     });
 
     it('returns UnknownData for other types', () => {
-      expect(coerceToSnippet('foo')).toEqual(snip('foo', UnknownData, /* origin */ 'constant'));
-      expect(coerceToSnippet({})).toEqual(snip({}, UnknownData, /* origin */ 'constant'));
-      expect(coerceToSnippet(null)).toEqual(snip(null, UnknownData, /* origin */ 'constant'));
+      expect(coerceToSnippet('foo')).toEqual(
+        snip('foo', UnknownData, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
+      expect(coerceToSnippet({})).toEqual(
+        snip({}, UnknownData, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
+      expect(coerceToSnippet(null)).toEqual(
+        snip(null, UnknownData, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
       expect(coerceToSnippet(undefined)).toEqual(
-        snip(undefined, UnknownData, /* origin */ 'constant'),
+        snip(undefined, UnknownData, /* origin */ 'constant', /* possibleSideEffects */ false),
       );
       const fn = () => {};
-      expect(coerceToSnippet(fn)).toEqual(snip(fn, UnknownData, /* origin */ 'constant'));
+      expect(coerceToSnippet(fn)).toEqual(
+        snip(fn, UnknownData, /* origin */ 'constant', /* possibleSideEffects */ false),
+      );
     });
   });
 });

--- a/packages/typegpu/tests/tgsl/sideEffects.test.ts
+++ b/packages/typegpu/tests/tgsl/sideEffects.test.ts
@@ -1,0 +1,97 @@
+import tgpu, { d } from 'typegpu';
+import { test } from 'typegpu-testing-utility';
+import { expectSideEffects } from '../utils/parseResolved.ts';
+import { describe } from 'vitest';
+
+describe('code without side-effects', () => {
+  test('scalar literals', () => {
+    const returnSlot = tgpu.slot();
+    const fn = tgpu.fn(() => {
+      'use gpu';
+      return returnSlot.$;
+    });
+
+    expectSideEffects(fn.with(returnSlot, 0)).toEqual(false);
+    expectSideEffects(fn.with(returnSlot, 1.5)).toEqual(false);
+    expectSideEffects(fn.with(returnSlot, -100)).toEqual(false);
+    expectSideEffects(fn.with(returnSlot, false)).toEqual(false);
+  });
+
+  test('vectors created from literals', () => {
+    expectSideEffects(() => {
+      'use gpu';
+      return d.vec3f();
+    }).toEqual(false);
+
+    expectSideEffects(() => {
+      'use gpu';
+      return d.vec3f(1, 2, 3);
+    }).toEqual(false);
+  });
+
+  test('variables', () => {
+    expectSideEffects(() => {
+      'use gpu';
+      const hello = 1;
+      return hello;
+    }).toEqual(false);
+
+    expectSideEffects(() => {
+      'use gpu';
+      const hello = [1, 2, 3];
+      return hello;
+    }).toEqual(false);
+  });
+
+  test('indexed arrays', () => {
+    expectSideEffects(() => {
+      'use gpu';
+      const hello = [1, 2, 3];
+      return hello[0];
+    }).toEqual(false);
+  });
+
+  test('vectors created from indexed arrays', () => {
+    expectSideEffects(() => {
+      'use gpu';
+      const arr = [1, 2, 3];
+      return d.vec3f(arr[0]!);
+    }).toEqual(false);
+  });
+
+  test('vector from accessor', () => {
+    const v = tgpu.accessor(d.vec3f, d.vec3f());
+    expectSideEffects(() => {
+      'use gpu';
+      return v.$;
+    }).toEqual(false);
+  });
+
+  test('prop access', () => {
+    const Foo = d.struct({
+      prop: d.f32,
+    });
+
+    expectSideEffects(() => {
+      'use gpu';
+      const foo = Foo();
+      return foo.prop;
+    }).toEqual(false);
+  });
+});
+
+describe('code with side-effects', () => {
+  test('vectors created from side-effectful components', () => {
+    const next = tgpu.privateVar(d.f32);
+
+    function getNextValue() {
+      'use gpu';
+      return next.$;
+    }
+
+    expectSideEffects(() => {
+      'use gpu';
+      return d.vec3f(getNextValue(), getNextValue(), getNextValue());
+    }).toEqual(true);
+  });
+});

--- a/packages/typegpu/tests/tgsl/ternaryOperator.test.ts
+++ b/packages/typegpu/tests/tgsl/ternaryOperator.test.ts
@@ -132,6 +132,55 @@ describe('ternary operator', () => {
     `);
   });
 
+  it('should generate select() when branches are scalars', () => {
+    function foo() {
+      'use gpu';
+      const cond = false;
+      return cond ? 1 : 0;
+    }
+
+    expect(tgpu.resolve([foo])).toMatchInlineSnapshot(`
+      "fn foo() -> i32 {
+        const cond = false;
+        return select(0i, 1i, cond);
+      }"
+    `);
+  });
+
+  it('should generate select() when branches are vector constructors', () => {
+    function foo() {
+      'use gpu';
+      const count = 10;
+      const anchor = count > 0 ? d.vec2f(1, 2) : d.vec2f();
+      return anchor;
+    }
+
+    expect(tgpu.resolve([foo])).toMatchInlineSnapshot(`
+      "fn foo() -> vec2f {
+        const count = 10;
+        let anchor = select(vec2f(), vec2f(1, 2), (count > 0i));
+        return anchor;
+      }"
+    `);
+  });
+
+  it('should generate select() when branches contain side-effect free array indexing', () => {
+    function foo() {
+      'use gpu';
+      const array = [0];
+      const cond = false;
+      return cond ? d.vec2f(array[0]!) : d.vec2f();
+    }
+
+    expect(tgpu.resolve([foo])).toMatchInlineSnapshot(`
+      "fn foo() -> vec2f {
+        let array_1 = array<i32, 1>(0);
+        const cond = false;
+        return select(vec2f(), vec2f(f32(array_1[0i])), cond);
+      }"
+    `);
+  });
+
   it('should throw when test is not comptime known', () => {
     const myFn = tgpu.fn(
       [d.u32],
@@ -143,7 +192,7 @@ describe('ternary operator', () => {
     expect(() => tgpu.resolve([myFn])).toThrowErrorMatchingInlineSnapshot(`
       [Error: Resolution of the following tree failed:
       - <root>
-      - fn:myFn: Ternary operator '(n > 0) ? n : (-n)' is invalid, because only comptime-known checks are supported. For runtime checks, please use 'std.select' or if/else statements.]
+      - fn:myFn: Ternary operator '(n > 0) ? n : (-n)' is invalid. For more complex branching, please use 'std.select' or if/else statements.]
     `);
   });
 });

--- a/packages/typegpu/tests/utils/parseResolved.ts
+++ b/packages/typegpu/tests/utils/parseResolved.ts
@@ -65,3 +65,7 @@ export function expectSnippetOf(
 export function expectDataTypeOf(cb: () => unknown): Assertion<d.BaseData | UnknownData> {
   return expect<d.BaseData | UnknownData>(extractSnippetFromFn(cb).dataType);
 }
+
+export function expectSideEffects(cb: () => unknown): Assertion<boolean> {
+  return expect<boolean>(extractSnippetFromFn(cb).possibleSideEffects);
+}


### PR DESCRIPTION
- Adds a new flag to the snippet, which needs to be explicitly set whenever we can guarantee that it contains a side-effect free expression
- Uses that flag to emit `std.select` from a ternary operator if both branches produce scalars or vectors, and are free of side-effects.

**TODO in subsequent PRs:**
- [ ] Detect if a function can produce side-effects, which should boil down to detecting if all of its statements are side-effect free.
- [ ] Mark more operations as side-effect free, like prop access, some standard functions (e.g. `atomicStore` is not side-effect free), etc.