### PR TITLE
feat: common.attachAutoResizer

### DIFF
--- a/apps/typegpu-docs/src/components/ExampleView.tsx
+++ b/apps/typegpu-docs/src/components/ExampleView.tsx
@@ -1,6 +1,6 @@
 import cs from 'classnames';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { type RefObject, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { currentSnackbarAtom } from '../utils/examples/currentSnackbarAtom.ts';
 import { codeEditorShownAtom, tsoverUsedAtom } from '../utils/examples/exampleViewStateAtoms.ts';
 import { ExecutionCancelledError } from '../utils/examples/errors.ts';
@@ -91,7 +91,6 @@ export function ExampleView({ example, common }: Props) {
   }, [htmlFile]);
 
   useExample(tsImport, setSnackbarText);
-  useResizableCanvas(exampleHtmlRef);
 
   return (
     <>
@@ -205,85 +204,6 @@ function GPUUnsupportedPanel() {
       </a>
     </div>
   );
-}
-
-function useResizableCanvas(exampleHtmlRef: RefObject<HTMLDivElement | null>) {
-  useEffect(() => {
-    const canvases = exampleHtmlRef.current?.querySelectorAll('canvas') as
-      | HTMLCanvasElement[]
-      | undefined;
-    const observers: ResizeObserver[] = [];
-
-    for (const canvas of canvases ?? []) {
-      if ('width' in canvas.attributes || 'height' in canvas.attributes) {
-        continue;
-      }
-
-      const newCanvas = document.createElement('canvas');
-      const container = document.createElement('div');
-      const frame = document.createElement('div');
-
-      frame.appendChild(newCanvas);
-      container.appendChild(frame);
-
-      container.className = 'flex flex-1 justify-center items-center w-full h-full md:w-auto';
-      container.style.containerType = 'size';
-
-      frame.className = 'relative';
-
-      if (canvas.dataset.fitToContainer !== undefined) {
-        frame.style.width = '100%';
-        frame.style.height = '100%';
-      } else {
-        const aspectRatio = canvas.dataset.aspectRatio ?? '1';
-        frame.style.aspectRatio = aspectRatio;
-        frame.style.height = `min(100cqh, calc(100cqw/(${aspectRatio})))`;
-      }
-
-      for (const prop of canvas.style) {
-        // @ts-expect-error
-        newCanvas.style[prop] = canvas.style[prop];
-      }
-      for (const attribute of canvas.attributes) {
-        // @ts-expect-error
-        newCanvas[attribute.name] = attribute.value;
-      }
-      newCanvas.className = 'absolute w-full h-full';
-
-      canvas.parentElement?.replaceChild(container, canvas);
-
-      const onResize: ResizeObserverCallback = ([entry]) => {
-        if (!entry) {
-          return;
-        }
-
-        // Despite what the types say this property does not exist in Safari (hence the optional chaining).
-        const dpcb = entry.devicePixelContentBoxSize?.[0] as ResizeObserverSize | undefined;
-
-        const dpr = dpcb ? 1 : window.devicePixelRatio || 1;
-        const box =
-          dpcb ??
-          (Array.isArray(entry.contentBoxSize) ? entry.contentBoxSize[0] : entry.contentBoxSize);
-
-        if (!box) {
-          return;
-        }
-
-        newCanvas.width = Math.round(box.inlineSize * dpr);
-        newCanvas.height = Math.round(box.blockSize * dpr);
-      };
-
-      const observer = new ResizeObserver(onResize);
-      observer.observe(newCanvas);
-      observers.push(observer);
-    }
-
-    return () => {
-      for (const observer of observers) {
-        observer.disconnect();
-      }
-    };
-  }, [exampleHtmlRef]);
 }
 
 /**

--- a/apps/typegpu-docs/src/components/stackblitz/stackBlitzIndex.ts
+++ b/apps/typegpu-docs/src/components/stackblitz/stackBlitzIndex.ts
@@ -10,52 +10,6 @@ body.style.margin = '0';
 body.style.boxSizing = 'border-box';
 body.style.padding = '1rem';
 
-// Resize canvases
-for (const canvas of document.querySelectorAll('canvas')) {
-  if ('width' in canvas.attributes || 'height' in canvas.attributes) {
-    continue; // custom canvas, not replacing with resizable
-  }
-
-  const container = document.createElement('div');
-  const frame = document.createElement('div');
-
-  canvas.parentElement?.replaceChild(container, canvas);
-
-  frame.appendChild(canvas);
-  container.appendChild(frame);
-
-  container.style.display = 'flex';
-  container.style.flex = '1';
-  container.style.justifyContent = 'center';
-  container.style.alignItems = 'top';
-  container.style.width = '100%';
-
-  container.style.containerType = 'size';
-
-  frame.style.position = 'relative';
-
-  if (canvas.dataset.fitToContainer !== undefined) {
-    frame.style.width = '100%';
-    frame.style.height = '100%';
-  } else {
-    const aspectRatio = canvas.dataset.aspectRatio ?? '1';
-    frame.style.aspectRatio = aspectRatio;
-    frame.style.height = `min(calc(min(100cqw, 100cqh)/(${aspectRatio})), min(100cqw, 100cqh))`;
-  }
-
-  canvas.style.position = 'absolute';
-  canvas.style.width = '100%';
-  canvas.style.height = '100%';
-
-  const onResize = () => {
-    canvas.width = frame.clientWidth * window.devicePixelRatio;
-    canvas.height = frame.clientHeight * window.devicePixelRatio;
-  };
-
-  onResize();
-  new ResizeObserver(onResize).observe(container);
-}
-
 const controlsPanel = document.createElement('div');
 controlsPanel.style.display = 'grid';
 controlsPanel.style.gridTemplateColumns = '1fr 1fr';

--- a/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/index.html
+++ b/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/index.html
@@ -1,4 +1,4 @@
-<canvas></canvas>
+<canvas class="w-full h-full" />
 <div id="sort-overlay" hidden>
   <div id="sort-spinner"></div>
   <span id="sort-status"></span>

--- a/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import {
   type BitonicSorter,
   type BitonicSorterOptions,
@@ -6,7 +6,6 @@ import {
   decomposeWorkgroups,
 } from '@typegpu/sort';
 import { randf } from '@typegpu/noise';
-import { fullScreenTriangle } from 'typegpu/common';
 import { defineControls } from '../../common/defineControls.ts';
 
 const maxBufferSize = await navigator.gpu.requestAdapter().then((adapter) => {
@@ -32,7 +31,10 @@ const querySet = hasTimestampQuery ? root.createQuerySet('timestamp', 2) : null;
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
 const context = root.configureContext({ canvas });
 
-const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+});
 
 const maxSide = Math.floor(Math.sqrt(maxBufferSize / 4));
 const minLog = 2; // log_2(4)
@@ -75,17 +77,11 @@ const state = {
 const WORKGROUP_SIZE = 256;
 
 const renderLayout = tgpu.bindGroupLayout({
-  data: {
-    storage: d.arrayOf(d.u32),
-    access: 'readonly',
-  },
+  data: { storage: d.arrayOf(d.u32), access: 'readonly' },
 });
 
 const initLayout = tgpu.bindGroupLayout({
-  data: {
-    storage: d.arrayOf(d.u32),
-    access: 'mutable',
-  },
+  data: { storage: d.arrayOf(d.u32), access: 'mutable' },
 });
 
 const initSeed = root.createUniform(d.f32, 0);
@@ -135,9 +131,8 @@ const initKernel = tgpu.computeFn({
 });
 
 const renderPipeline = root.createRenderPipeline({
-  vertex: fullScreenTriangle,
+  vertex: common.fullScreenTriangle,
   fragment: fragmentFn,
-  targets: { format: presentationFormat },
 });
 
 const initPipeline = root.createComputePipeline({ compute: initKernel });
@@ -275,6 +270,7 @@ export function onCleanup() {
   for (const s of Object.values(sorters)) {
     s.destroy();
   }
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/index.ts
@@ -236,7 +236,7 @@ async function sort() {
   hideOverlay();
 }
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -273,7 +273,7 @@ export function onCleanup() {
   for (const s of Object.values(sorters)) {
     s.destroy();
   }
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/index.ts
@@ -31,11 +31,6 @@ const querySet = hasTimestampQuery ? root.createQuerySet('timestamp', 2) : null;
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
 const context = root.configureContext({ canvas });
 
-const detachAutoResizer = common.attachAutoResizer({
-  root,
-  canvas,
-});
-
 const maxSide = Math.floor(Math.sqrt(maxBufferSize / 4));
 const minLog = 2; // log_2(4)
 const maxLog = Math.floor(Math.log2(maxSide));
@@ -240,6 +235,14 @@ async function sort() {
   showOverlay(`\u2714 Sorted${timeStr}`, false);
   hideOverlay();
 }
+
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    render();
+  },
+});
 
 // #region Example controls & Cleanup
 

--- a/apps/typegpu-docs/src/examples/algorithms/genetic-racing/index.html
+++ b/apps/typegpu-docs/src/examples/algorithms/genetic-racing/index.html
@@ -1,4 +1,4 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />
 <div class="stats"></div>
 <style>
   .stats {

--- a/apps/typegpu-docs/src/examples/algorithms/genetic-racing/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/genetic-racing/index.ts
@@ -532,6 +532,11 @@ applyGridSize(...GRID_SIZES[gridSizeKey]);
 applyTrack(generateGridTrack(trackSeed, ...GRID_SIZES[gridSizeKey]));
 startSimulation();
 
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+});
+
 // #region Example controls & Cleanup
 
 export const controls = defineControls({
@@ -605,6 +610,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(rafHandle);
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/algorithms/genetic-racing/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/genetic-racing/index.ts
@@ -532,7 +532,7 @@ applyGridSize(...GRID_SIZES[gridSizeKey]);
 applyTrack(generateGridTrack(trackSeed, ...GRID_SIZES[gridSizeKey]));
 startSimulation();
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
 });
@@ -610,7 +610,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(rafHandle);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/index.html
+++ b/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/index.ts
@@ -342,8 +342,6 @@ function recreateResources() {
   sourceIdx = 0;
 }
 
-clearCanvas();
-
 function getTouchPosition(rect: DOMRect, touches: TouchList) {
   if (touches.length === 2) {
     return {
@@ -357,17 +355,16 @@ function getTouchPosition(rect: DOMRect, touches: TouchList) {
   };
 }
 
-// #region Example controls & Cleanup
-
-let resizeTimeout: ReturnType<typeof setTimeout>;
-const resizeObserver = new ResizeObserver(() => {
-  clearTimeout(resizeTimeout);
-  resizeTimeout = setTimeout(() => {
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
     recreateResources();
     clearCanvas();
-  }, 100);
+  },
 });
-resizeObserver.observe(canvas);
+
+// #region Example controls & Cleanup
 
 const onMouseDown = (e: MouseEvent) => {
   if (e.button !== 0 && e.button !== 2) {
@@ -475,8 +472,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  clearTimeout(resizeTimeout);
-  resizeObserver.disconnect();
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/index.ts
@@ -355,7 +355,7 @@ function getTouchPosition(rect: DOMRect, touches: TouchList) {
   };
 }
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -472,7 +472,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/algorithms/jump-flood-voronoi/index.html
+++ b/apps/typegpu-docs/src/examples/algorithms/jump-flood-voronoi/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/algorithms/jump-flood-voronoi/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/jump-flood-voronoi/index.ts
@@ -241,7 +241,7 @@ function reset() {
 
 reset();
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -294,7 +294,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/algorithms/jump-flood-voronoi/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/jump-flood-voronoi/index.ts
@@ -239,6 +239,8 @@ function reset() {
   void runFloodAnimated(currentRunId);
 }
 
+reset();
+
 const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,

--- a/apps/typegpu-docs/src/examples/algorithms/jump-flood-voronoi/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/jump-flood-voronoi/index.ts
@@ -239,19 +239,16 @@ function reset() {
   void runFloodAnimated(currentRunId);
 }
 
-reset();
-
-// #region Example controls & Cleanup
-
-let resizeTimeout: ReturnType<typeof setTimeout>;
-const resizeObserver = new ResizeObserver(() => {
-  clearTimeout(resizeTimeout);
-  resizeTimeout = setTimeout(() => {
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
     recreateResources();
     reset();
-  }, 100);
+  },
 });
-resizeObserver.observe(canvas);
+
+// #region Example controls & Cleanup
 
 export const controls = defineControls({
   'Run Algorithm': {
@@ -295,8 +292,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  clearTimeout(resizeTimeout);
-  resizeObserver.disconnect();
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/algorithms/mnist-inference/index.html
+++ b/apps/typegpu-docs/src/examples/algorithms/mnist-inference/index.html
@@ -1,6 +1,6 @@
 <div class="loading">🤖 Downloading the model...</div>
-<div class="example">
-  <canvas></canvas>
+<div class="example gap-4 flex-col md:flex-row">
+  <canvas class="w-80 h-80"></canvas>
   <div class="predictions-container">
     <div class="bars-container">
       <div class="bar">O</div>
@@ -36,7 +36,7 @@
   }
 
   .loading.loaded ~ .example {
-    display: contents;
+    display: flex;
   }
 
   .predictions-container {

--- a/apps/typegpu-docs/src/examples/algorithms/mnist-inference/index.html
+++ b/apps/typegpu-docs/src/examples/algorithms/mnist-inference/index.html
@@ -1,6 +1,6 @@
 <div class="loading">🤖 Downloading the model...</div>
 <div class="example gap-4 flex-col md:flex-row">
-  <canvas class="w-80 h-80"></canvas>
+  <canvas class="w-80 h-80" />
   <div class="predictions-container">
     <div class="bars-container">
       <div class="bar">O</div>

--- a/apps/typegpu-docs/src/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/mnist-inference/index.ts
@@ -255,7 +255,7 @@ updateSubgroupsStatus();
 
 run();
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const autoResizer = common.attachAutoResizer({ root, canvas });
 
 canvas.addEventListener('mousedown', () => {
   uiState.isDrawing = true;
@@ -397,7 +397,7 @@ export function onCleanup() {
   cancelAnimationFrame(animationFrameId);
   window.removeEventListener('mouseup', mouseUpEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/mnist-inference/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import { ioLayout, type LayerData, type Network, weightsBiasesLayout } from './data.ts';
 import { downloadLayers } from './helpers.ts';
 import { defineControls } from '../../common/defineControls.ts';
@@ -255,6 +255,8 @@ updateSubgroupsStatus();
 
 run();
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 canvas.addEventListener('mousedown', () => {
   uiState.isDrawing = true;
 });
@@ -395,6 +397,7 @@ export function onCleanup() {
   cancelAnimationFrame(animationFrameId);
   window.removeEventListener('mouseup', mouseUpEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/geometry/circles/index.html
+++ b/apps/typegpu-docs/src/examples/geometry/circles/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/geometry/circles/index.ts
+++ b/apps/typegpu-docs/src/examples/geometry/circles/index.ts
@@ -1,5 +1,5 @@
 import { circle, circleVertexCount } from '@typegpu/geometry';
-import tgpu, { d, std as s } from 'typegpu';
+import tgpu, { common, d, std as s } from 'typegpu';
 
 const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 const canvas = document.querySelector('canvas');
@@ -128,29 +128,34 @@ const pipeline = root.createRenderPipeline({
   multisample: { count: multisample ? 4 : 1 },
 });
 
-setTimeout(() => {
-  pipeline
-    .with(uniformsBindGroup)
-    .withColorAttachment({
-      ...(multisample
-        ? {
-            view: msaaTextureView,
-            resolveTarget: context,
-          }
-        : { view: context }),
-      clearValue: [0, 0, 0, 0],
-      loadOp: 'clear',
-      storeOp: 'store',
-    })
-    .withPerformanceCallback((a, b) => {
-      console.log((Number(b - a) * 1e-6).toFixed(3), 'ms');
-    })
-    .draw(circleVertexCount(4), circleCount);
-}, 100);
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    pipeline
+      .with(uniformsBindGroup)
+      .withColorAttachment({
+        ...(multisample
+          ? {
+              view: msaaTextureView,
+              resolveTarget: context,
+            }
+          : { view: context }),
+        clearValue: [0, 0, 0, 0],
+        loadOp: 'clear',
+        storeOp: 'store',
+      })
+      .withPerformanceCallback((a, b) => {
+        console.log((Number(b - a) * 1e-6).toFixed(3), 'ms');
+      })
+      .draw(circleVertexCount(4), circleCount);
+  },
+});
 
 // #region Example controls & Cleanup
 
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/geometry/circles/index.ts
+++ b/apps/typegpu-docs/src/examples/geometry/circles/index.ts
@@ -126,6 +126,26 @@ const pipeline = root.createRenderPipeline({
   multisample: { count: multisample ? 4 : 1 },
 });
 
+const render = () => {
+  pipeline
+    .with(uniformsBindGroup)
+    .withColorAttachment({
+      ...(multisample
+        ? {
+            view: msaaTextureView,
+            resolveTarget: context,
+          }
+        : { view: context }),
+      clearValue: [0, 0, 0, 0],
+      loadOp: 'clear',
+      storeOp: 'store',
+    })
+    .withPerformanceCallback((a, b) => {
+      console.log((Number(b - a) * 1e-6).toFixed(3), 'ms');
+    })
+    .draw(circleVertexCount(4), circleCount);
+};
+
 const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
@@ -137,23 +157,7 @@ const detachAutoResizer = common.attachAutoResizer({
 
     createDepthAndMsaaTextures();
 
-    pipeline
-      .with(uniformsBindGroup)
-      .withColorAttachment({
-        ...(multisample
-          ? {
-              view: msaaTextureView,
-              resolveTarget: context,
-            }
-          : { view: context }),
-        clearValue: [0, 0, 0, 0],
-        loadOp: 'clear',
-        storeOp: 'store',
-      })
-      .withPerformanceCallback((a, b) => {
-        console.log((Number(b - a) * 1e-6).toFixed(3), 'ms');
-      })
-      .draw(circleVertexCount(4), circleCount);
+    render();
   },
 });
 

--- a/apps/typegpu-docs/src/examples/geometry/circles/index.ts
+++ b/apps/typegpu-docs/src/examples/geometry/circles/index.ts
@@ -45,8 +45,6 @@ const createDepthAndMsaaTextures = () => {
 };
 
 createDepthAndMsaaTextures();
-const resizeObserver = new ResizeObserver(createDepthAndMsaaTextures);
-resizeObserver.observe(canvas);
 
 // const Uniforms = d.struct({});
 
@@ -132,6 +130,13 @@ const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+
+    createDepthAndMsaaTextures();
+
     pipeline
       .with(uniformsBindGroup)
       .withColorAttachment({

--- a/apps/typegpu-docs/src/examples/geometry/circles/index.ts
+++ b/apps/typegpu-docs/src/examples/geometry/circles/index.ts
@@ -146,7 +146,7 @@ const render = () => {
     .draw(circleVertexCount(4), circleCount);
 };
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -164,7 +164,7 @@ const detachAutoResizer = common.attachAutoResizer({
 // #region Example controls & Cleanup
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/geometry/lines-combinations/index.html
+++ b/apps/typegpu-docs/src/examples/geometry/lines-combinations/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/geometry/lines-combinations/index.ts
+++ b/apps/typegpu-docs/src/examples/geometry/lines-combinations/index.ts
@@ -10,7 +10,7 @@ import {
   startCapSlot,
   arrowCapParamsSlot,
 } from '@typegpu/geometry';
-import tgpu, { type ColorAttachment } from 'typegpu';
+import tgpu, { common, type ColorAttachment } from 'typegpu';
 import {
   arrayOf,
   builtin,
@@ -409,6 +409,8 @@ const runAnimationFrame = (timeMs: number) => {
 };
 runAnimationFrame(0);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 const fillOptions = {
   none: 0,
   solid: 1,
@@ -505,6 +507,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
   cancelAnimationFrame(frameId);
 }

--- a/apps/typegpu-docs/src/examples/geometry/lines-combinations/index.ts
+++ b/apps/typegpu-docs/src/examples/geometry/lines-combinations/index.ts
@@ -407,7 +407,7 @@ const runAnimationFrame = (timeMs: number) => {
 };
 runAnimationFrame(0);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -517,7 +517,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
   cancelAnimationFrame(frameId);
 }

--- a/apps/typegpu-docs/src/examples/geometry/lines-combinations/index.ts
+++ b/apps/typegpu-docs/src/examples/geometry/lines-combinations/index.ts
@@ -73,8 +73,6 @@ const createDepthAndMsaaTextures = () => {
 };
 
 createDepthAndMsaaTextures();
-const resizeObserver = new ResizeObserver(createDepthAndMsaaTextures);
-resizeObserver.observe(canvas);
 
 const Uniforms = struct({
   time: f32,
@@ -409,7 +407,19 @@ const runAnimationFrame = (timeMs: number) => {
 };
 runAnimationFrame(0);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+
+    createDepthAndMsaaTextures();
+    draw(time);
+  },
+});
 
 const fillOptions = {
   none: 0,

--- a/apps/typegpu-docs/src/examples/image-processing/ascii-filter/index.html
+++ b/apps/typegpu-docs/src/examples/image-processing/ascii-filter/index.html
@@ -2,7 +2,7 @@
   <div class="spinner">Loading...</div>
 </div>
 
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />
 <video autoplay playsinline></video>
 
 <style>

--- a/apps/typegpu-docs/src/examples/image-processing/ascii-filter/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/ascii-filter/index.ts
@@ -241,6 +241,11 @@ if (isIOS) {
 
 videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
 
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+});
+
 export const controls = defineControls({
   'use extended characters': {
     initial: false,
@@ -279,5 +284,6 @@ export function onCleanup() {
     }
   }
 
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/image-processing/ascii-filter/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/ascii-filter/index.ts
@@ -53,6 +53,24 @@ const spinner = document.querySelector('.spinner-background') as HTMLDivElement;
 const context = root.configureContext({ canvas, alphaMode: 'premultiplied' });
 canvas.parentElement?.appendChild(video);
 
+let frameSize: { width: number; height: number } | undefined;
+function handleResize() {
+  if (!frameSize) {
+    return;
+  }
+
+  const domAspectRatio = canvas.clientWidth / canvas.clientHeight;
+  const targetAspectRatio = frameSize.width / frameSize.height;
+
+  if (targetAspectRatio > domAspectRatio) {
+    // the surface is wider than the container
+    canvas.height = canvas.width / targetAspectRatio;
+  } else {
+    // the surface is taller than the container
+    canvas.width = canvas.height * targetAspectRatio;
+  }
+}
+
 const pipeline = root.createRenderPipeline({
   vertex: common.fullScreenTriangle,
   /**
@@ -172,7 +190,6 @@ let bindGroup:
   | undefined;
 
 let videoFrameCallbackId: number | undefined;
-let lastFrameSize: { width: number; height: number } | undefined;
 
 function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata) {
   if (video.readyState < 2) {
@@ -183,14 +200,9 @@ function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata) {
   const frameWidth = metadata.width;
   const frameHeight = metadata.height;
 
-  if (
-    !lastFrameSize ||
-    lastFrameSize.width !== frameWidth ||
-    lastFrameSize.height !== frameHeight
-  ) {
-    lastFrameSize = { width: frameWidth, height: frameHeight };
-
-    updateVideoDisplay(frameWidth, frameHeight);
+  if (!frameSize || frameSize.width !== frameWidth || frameSize.height !== frameHeight) {
+    frameSize = { width: frameWidth, height: frameHeight };
+    handleResize();
   }
 
   bindGroup = root.createBindGroup(layout, {
@@ -208,14 +220,6 @@ function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata) {
   spinner.style.display = 'none';
 
   videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
-}
-
-function updateVideoDisplay(frameWidth: number, frameHeight: number) {
-  const aspectRatio = frameWidth / frameHeight;
-  if (canvas.parentElement) {
-    canvas.parentElement.style.aspectRatio = `${aspectRatio}`;
-    canvas.parentElement.style.height = `min(100cqh, calc(100cqw/(${aspectRatio})))`;
-  }
 }
 
 const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
@@ -244,6 +248,9 @@ videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
 const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
+  onResize() {
+    handleResize();
+  },
 });
 
 export const controls = defineControls({

--- a/apps/typegpu-docs/src/examples/image-processing/ascii-filter/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/ascii-filter/index.ts
@@ -245,7 +245,7 @@ if (isIOS) {
 
 videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -291,6 +291,6 @@ export function onCleanup() {
     }
   }
 
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/image-processing/background-segmentation/index.html
+++ b/apps/typegpu-docs/src/examples/image-processing/background-segmentation/index.html
@@ -1,4 +1,4 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />
 <video
   autoplay
   playsinline

--- a/apps/typegpu-docs/src/examples/image-processing/background-segmentation/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/background-segmentation/index.ts
@@ -295,6 +295,11 @@ async function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata
 }
 videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
 
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+});
+
 // #region Example controls & Cleanup
 
 export const controls = defineControls({
@@ -355,6 +360,7 @@ export function onCleanup() {
     adapter.requestDevice = oldRequestDevice;
   }
 
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/image-processing/background-segmentation/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/background-segmentation/index.ts
@@ -203,15 +203,28 @@ function updateCropBounds(aspectRatio: number) {
   });
 }
 
-function onVideoChange(size: { width: number; height: number }) {
-  const aspectRatio = size.width / size.height;
-  video.style.height = `${video.clientWidth / aspectRatio}px`;
-  if (canvas.parentElement) {
-    canvas.parentElement.style.aspectRatio = `${aspectRatio}`;
-    canvas.parentElement.style.height = `min(100cqh, calc(100cqw/(${aspectRatio})))`;
+let frameSize: { width: number; height: number } | undefined;
+
+function handleResize() {
+  if (!frameSize) {
+    return;
+  }
+  const size = frameSize;
+
+  const targetAspectRatio = size.width / size.height;
+  video.style.height = `${video.clientWidth / targetAspectRatio}px`;
+
+  const domAspectRatio = canvas.clientWidth / canvas.clientHeight;
+
+  if (targetAspectRatio > domAspectRatio) {
+    // the surface is wider than the container
+    canvas.height = canvas.width / targetAspectRatio;
+  } else {
+    // the surface is taller than the container
+    canvas.width = canvas.height * targetAspectRatio;
   }
 
-  updateCropBounds(aspectRatio);
+  updateCropBounds(targetAspectRatio);
 
   blurredTextures = [0, 1].map(() =>
     root
@@ -241,7 +254,6 @@ function onVideoChange(size: { width: number; height: number }) {
 }
 
 let videoFrameCallbackId: number | undefined;
-let lastFrameSize: { width: number; height: number } | undefined;
 
 async function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata) {
   if (video.readyState < 2) {
@@ -252,13 +264,9 @@ async function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata
   const frameWidth = metadata.width;
   const frameHeight = metadata.height;
 
-  if (
-    !lastFrameSize ||
-    lastFrameSize.width !== frameWidth ||
-    lastFrameSize.height !== frameHeight
-  ) {
-    lastFrameSize = { width: frameWidth, height: frameHeight };
-    onVideoChange(lastFrameSize);
+  if (!frameSize || frameSize.width !== frameWidth || frameSize.height !== frameHeight) {
+    frameSize = { width: frameWidth, height: frameHeight };
+    handleResize();
   }
 
   blurredTextures[0].write(video);
@@ -298,6 +306,9 @@ videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
 const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
+  onResize() {
+    handleResize();
+  },
 });
 
 // #region Example controls & Cleanup
@@ -335,8 +346,8 @@ export const controls = defineControls({
     initial: useSquareCrop,
     onToggleChange(value) {
       useSquareCrop = value;
-      if (lastFrameSize) {
-        updateCropBounds(lastFrameSize.width / lastFrameSize.height);
+      if (frameSize) {
+        updateCropBounds(frameSize.width / frameSize.height);
       }
     },
   },

--- a/apps/typegpu-docs/src/examples/image-processing/background-segmentation/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/background-segmentation/index.ts
@@ -303,7 +303,7 @@ async function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata
 }
 videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -371,7 +371,7 @@ export function onCleanup() {
     adapter.requestDevice = oldRequestDevice;
   }
 
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/image-processing/blur/index.html
+++ b/apps/typegpu-docs/src/examples/image-processing/blur/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/image-processing/blur/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/blur/index.ts
@@ -180,8 +180,6 @@ const detachAutoResizer = common.attachAutoResizer({
     canvas.width = size;
     canvas.height = size;
     render();
-
-    render();
   },
 });
 

--- a/apps/typegpu-docs/src/examples/image-processing/blur/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/blur/index.ts
@@ -175,6 +175,12 @@ const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    render();
+
     render();
   },
 });

--- a/apps/typegpu-docs/src/examples/image-processing/blur/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/blur/index.ts
@@ -171,7 +171,13 @@ function render() {
 
   renderPipeline.withColorAttachment({ view: context }).draw(3);
 }
-render();
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    render();
+  },
+});
 
 // #region Example controls & Cleanup
 
@@ -200,6 +206,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/image-processing/blur/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/blur/index.ts
@@ -171,7 +171,7 @@ function render() {
 
   renderPipeline.withColorAttachment({ view: context }).draw(3);
 }
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -210,7 +210,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/image-processing/camera-thresholding/index.html
+++ b/apps/typegpu-docs/src/examples/image-processing/camera-thresholding/index.html
@@ -2,7 +2,7 @@
   <div class="spinner">Loading...</div>
 </div>
 
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />
 <video autoplay playsinline></video>
 
 <style>

--- a/apps/typegpu-docs/src/examples/image-processing/camera-thresholding/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/camera-thresholding/index.ts
@@ -133,6 +133,11 @@ function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata) {
 }
 videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
 
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+});
+
 // #region Example controls & Cleanup
 
 export const controls = defineControls({
@@ -160,6 +165,7 @@ export function onCleanup() {
       track.stop();
     }
   }
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/image-processing/camera-thresholding/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/camera-thresholding/index.ts
@@ -139,7 +139,7 @@ function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata) {
 }
 videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize: handleResize,
@@ -172,7 +172,7 @@ export function onCleanup() {
       track.stop();
     }
   }
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/image-processing/camera-thresholding/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/camera-thresholding/index.ts
@@ -64,12 +64,22 @@ const renderPipeline = root.createRenderPipeline({
   targets: { format: presentationFormat },
 });
 
-function onVideoChange(size: { width: number; height: number }) {
-  const aspectRatio = size.width / size.height;
-  video.style.height = `${video.clientWidth / aspectRatio}px`;
-  if (canvas.parentElement) {
-    canvas.parentElement.style.aspectRatio = `${aspectRatio}`;
-    canvas.parentElement.style.height = `min(100cqh, calc(100cqw/(${aspectRatio})))`;
+function handleResize() {
+  if (!frameSize) {
+    return;
+  }
+
+  const targetAspectRatio = frameSize.width / frameSize.height;
+  video.style.height = `${video.clientWidth / targetAspectRatio}px`;
+
+  const domAspectRatio = canvas.clientWidth / canvas.clientHeight;
+
+  if (targetAspectRatio > domAspectRatio) {
+    // the surface is wider than the container
+    canvas.height = canvas.width / targetAspectRatio;
+  } else {
+    // the surface is taller than the container
+    canvas.width = canvas.height * targetAspectRatio;
   }
 }
 
@@ -95,7 +105,7 @@ if (isIOS) {
 }
 
 let videoFrameCallbackId: number | undefined;
-let lastFrameSize: { width: number; height: number } | undefined;
+let frameSize: { width: number; height: number } | undefined;
 
 function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata) {
   if (video.readyState < 2) {
@@ -106,13 +116,9 @@ function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata) {
   const frameWidth = metadata.width;
   const frameHeight = metadata.height;
 
-  if (
-    !lastFrameSize ||
-    lastFrameSize.width !== frameWidth ||
-    lastFrameSize.height !== frameHeight
-  ) {
-    lastFrameSize = { width: frameWidth, height: frameHeight };
-    onVideoChange(lastFrameSize);
+  if (!frameSize || frameSize.width !== frameWidth || frameSize.height !== frameHeight) {
+    frameSize = { width: frameWidth, height: frameHeight };
+    handleResize();
   }
 
   renderPipeline
@@ -136,6 +142,7 @@ videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
 const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
+  onResize: handleResize,
 });
 
 // #region Example controls & Cleanup

--- a/apps/typegpu-docs/src/examples/image-processing/chroma-keying/index.html
+++ b/apps/typegpu-docs/src/examples/image-processing/chroma-keying/index.html
@@ -1,4 +1,4 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />
 <video autoplay playsinline></video>
 
 <style>

--- a/apps/typegpu-docs/src/examples/image-processing/chroma-keying/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/chroma-keying/index.ts
@@ -63,12 +63,23 @@ const renderPipeline = root.createRenderPipeline({
   targets: { format: presentationFormat },
 });
 
-function onVideoChange(size: { width: number; height: number }) {
-  const aspectRatio = size.width / size.height;
-  video.style.height = `${video.clientWidth / aspectRatio}px`;
-  if (canvas.parentElement) {
-    canvas.parentElement.style.aspectRatio = `${aspectRatio}`;
-    canvas.parentElement.style.height = `min(100cqh, calc(100cqw/(${aspectRatio})))`;
+function handleResize() {
+  if (!frameSize) {
+    return;
+  }
+
+  const size = frameSize;
+  const targetAspectRatio = size.width / size.height;
+  video.style.height = `${video.clientWidth / targetAspectRatio}px`;
+
+  const domAspectRatio = canvas.clientWidth / canvas.clientHeight;
+
+  if (targetAspectRatio > domAspectRatio) {
+    // the surface is wider than the container
+    canvas.height = canvas.width / targetAspectRatio;
+  } else {
+    // the surface is taller than the container
+    canvas.width = canvas.height * targetAspectRatio;
   }
 }
 
@@ -94,7 +105,7 @@ if (isIOS) {
 }
 
 let videoFrameCallbackId: number | undefined;
-let lastFrameSize: { width: number; height: number } | undefined;
+let frameSize: { width: number; height: number } | undefined;
 
 function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata) {
   if (video.readyState < 2) {
@@ -105,13 +116,9 @@ function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata) {
   const frameWidth = metadata.width;
   const frameHeight = metadata.height;
 
-  if (
-    !lastFrameSize ||
-    lastFrameSize.width !== frameWidth ||
-    lastFrameSize.height !== frameHeight
-  ) {
-    lastFrameSize = { width: frameWidth, height: frameHeight };
-    onVideoChange(lastFrameSize);
+  if (!frameSize || frameSize.width !== frameWidth || frameSize.height !== frameHeight) {
+    frameSize = { width: frameWidth, height: frameHeight };
+    handleResize();
   }
 
   const group = root.createBindGroup(layout, {
@@ -128,6 +135,7 @@ videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
 const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
+  onResize: handleResize,
 });
 
 // #region Example controls & Cleanup

--- a/apps/typegpu-docs/src/examples/image-processing/chroma-keying/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/chroma-keying/index.ts
@@ -132,7 +132,7 @@ function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata) {
 
 videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize: handleResize,
@@ -165,7 +165,7 @@ export function onCleanup() {
       track.stop();
     }
   }
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/image-processing/chroma-keying/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/chroma-keying/index.ts
@@ -125,6 +125,11 @@ function processVideoFrame(_: number, metadata: VideoFrameCallbackMetadata) {
 
 videoFrameCallbackId = video.requestVideoFrameCallback(processVideoFrame);
 
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+});
+
 // #region Example controls & Cleanup
 
 export const controls = defineControls({
@@ -152,6 +157,7 @@ export function onCleanup() {
       track.stop();
     }
   }
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/image-processing/image-tuning/index.html
+++ b/apps/typegpu-docs/src/examples/image-processing/image-tuning/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/image-processing/image-tuning/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/image-tuning/index.ts
@@ -348,6 +348,10 @@ const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
     render();
   },
 });

--- a/apps/typegpu-docs/src/examples/image-processing/image-tuning/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/image-tuning/index.ts
@@ -344,10 +344,17 @@ export const controls = defineControls({
   },
 });
 
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    render();
+  },
+});
+
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
 }
 
 // #endregion
-
-render();

--- a/apps/typegpu-docs/src/examples/image-processing/image-tuning/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/image-tuning/index.ts
@@ -344,7 +344,7 @@ export const controls = defineControls({
   },
 });
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -357,7 +357,7 @@ const detachAutoResizer = common.attachAutoResizer({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/index.html
+++ b/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/index.html
@@ -1,15 +1,7 @@
-<canvas></canvas>
-<video autoplay playsinline></video>
-
-<style>
-  /* Keep the video "painted" so Safari continues decoding frames. */
-  video {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 1px;
-    height: 1px;
-    opacity: 0;
-    pointer-events: none;
-  }
-</style>
+<canvas class="w-full h-full object-contain" />
+<video
+  autoplay
+  playsinline
+  <!-- Keep the video "painted" so Safari continues decoding frames. -->
+  class="absolute top-0 left-0 w-[1px] h-[1px] opacity-0 pointer-events-none"
+/>

--- a/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/index.html
+++ b/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/index.html
@@ -1,7 +1,7 @@
 <canvas class="w-full h-full object-contain" />
+<!-- Keep the video "painted" so Safari continues decoding frames. -->
 <video
   autoplay
   playsinline
-  <!-- Keep the video "painted" so Safari continues decoding frames. -->
   class="absolute top-0 left-0 w-[1px] h-[1px] opacity-0 pointer-events-none"
 />

--- a/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/index.ts
@@ -20,7 +20,7 @@ const canvas = document.querySelector('canvas') as HTMLCanvasElement;
 const context = root.configureContext({ canvas });
 const video = document.querySelector('video') as HTMLVideoElement;
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -206,7 +206,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   video.cancelVideoFrameCallback(videoFrameCallbackId);
-  detachAutoResizer();
+  autoResizer.detach();
   if (isIOS) {
     window.removeEventListener('orientationchange', setUVTransformForIOS);
   }

--- a/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/index.ts
@@ -18,8 +18,18 @@ import {
 const root = await tgpu.init();
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
 const context = root.configureContext({ canvas });
-
 const video = document.querySelector('video') as HTMLVideoElement;
+
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+  },
+});
 
 const sampler = root.createSampler({
   magFilter: 'linear',
@@ -196,6 +206,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   video.cancelVideoFrameCallback(videoFrameCallbackId);
+  detachAutoResizer();
   if (isIOS) {
     window.removeEventListener('orientationchange', setUVTransformForIOS);
   }

--- a/apps/typegpu-docs/src/examples/react/shifting-gradient/index.tsx
+++ b/apps/typegpu-docs/src/examples/react/shifting-gradient/index.tsx
@@ -37,7 +37,7 @@ function App() {
     renderPipeline.withColorAttachment({ view: ctxRef.current }).draw(3);
   });
 
-  return <canvas ref={ref} className="aspect-square h-full max-h-[100vw]" />;
+  return <canvas ref={ref} className="aspect-square w-auto h-full max-h-[100vw]" />;
 }
 
 // #region Example controls and cleanup

--- a/apps/typegpu-docs/src/examples/react/spinning-triangle/index.tsx
+++ b/apps/typegpu-docs/src/examples/react/spinning-triangle/index.tsx
@@ -63,7 +63,7 @@ function App() {
     renderPipeline.withColorAttachment({ view: ctxRef.current }).draw(3);
   });
 
-  return <canvas ref={ref} className="aspect-square h-full max-h-[100vw]" />;
+  return <canvas ref={ref} className="aspect-square w-auto h-full max-h-[100vw]" />;
 }
 
 // #region Example controls and cleanup

--- a/apps/typegpu-docs/src/examples/rendering/3d-fish/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/3d-fish/index.html
@@ -44,4 +44,4 @@
     from original
   </p>
 </div>
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/rendering/3d-fish/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/3d-fish/index.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import * as m from 'wgpu-matrix';
 import { simulate } from './compute.ts';
 import { loadModel } from './load-model.ts';
@@ -421,23 +421,26 @@ window.addEventListener('touchmove', touchMoveEventListener);
 
 // observer and cleanup
 
-const resizeObserver = new ResizeObserver(() => {
-  camera.projection = m.mat4.perspective(
-    Math.PI / 4,
-    canvas.clientWidth / canvas.clientHeight,
-    0.1,
-    1000,
-    d.mat4x4f(),
-  );
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    camera.projection = m.mat4.perspective(
+      Math.PI / 4,
+      canvas.clientWidth / canvas.clientHeight,
+      0.1,
+      1000,
+      d.mat4x4f(),
+    );
 
-  depthTexture.destroy();
-  depthTexture = root.device.createTexture({
-    size: [canvas.width, canvas.height, 1],
-    format: 'depth24plus',
-    usage: GPUTextureUsage.RENDER_ATTACHMENT,
-  });
+    depthTexture.destroy();
+    depthTexture = root.device.createTexture({
+      size: [canvas.width, canvas.height, 1],
+      format: 'depth24plus',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+  },
 });
-resizeObserver.observe(canvas);
 
 export function onCleanup() {
   disposed = true;
@@ -445,7 +448,7 @@ export function onCleanup() {
   window.removeEventListener('mouseup', mouseUpEventListener);
   window.removeEventListener('mousemove', mouseMoveEventListener);
   window.removeEventListener('touchmove', touchMoveEventListener);
-  resizeObserver.disconnect();
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/3d-fish/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/3d-fish/index.ts
@@ -425,7 +425,7 @@ window.addEventListener('touchmove', touchMoveEventListener);
 
 // observer and cleanup
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -458,7 +458,7 @@ export function onCleanup() {
   window.removeEventListener('mouseup', mouseUpEventListener);
   window.removeEventListener('mousemove', mouseMoveEventListener);
   window.removeEventListener('touchmove', touchMoveEventListener);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/3d-fish/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/3d-fish/index.ts
@@ -219,22 +219,7 @@ const computeBindGroups = [0, 1].map((idx) =>
   }),
 );
 
-// frame
-
-let odd = false;
-let lastTimestamp: DOMHighResTimeStamp = 0;
-let animationFrameId: number;
-
-function frame(timestamp: DOMHighResTimeStamp) {
-  odd = !odd;
-
-  currentTimeBuffer.write(timestamp);
-  timePassedBuffer.write((timestamp - lastTimestamp) * speedMultiplier);
-  lastTimestamp = timestamp;
-  cameraBuffer.write(camera);
-
-  simulatePipeline.with(computeBindGroups[odd ? 1 : 0]).dispatchThreads(p.fishAmount);
-
+function render() {
   renderPipeline
     .withColorAttachment({
       view: context,
@@ -267,6 +252,25 @@ function frame(timestamp: DOMHighResTimeStamp) {
     .with(renderInstanceLayout, fishDataBuffers[odd ? 1 : 0])
     .with(renderFishBindGroups[odd ? 1 : 0])
     .draw(fishModel.polygonCount, p.fishAmount);
+}
+
+// frame
+
+let odd = false;
+let lastTimestamp: DOMHighResTimeStamp = 0;
+let animationFrameId: number;
+
+function frame(timestamp: DOMHighResTimeStamp) {
+  odd = !odd;
+
+  currentTimeBuffer.write(timestamp);
+  timePassedBuffer.write((timestamp - lastTimestamp) * speedMultiplier);
+  lastTimestamp = timestamp;
+  cameraBuffer.write(camera);
+
+  simulatePipeline.with(computeBindGroups[odd ? 1 : 0]).dispatchThreads(p.fishAmount);
+
+  render();
 
   animationFrameId = requestAnimationFrame(frame);
 }
@@ -433,12 +437,18 @@ const detachAutoResizer = common.attachAutoResizer({
       d.mat4x4f(),
     );
 
+    cameraBuffer.patch({
+      projection: camera.projection,
+    });
+
     depthTexture.destroy();
     depthTexture = root.device.createTexture({
       size: [canvas.width, canvas.height, 1],
       format: 'depth24plus',
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
+
+    render();
   },
 });
 

--- a/apps/typegpu-docs/src/examples/rendering/box-raytracing/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/box-raytracing/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/rendering/box-raytracing/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/box-raytracing/index.ts
@@ -246,6 +246,10 @@ const pipeline = root.createRenderPipeline({
 
 // UI
 
+function render() {
+  pipeline.withColorAttachment({ view: context }).draw(3);
+}
+
 let animationFrameId: number;
 let lastTime: number | null = null;
 
@@ -269,12 +273,22 @@ const runner = (timestamp: number) => {
 
   frame += (rotationSpeed * deltaTime) / 1000;
 
-  pipeline.withColorAttachment({ view: context }).draw(3);
+  render();
   animationFrameId = requestAnimationFrame(runner);
 };
 animationFrameId = requestAnimationFrame(runner);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    render();
+  },
+});
 
 // #region Example controls and cleanup
 

--- a/apps/typegpu-docs/src/examples/rendering/box-raytracing/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/box-raytracing/index.ts
@@ -1,5 +1,5 @@
 import { linearToSrgb, srgbToLinear } from '@typegpu/color';
-import tgpu, { d, type TgpuFragmentFn, type TgpuVertexFn } from 'typegpu';
+import tgpu, { common, d, type TgpuFragmentFn, type TgpuVertexFn } from 'typegpu';
 import { discard, max, min, mul, normalize, pow, sub } from 'typegpu/std';
 import { mat4 } from 'wgpu-matrix';
 import { defineControls } from '../../common/defineControls.ts';
@@ -274,6 +274,8 @@ const runner = (timestamp: number) => {
 };
 animationFrameId = requestAnimationFrame(runner);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls and cleanup
 
 export const controls = defineControls({
@@ -320,6 +322,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameId);
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/box-raytracing/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/box-raytracing/index.ts
@@ -278,7 +278,7 @@ const runner = (timestamp: number) => {
 };
 animationFrameId = requestAnimationFrame(runner);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -336,7 +336,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameId);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/caustics/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/caustics/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/rendering/caustics/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/caustics/index.ts
@@ -148,7 +148,7 @@ function frame(timestamp: number) {
 }
 requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -176,7 +176,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   isRunning = false;
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/caustics/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/caustics/index.ts
@@ -1,5 +1,5 @@
 import { perlin3d } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const mainVertex = tgpu.vertexFn({
@@ -146,6 +146,8 @@ function draw(timestamp: number) {
 }
 requestAnimationFrame(draw);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls and cleanup
 
 export const controls = defineControls({
@@ -162,6 +164,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   isRunning = false;
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/caustics/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/caustics/index.ts
@@ -135,18 +135,30 @@ const pipeline = root.createRenderPipeline({
 
 let isRunning = true;
 
-function draw(timestamp: number) {
+function render() {
+  pipeline.withColorAttachment({ view: context }).draw(3);
+}
+
+function frame(timestamp: number) {
   if (!isRunning) return;
 
   time.write((timestamp * 0.001) % 1000);
-
-  pipeline.withColorAttachment({ view: context }).draw(3);
-
-  requestAnimationFrame(draw);
+  render();
+  requestAnimationFrame(frame);
 }
-requestAnimationFrame(draw);
+requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    render();
+  },
+});
 
 // #region Example controls and cleanup
 

--- a/apps/typegpu-docs/src/examples/rendering/clouds/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/clouds/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/rendering/clouds/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/clouds/index.ts
@@ -109,6 +109,8 @@ function render(timestamp: number) {
 
 frameId = requestAnimationFrame(render);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 const qualityOptions = {
   'very high': {
     maxSteps: 150,
@@ -145,5 +147,6 @@ export const controls = defineControls({
 export function onCleanup() {
   cancelAnimationFrame(frameId);
   resizeObserver.disconnect();
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/clouds/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/clouds/index.ts
@@ -1,4 +1,5 @@
 import tgpu, { common, d, std } from 'typegpu';
+import { randf } from '@typegpu/noise';
 import {
   FOV_FACTOR,
   NOISE_TEXTURE_SIZE,
@@ -11,7 +12,6 @@ import {
 } from './consts.ts';
 import { raymarch } from './utils.ts';
 import { cloudsLayout, CloudsParams } from './types.ts';
-import { randf } from '@typegpu/noise';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();
@@ -21,10 +21,10 @@ const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
 const paramsUniform = root.createUniform(CloudsParams, {
   time: 0,
+  aspectRatio: 1,
   maxSteps: 50,
   maxDistance: 10.0,
 });
-const resolutionUniform = root.createUniform(d.vec2f, d.vec2f(canvas.width, canvas.height));
 
 const noiseData = new Uint8Array(NOISE_TEXTURE_SIZE * NOISE_TEXTURE_SIZE);
 for (let i = 0; i < noiseData.length; i += 1) {
@@ -57,8 +57,7 @@ const pipeline = root.createRenderPipeline({
   fragment: ({ uv }) => {
     'use gpu';
     randf.seed2(uv * cloudsLayout.$.params.time);
-    const screenRes = resolutionUniform.$;
-    const aspect = screenRes.x / screenRes.y;
+    const aspect = cloudsLayout.$.params.aspectRatio;
 
     let screenPos = (uv - 0.5) * 2;
     screenPos = d.vec2f(screenPos.x * std.max(aspect, 1), screenPos.y * std.max(1 / aspect, 1));
@@ -86,16 +85,7 @@ const pipeline = root.createRenderPipeline({
   targets: { format: presentationFormat },
 });
 
-const resizeObserver = new ResizeObserver(() => {
-  resolutionUniform.write(d.vec2f(canvas.width, canvas.height));
-});
-resizeObserver.observe(canvas);
-
-let frameId: number;
-
-function render(timestamp: number) {
-  paramsUniform.patch({ time: (timestamp / 1000) % 500 });
-
+function render() {
   pipeline
     .with(bindGroup)
     .withColorAttachment({
@@ -103,13 +93,33 @@ function render(timestamp: number) {
       clearValue: [0, 0, 0, 1],
     })
     .draw(6);
-
-  frameId = requestAnimationFrame(render);
 }
 
-frameId = requestAnimationFrame(render);
+let frameId: number;
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+function frame(timestamp: number) {
+  paramsUniform.patch({ time: (timestamp / 1000) % 500 });
+  render();
+  frameId = requestAnimationFrame(frame);
+}
+
+frameId = requestAnimationFrame(frame);
+
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // The clouds are very blurry, so there is no benefit from full-resolution
+    canvas.width = Math.max(1, canvas.width / 4);
+    canvas.height = Math.max(1, canvas.height / 4);
+
+    paramsUniform.patch({
+      aspectRatio: canvas.width / canvas.height,
+    });
+
+    render();
+  },
+});
 
 const qualityOptions = {
   'very high': {
@@ -146,7 +156,6 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(frameId);
-  resizeObserver.disconnect();
   detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/clouds/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/clouds/index.ts
@@ -105,7 +105,7 @@ function frame(timestamp: number) {
 
 frameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -156,6 +156,6 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(frameId);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/clouds/types.ts
+++ b/apps/typegpu-docs/src/examples/rendering/clouds/types.ts
@@ -2,6 +2,7 @@ import tgpu, { d } from 'typegpu';
 
 export const CloudsParams = d.struct({
   time: d.f32,
+  aspectRatio: d.f32,
   maxSteps: d.i32,
   maxDistance: d.f32,
 });

--- a/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.html
@@ -38,4 +38,4 @@
     under CC BY 4.0 / Modified from original
   </p>
 </div>
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.ts
@@ -285,6 +285,8 @@ const detachAutoResizer = common.attachAutoResizer({
       d.mat4x4f(),
     );
     cameraBuffer.patch({ projection: newProj });
+
+    render();
   },
 });
 

--- a/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.ts
@@ -273,7 +273,7 @@ loop();
 
 // #region Example controls and cleanup
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -497,7 +497,7 @@ export function onCleanup() {
   window.removeEventListener('mousemove', mouseMoveEventListener);
   window.removeEventListener('touchmove', touchMoveEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
-  detachAutoResizer();
+  autoResizer.detach();
   icosphereGenerator.destroy();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import * as m from 'wgpu-matrix';
 import { type CubemapNames, cubeVertices, loadCubemap } from './cubemap.ts';
 import { Camera, CubeVertex, DirectionalLight, Material, Vertex } from './dataTypes.ts';
@@ -273,13 +273,10 @@ loop();
 
 // #region Example controls and cleanup
 
-const resizeObserver = new ResizeObserver((entries) => {
-  for (const entry of entries) {
-    const dpr = window.devicePixelRatio;
-    const width = entry.contentRect.width;
-    const height = entry.contentRect.height;
-    canvas.width = width * dpr;
-    canvas.height = height * dpr;
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
     const newProj = m.mat4.perspective(
       Math.PI / 4,
       canvas.width / canvas.height,
@@ -288,9 +285,8 @@ const resizeObserver = new ResizeObserver((entries) => {
       d.mat4x4f(),
     );
     cameraBuffer.patch({ projection: newProj });
-  }
+  },
 });
-resizeObserver.observe(canvas);
 
 // Variables for mouse interaction.
 let isDragging = false;
@@ -499,7 +495,7 @@ export function onCleanup() {
   window.removeEventListener('mousemove', mouseMoveEventListener);
   window.removeEventListener('touchmove', touchMoveEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
-  resizeObserver.unobserve(canvas);
+  detachAutoResizer();
   icosphereGenerator.destroy();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/disco/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/disco/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full"></canvas>

--- a/apps/typegpu-docs/src/examples/rendering/disco/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/disco/index.html
@@ -1,1 +1,1 @@
-<canvas class="w-full h-full"></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/rendering/disco/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/disco/index.ts
@@ -42,11 +42,7 @@ let currentPipeline = pipelines[0];
 let startTime: null | number = null;
 let frameId: number;
 
-function render(timestamp: number) {
-  if (startTime === null) {
-    startTime = timestamp;
-  }
-  time.write((timestamp - startTime) / 1000);
+function render() {
   resolutionUniform.write(d.vec2f(canvas.width, canvas.height));
 
   currentPipeline
@@ -55,15 +51,27 @@ function render(timestamp: number) {
       clearValue: [0, 0, 0, 1],
     })
     .draw(6);
-
-  frameId = requestAnimationFrame(render);
 }
 
-frameId = requestAnimationFrame(render);
+function frame(timestamp: number) {
+  if (startTime === null) {
+    startTime = timestamp;
+  }
+  time.write((timestamp - startTime) / 1000);
+
+  render();
+
+  frameId = requestAnimationFrame(frame);
+}
+
+frameId = requestAnimationFrame(frame);
 
 const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
+  onResize() {
+    render();
+  },
 });
 
 export function onCleanup() {

--- a/apps/typegpu-docs/src/examples/rendering/disco/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/disco/index.ts
@@ -66,7 +66,7 @@ function frame(timestamp: number) {
 
 frameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -76,7 +76,7 @@ const detachAutoResizer = common.attachAutoResizer({
 
 export function onCleanup() {
   cancelAnimationFrame(frameId);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/disco/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/disco/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import tgpu, { common, d } from 'typegpu';
 import { resolutionAccess, timeAccess } from './consts.ts';
 import {
   mainFragment1,
@@ -61,8 +61,14 @@ function render(timestamp: number) {
 
 frameId = requestAnimationFrame(render);
 
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+});
+
 export function onCleanup() {
   cancelAnimationFrame(frameId);
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/function-visualizer/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/function-visualizer/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/rendering/function-visualizer/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/function-visualizer/index.ts
@@ -383,22 +383,22 @@ window.addEventListener('touchend', touchEndEventListener);
 
 // Resize observer and cleanup
 
-const resizeObserver = new ResizeObserver(() => {
-  queuePropertiesBufferUpdate();
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    queuePropertiesBufferUpdate();
 
-  msTexture.destroy();
-  msTexture = device.createTexture({
-    size: [canvas.width, canvas.height],
-    sampleCount: 4,
-    format: presentationFormat,
-    usage: GPUTextureUsage.RENDER_ATTACHMENT,
-  });
-  msView = msTexture.createView();
+    msTexture.destroy();
+    msTexture = device.createTexture({
+      size: [canvas.width, canvas.height],
+      sampleCount: 4,
+      format: presentationFormat,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    msView = msTexture.createView();
+  },
 });
-
-resizeObserver.observe(canvas);
-
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
 
 // #region Example controls and cleanup
 
@@ -458,7 +458,6 @@ export function onCleanup() {
   window.removeEventListener('mousemove', mouseMoveEventListener);
   window.removeEventListener('touchmove', touchMoveEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
-  resizeObserver.disconnect();
   detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/function-visualizer/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/function-visualizer/index.ts
@@ -1,5 +1,5 @@
 import type { TgpuGuardedComputePipeline, TgpuRawCodeSnippet } from 'typegpu';
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import { mat4 } from 'wgpu-matrix';
 import { defineControls } from '../../common/defineControls.ts';
 
@@ -398,6 +398,8 @@ const resizeObserver = new ResizeObserver(() => {
 
 resizeObserver.observe(canvas);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls and cleanup
 
 export const controls = defineControls({
@@ -457,6 +459,7 @@ export function onCleanup() {
   window.removeEventListener('touchmove', touchMoveEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
   resizeObserver.disconnect();
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/function-visualizer/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/function-visualizer/index.ts
@@ -383,7 +383,7 @@ window.addEventListener('touchend', touchEndEventListener);
 
 // Resize observer and cleanup
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -458,7 +458,7 @@ export function onCleanup() {
   window.removeEventListener('mousemove', mouseMoveEventListener);
   window.removeEventListener('touchmove', touchMoveEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/jelly-slider/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-slider/index.html
@@ -33,4 +33,4 @@
   Inspired by work of
   <a href="https://x.com/cerpow/status/1964953851603358112" target="_blank">Voicu Apostol</a>
 </div>
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/rendering/jelly-slider/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-slider/index.ts
@@ -714,7 +714,6 @@ const renderPipeline = root.createRenderPipeline({
 });
 
 const eventHandler = new EventHandler(canvas);
-let lastTimestamp: number | null = null;
 let frameCount = 0;
 const taaResolver = new TAAResolver(root, width, height);
 
@@ -748,20 +747,12 @@ function createBindGroups() {
 
 let bindGroups = createBindGroups();
 
-let animationFrameHandle: number;
-function render(timestamp: number) {
+function render() {
   frameCount++;
-  camera.jitter();
-  const deltaTime = Math.min(lastTimestamp !== null ? (timestamp - lastTimestamp) * 0.001 : 0, 0.1);
-  lastTimestamp = timestamp;
-
-  randomUniform.write(d.vec2f((Math.random() - 0.5) * 2, (Math.random() - 0.5) * 2));
-
-  eventHandler.update();
-  slider.setDragX(eventHandler.currentMouseX);
-  slider.update(deltaTime);
-
   const currentFrame = frameCount % 2;
+
+  camera.jitter();
+  randomUniform.write(d.vec2f((Math.random() - 0.5) * 2, (Math.random() - 0.5) * 2));
 
   rayMarchPipeline
     .withColorAttachment({
@@ -777,11 +768,14 @@ function render(timestamp: number) {
     .withColorAttachment({ view: context })
     .with(bindGroups.render[currentFrame])
     .draw(3);
-
-  animationFrameHandle = requestAnimationFrame(render);
 }
 
 function handleResize() {
+  // Keeping the aspect ratio 1:1
+  const size = Math.min(canvas.width, canvas.height);
+  canvas.width = size;
+  canvas.height = size;
+
   [width, height] = [canvas.width * qualityScale, canvas.height * qualityScale];
   camera.updateProjection(Math.PI / 4, width, height);
   textures = createTextures(root, width, height);
@@ -790,6 +784,7 @@ function handleResize() {
   frameCount = 0;
 
   bindGroups = createBindGroups();
+  render();
 }
 
 const detachAutoResizer = common.attachAutoResizer({
@@ -800,7 +795,21 @@ const detachAutoResizer = common.attachAutoResizer({
   },
 });
 
-animationFrameHandle = requestAnimationFrame(render);
+let lastTimestamp: number | null = null;
+let animationFrameHandle: number;
+function frame(timestamp: number) {
+  const deltaTime = Math.min(lastTimestamp !== null ? (timestamp - lastTimestamp) * 0.001 : 0, 0.1);
+  lastTimestamp = timestamp;
+
+  eventHandler.update();
+  slider.setDragX(eventHandler.currentMouseX);
+  slider.update(deltaTime);
+
+  render();
+
+  animationFrameHandle = requestAnimationFrame(frame);
+}
+animationFrameHandle = requestAnimationFrame(frame);
 
 // #region Example controls and cleanup
 

--- a/apps/typegpu-docs/src/examples/rendering/jelly-slider/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-slider/index.ts
@@ -787,7 +787,7 @@ function handleResize() {
   render();
 }
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -918,7 +918,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameHandle);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/jelly-slider/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-slider/index.ts
@@ -792,10 +792,13 @@ function handleResize() {
   bindGroups = createBindGroups();
 }
 
-const resizeObserver = new ResizeObserver(() => {
-  handleResize();
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    handleResize();
+  },
 });
-resizeObserver.observe(canvas);
 
 animationFrameHandle = requestAnimationFrame(render);
 
@@ -906,7 +909,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameHandle);
-  resizeObserver.disconnect();
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.ts
@@ -542,7 +542,7 @@ function handleResize() {
   render();
 }
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -696,7 +696,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameHandle);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.ts
@@ -545,10 +545,13 @@ function handleResize() {
   bindGroups = createBindGroups();
 }
 
-const resizeObserver = new ResizeObserver(() => {
-  handleResize();
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    handleResize();
+  },
 });
-resizeObserver.observe(canvas);
 
 animationFrameHandle = requestAnimationFrame(render);
 
@@ -684,7 +687,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameHandle);
-  resizeObserver.disconnect();
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.ts
@@ -484,7 +484,6 @@ const renderPipeline = root.createRenderPipeline({
   targets: { format: presentationFormat },
 });
 
-let lastTimestamp: number | null = null;
 let frameCount = 0;
 const taaResolver = new TAAResolver(root, width, height);
 
@@ -503,18 +502,12 @@ function createBindGroups() {
 
 let bindGroups = createBindGroups();
 
-let animationFrameHandle: number;
-function render(timestamp: number) {
+function render() {
   frameCount++;
-  camera.jitter();
-  const deltaTime = Math.min(lastTimestamp !== null ? (timestamp - lastTimestamp) * 0.001 : 0, 0.1);
-  lastTimestamp = timestamp;
-
-  randomUniform.write(d.vec2f((Math.random() - 0.5) * 2, (Math.random() - 0.5) * 2));
-
-  switchBehavior.update(deltaTime);
-
   const currentFrame = frameCount % 2;
+
+  camera.jitter();
+  randomUniform.write(d.vec2f((Math.random() - 0.5) * 2, (Math.random() - 0.5) * 2));
 
   rayMarchPipeline
     .withColorAttachment({
@@ -530,11 +523,14 @@ function render(timestamp: number) {
     .withColorAttachment({ view: context })
     .with(bindGroups.render[currentFrame])
     .draw(3);
-
-  animationFrameHandle = requestAnimationFrame(render);
 }
 
 function handleResize() {
+  // Keeping the aspect ratio 1:1
+  const size = Math.min(canvas.width, canvas.height);
+  canvas.width = size;
+  canvas.height = size;
+
   [width, height] = [canvas.width * qualityScale, canvas.height * qualityScale];
   camera.updateProjection(Math.PI / 4, width, height);
   textures = createTextures(root, width, height);
@@ -543,6 +539,7 @@ function handleResize() {
   frameCount = 0;
 
   bindGroups = createBindGroups();
+  render();
 }
 
 const detachAutoResizer = common.attachAutoResizer({
@@ -553,7 +550,19 @@ const detachAutoResizer = common.attachAutoResizer({
   },
 });
 
-animationFrameHandle = requestAnimationFrame(render);
+let lastTimestamp: number | null = null;
+let animationFrameHandle: number;
+function frame(timestamp: number) {
+  const deltaTime = Math.min(lastTimestamp !== null ? (timestamp - lastTimestamp) * 0.001 : 0, 0.1);
+  lastTimestamp = timestamp;
+
+  switchBehavior.update(deltaTime);
+
+  render();
+
+  animationFrameHandle = requestAnimationFrame(frame);
+}
+animationFrameHandle = requestAnimationFrame(frame);
 
 // #region Example controls and cleanup
 

--- a/apps/typegpu-docs/src/examples/rendering/os-awards/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/os-awards/index.html
@@ -12,4 +12,4 @@
 <div class="spinner-background">
   <div class="spinner">Loading...</div>
 </div>
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/rendering/os-awards/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/os-awards/index.ts
@@ -398,7 +398,7 @@ function render() {
 }
 
 let depth = createDepthTexture();
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -440,6 +440,6 @@ export const controls = defineControls({
 export function onCleanup() {
   exampleDestroyed = true;
   cleanupCamera();
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/os-awards/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/os-awards/index.ts
@@ -381,22 +381,7 @@ function createDepthTexture() {
   return { texture, view: texture.createView() };
 }
 
-let depth = createDepthTexture();
-const resizeObserver = new ResizeObserver(() => {
-  depth.texture.destroy();
-  depth = createDepthTexture();
-});
-resizeObserver.observe(canvas);
-
-let exampleDestroyed = false;
-let firstFrameDrawn = false;
-
-function frame(timeMs: number) {
-  if (exampleDestroyed) {
-    return;
-  }
-  updateAwardTransform(timeMs);
-
+function render() {
   envPipeline.withColorAttachment({ view: context }).draw(3);
 
   awardPipeline
@@ -410,6 +395,29 @@ function frame(timeMs: number) {
     .with(awardVertexLayout, award.vertexBuffer)
     .withIndexBuffer(award.indexBuffer)
     .drawIndexed(award.indexCount);
+}
+
+let depth = createDepthTexture();
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    depth.texture.destroy();
+    depth = createDepthTexture();
+    render();
+  },
+});
+
+let exampleDestroyed = false;
+let firstFrameDrawn = false;
+
+function frame(timeMs: number) {
+  if (exampleDestroyed) {
+    return;
+  }
+  updateAwardTransform(timeMs);
+
+  render();
 
   if (!firstFrameDrawn) {
     loadingScreen.style.display = 'none';
@@ -432,6 +440,6 @@ export const controls = defineControls({
 export function onCleanup() {
   exampleDestroyed = true;
   cleanupCamera();
-  resizeObserver.unobserve(canvas);
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/perlin-noise/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/perlin-noise/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/rendering/perlin-noise/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/perlin-noise/index.ts
@@ -80,6 +80,8 @@ function draw(timestamp: number) {
 
 requestAnimationFrame(draw);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 export const controls = defineControls({
   'grid size': {
     initial: '4',
@@ -109,5 +111,6 @@ export const controls = defineControls({
 
 export function onCleanup() {
   isRunning = false;
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/perlin-noise/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/perlin-noise/index.ts
@@ -83,7 +83,7 @@ function frame(timestamp: number) {
 
 requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -124,6 +124,6 @@ export const controls = defineControls({
 
 export function onCleanup() {
   isRunning = false;
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/perlin-noise/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/perlin-noise/index.ts
@@ -66,21 +66,34 @@ let activeSharpenFn: 'exponential' | 'tanh' = 'exponential';
 let isRunning = true;
 let bindGroup = root.createBindGroup(dynamicLayout, perlinCache.bindings);
 
-function draw(timestamp: number) {
+function render() {
+  renderPipelines[activeSharpenFn].with(bindGroup).withColorAttachment({ view: context }).draw(3);
+}
+
+function frame(timestamp: number) {
   if (!isRunning) {
     return;
   }
 
   time.write((timestamp * 0.0002) % DEPTH);
+  render();
 
-  renderPipelines[activeSharpenFn].with(bindGroup).withColorAttachment({ view: context }).draw(3);
-
-  requestAnimationFrame(draw);
+  requestAnimationFrame(frame);
 }
 
-requestAnimationFrame(draw);
+requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    render();
+  },
+});
 
 export const controls = defineControls({
   'grid size': {

--- a/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full"></canvas>

--- a/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.html
@@ -1,1 +1,1 @@
-<canvas class="w-full h-full"></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import * as p from './params.ts';
 import {
   ExampleControls,
@@ -175,10 +175,13 @@ const resizeObserver = new ResizeObserver(() => {
 });
 resizeObserver.observe(canvas);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 export function onCleanup() {
   cancelAnimationFrame(frameId);
   cleanupCamera();
   resizeObserver.unobserve(canvas);
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.ts
@@ -125,7 +125,7 @@ function frame() {
 }
 frameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -185,7 +185,7 @@ export const controls = defineControls({
 export function onCleanup() {
   cancelAnimationFrame(frameId);
   cleanupCamera();
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.ts
@@ -101,9 +101,7 @@ let depthTexture = root.device.createTexture({
   usage: GPUTextureUsage.RENDER_ATTACHMENT,
 });
 
-// frame
-let frameId: number;
-function frame() {
+function render() {
   renderPipeline
     .withColorAttachment({
       view: context,
@@ -117,10 +115,29 @@ function frame() {
     })
     .with(modelVertexLayout, model.vertexBuffer)
     .draw(model.polygonCount);
+}
 
+// frame
+let frameId: number;
+function frame() {
+  render();
   frameId = requestAnimationFrame(frame);
 }
 frameId = requestAnimationFrame(frame);
+
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    depthTexture.destroy();
+    depthTexture = root.device.createTexture({
+      size: [canvas.width, canvas.height, 1],
+      format: 'depth24plus',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    render();
+  },
+});
 
 // #region Example controls and cleanup
 export const controls = defineControls({
@@ -165,22 +182,9 @@ export const controls = defineControls({
   },
 });
 
-const resizeObserver = new ResizeObserver(() => {
-  depthTexture.destroy();
-  depthTexture = root.device.createTexture({
-    size: [canvas.width, canvas.height, 1],
-    format: 'depth24plus',
-    usage: GPUTextureUsage.RENDER_ATTACHMENT,
-  });
-});
-resizeObserver.observe(canvas);
-
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
-
 export function onCleanup() {
   cancelAnimationFrame(frameId);
   cleanupCamera();
-  resizeObserver.unobserve(canvas);
   detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.ts
@@ -7,7 +7,6 @@ import { CameraData, InstanceData, instanceLayout, VertexData, vertexLayout } fr
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();
-const device = root.device;
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
 const context = root.configureContext({ canvas });
 const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
@@ -356,28 +355,11 @@ let lastTime: number | null = null;
 let time = 0;
 let animationFrameId: number;
 
-function render(timestamp: number) {
-  const dt = lastTime !== null ? (timestamp - lastTime) / 1000 : 0;
-  lastTime = timestamp;
-  time += dt;
-
-  for (let i = 0; i < orbitingCubes.length; i++) {
-    const offset = (i / orbitingCubes.length) * Math.PI * 2;
-    const angle = time * 0.5 + offset;
-    const radius = 4 + Math.sin(time * 2 + offset * 3) * 0.5;
-    const x = Math.cos(angle) * radius;
-    const z = Math.sin(angle) * radius;
-    const y = 2 + Math.sin(time * 1.5 + offset * 2) * 1.5;
-    orbitingCubes[i].position = d.vec3f(x, y, z);
-    orbitingCubes[i].rotation = d.vec3f(time, time * 0.5, 0);
-  }
-
-  scene.update();
+function render() {
   pointLight.renderShadowMaps(pipelineDepthOne, renderLayout, scene);
 
   if (showDepthPreview) {
     pipelinePreview.withColorAttachment({ view: context }).draw(3);
-    animationFrameId = requestAnimationFrame(render);
     return;
   }
 
@@ -415,15 +397,42 @@ function render(timestamp: number) {
     .withIndexBuffer(BoxGeometry.indexBuffer)
     .with(vertexLayout, BoxGeometry.vertexBuffer)
     .drawIndexed(BoxGeometry.indexCount);
-
-  animationFrameId = requestAnimationFrame(render);
 }
-animationFrameId = requestAnimationFrame(render);
+
+function frame(timestamp: number) {
+  animationFrameId = requestAnimationFrame(frame);
+
+  const dt = lastTime !== null ? (timestamp - lastTime) / 1000 : 0;
+  lastTime = timestamp;
+  time += dt;
+
+  for (let i = 0; i < orbitingCubes.length; i++) {
+    const offset = (i / orbitingCubes.length) * Math.PI * 2;
+    const angle = time * 0.5 + offset;
+    const radius = 4 + Math.sin(time * 2 + offset * 3) * 0.5;
+    const x = Math.cos(angle) * radius;
+    const z = Math.sin(angle) * radius;
+    const y = 2 + Math.sin(time * 1.5 + offset * 2) * 1.5;
+    orbitingCubes[i].position = d.vec3f(x, y, z);
+    orbitingCubes[i].rotation = d.vec3f(time, time * 0.5, 0);
+  }
+
+  scene.update();
+
+  render();
+}
+
+animationFrameId = requestAnimationFrame(frame);
 
 const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+
     depthTexture = root
       .createTexture({
         size: [canvas.width, canvas.height],
@@ -438,6 +447,8 @@ const detachAutoResizer = common.attachAutoResizer({
         sampleCount: 4,
       })
       .$usage('render');
+
+    render();
   },
 });
 

--- a/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.ts
@@ -420,13 +420,10 @@ function render(timestamp: number) {
 }
 animationFrameId = requestAnimationFrame(render);
 
-const resizeObserver = new ResizeObserver((entries) => {
-  for (const entry of entries) {
-    const width = entry.contentBoxSize[0].inlineSize;
-    const height = entry.contentBoxSize[0].blockSize;
-    canvas.width = Math.max(1, Math.min(width, device.limits.maxTextureDimension2D));
-    canvas.height = Math.max(1, Math.min(height, device.limits.maxTextureDimension2D));
-
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
     depthTexture = root
       .createTexture({
         size: [canvas.width, canvas.height],
@@ -441,9 +438,8 @@ const resizeObserver = new ResizeObserver((entries) => {
         sampleCount: 4,
       })
       .$usage('render');
-  }
+  },
 });
-resizeObserver.observe(canvas);
 
 const initialCamPos = { x: 5, y: 5, z: -5 };
 let theta = Math.atan2(initialCamPos.z, initialCamPos.x);
@@ -651,7 +647,7 @@ export function onCleanup() {
   window.removeEventListener('mousemove', mouseMoveEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
   window.removeEventListener('touchmove', touchMoveEventListener);
-  resizeObserver.disconnect();
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.ts
@@ -424,7 +424,7 @@ function frame(timestamp: number) {
 
 animationFrameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -658,7 +658,7 @@ export function onCleanup() {
   window.removeEventListener('mousemove', mouseMoveEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
   window.removeEventListener('touchmove', touchMoveEventListener);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/pom/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/pom/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/rendering/pom/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/pom/index.ts
@@ -404,8 +404,7 @@ function createDepthTexture() {
 }
 createDepthTexture();
 
-let frameId: number;
-function frame() {
+function render() {
   pipeline
     .withColorAttachment({ view: context, clearValue: [0, 0, 0, 1] })
     .withDepthStencilAttachment({
@@ -415,9 +414,23 @@ function frame() {
       depthStoreOp: 'store',
     })
     .drawIndexed(planeMesh.indexCount);
+}
+
+let frameId: number;
+function frame() {
+  render();
   frameId = requestAnimationFrame(frame);
 }
 frameId = requestAnimationFrame(frame);
+
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    createDepthTexture();
+    render();
+  },
+});
 
 // #region Example controls and cleanup
 
@@ -480,14 +493,6 @@ export const controls = defineControls({
       sunAngle = (v * Math.PI) / 180;
       pomParams.patch({ lightDir: computeLightDir(sunAngle, sunHeight) });
     },
-  },
-});
-
-const detachAutoResizer = common.attachAutoResizer({
-  root,
-  canvas,
-  onResize() {
-    createDepthTexture();
   },
 });
 

--- a/apps/typegpu-docs/src/examples/rendering/pom/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/pom/index.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { d, std, type RenderFlag, type TgpuTexture } from 'typegpu';
+import tgpu, { common, d, std, type RenderFlag, type TgpuTexture } from 'typegpu';
 import { Camera, setupOrbitCamera } from '../../common/setup-orbit-camera.ts';
 import { defineControls } from '../../common/defineControls.ts';
 import {
@@ -483,13 +483,18 @@ export const controls = defineControls({
   },
 });
 
-const resizeObserver = new ResizeObserver(createDepthTexture);
-resizeObserver.observe(canvas);
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    createDepthTexture();
+  },
+});
 
 export function onCleanup() {
   cancelAnimationFrame(frameId);
   cleanupCamera();
-  resizeObserver.unobserve(canvas);
+  detachAutoResizer();
   depthTexture.destroy();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/pom/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/pom/index.ts
@@ -423,7 +423,7 @@ function frame() {
 }
 frameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -499,7 +499,7 @@ export const controls = defineControls({
 export function onCleanup() {
   cancelAnimationFrame(frameId);
   cleanupCamera();
-  detachAutoResizer();
+  autoResizer.detach();
   depthTexture.destroy();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/radiance-cascades-drawing/drawInteraction.ts
+++ b/apps/typegpu-docs/src/examples/rendering/radiance-cascades-drawing/drawInteraction.ts
@@ -42,9 +42,17 @@ export function createDrawInteraction({ canvas, onDraw, onStop }: DrawInteractio
 
   function mousePosition(e: MouseEvent): Point {
     const rect = canvas.getBoundingClientRect();
+
+    // Taking into account the square aspect ratio
+    const centerX = rect.x + rect.width / 2;
+    const centerY = rect.y + rect.height / 2;
+    const size = Math.min(rect.width, rect.height);
+    const squareLeft = centerX - size / 2;
+    const squareTop = centerY - size / 2;
+
     return {
-      x: (e.clientX - rect.left) / rect.width,
-      y: (e.clientY - rect.top) / rect.height,
+      x: (e.clientX - squareLeft) / size,
+      y: (e.clientY - squareTop) / size,
     };
   }
 

--- a/apps/typegpu-docs/src/examples/rendering/radiance-cascades-drawing/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/radiance-cascades-drawing/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/rendering/radiance-cascades-drawing/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/radiance-cascades-drawing/index.ts
@@ -17,7 +17,7 @@ context.configure({
   format: presentationFormat,
 });
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -258,7 +258,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(frameId);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/radiance-cascades-drawing/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/radiance-cascades-drawing/index.ts
@@ -4,6 +4,8 @@ import tgpu, { common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 import { createDrawInteraction } from './drawInteraction.ts';
 
+const [sceneWidth, sceneHeight] = [1024, 1024];
+
 const root = await tgpu.init();
 
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
@@ -15,12 +17,21 @@ context.configure({
   format: presentationFormat,
 });
 
-const [width, height] = [canvas.width, canvas.height];
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+  },
+});
 
 // Scene texture + views.
 const sceneTexture = root
   .createTexture({
-    size: [width, height],
+    size: [sceneWidth, sceneHeight],
     format: 'rgba16float',
   })
   .$usage('storage', 'sampled');
@@ -80,7 +91,7 @@ const drawCompute = root.createGuardedComputePipeline((x, y) => {
   std.textureStore(sceneWriteView.$, d.vec2u(x, y), out);
 });
 
-const floodSize = { width: canvas.width, height: canvas.height };
+const floodSize = { width: sceneWidth, height: sceneHeight };
 const floodRunner = sdf
   .createJumpFlood({
     root,
@@ -114,7 +125,7 @@ const floodColorView = floodRunner.colorOutput.createView();
 
 const radianceRunner = rc.createRadianceCascades({
   root,
-  size: { width: Math.floor(width / 4), height: Math.floor(height / 4) },
+  size: { width: Math.floor(sceneWidth / 4), height: Math.floor(sceneHeight / 4) },
   sdfResolution: floodSize,
   sdf: (uv) => {
     'use gpu';
@@ -176,7 +187,7 @@ const displayPipeline = root.createRenderPipeline({
 let sceneDirty = false;
 
 function drawScene() {
-  drawCompute.dispatchThreads(width, height);
+  drawCompute.dispatchThreads(sceneWidth, sceneHeight);
   sceneDirty = true;
 }
 
@@ -214,8 +225,6 @@ function frame(timestamp: number) {
 
   frameId = requestAnimationFrame(frame);
 }
-
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
 
 // #region Example controls and cleanup
 

--- a/apps/typegpu-docs/src/examples/rendering/radiance-cascades-drawing/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/radiance-cascades-drawing/index.ts
@@ -215,6 +215,8 @@ function frame(timestamp: number) {
   frameId = requestAnimationFrame(frame);
 }
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls and cleanup
 
 export const controls = defineControls({
@@ -247,6 +249,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(frameId);
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/radiance-cascades/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/radiance-cascades/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/rendering/radiance-cascades/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/radiance-cascades/index.ts
@@ -481,6 +481,11 @@ const detachAutoResizer = common.attachAutoResizer({
   onResize() {
     clearTimeout(resizeTimeout);
     resizeTimeout = setTimeout(recreateSizedResources, 100);
+
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
   },
 });
 

--- a/apps/typegpu-docs/src/examples/rendering/radiance-cascades/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/radiance-cascades/index.ts
@@ -475,15 +475,18 @@ const dragController = new DragController(canvas, onDrag, onDrag);
 // #region Example controls and cleanup
 
 let resizeTimeout: ReturnType<typeof setTimeout>;
-const resizeObserver = new ResizeObserver(() => {
-  clearTimeout(resizeTimeout);
-  resizeTimeout = setTimeout(recreateSizedResources, 100);
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    clearTimeout(resizeTimeout);
+    resizeTimeout = setTimeout(recreateSizedResources, 100);
+  },
 });
-resizeObserver.observe(canvas);
 
 export function onCleanup() {
   dragController.destroy();
-  resizeObserver.disconnect();
+  detachAutoResizer();
   clearTimeout(resizeTimeout);
   if (frameId !== null) {
     cancelAnimationFrame(frameId);

--- a/apps/typegpu-docs/src/examples/rendering/radiance-cascades/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/radiance-cascades/index.ts
@@ -475,7 +475,7 @@ const dragController = new DragController(canvas, onDrag, onDrag);
 // #region Example controls and cleanup
 
 let resizeTimeout: ReturnType<typeof setTimeout>;
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -491,7 +491,7 @@ const detachAutoResizer = common.attachAutoResizer({
 
 export function onCleanup() {
   dragController.destroy();
-  detachAutoResizer();
+  autoResizer.detach();
   clearTimeout(resizeTimeout);
   if (frameId !== null) {
     cancelAnimationFrame(frameId);

--- a/apps/typegpu-docs/src/examples/rendering/ray-marching/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/ray-marching/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/rendering/ray-marching/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/ray-marching/index.ts
@@ -232,13 +232,13 @@ function run(timestamp: number) {
 
 animationFrame = requestAnimationFrame(run);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
 });
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrame);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/ray-marching/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/ray-marching/index.ts
@@ -1,5 +1,5 @@
 import { sdBoxFrame3d, sdPlane, sdSphere } from '@typegpu/sdf';
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 
 const root = await tgpu.init();
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
@@ -232,7 +232,13 @@ function run(timestamp: number) {
 
 animationFrame = requestAnimationFrame(run);
 
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+});
+
 export function onCleanup() {
   cancelAnimationFrame(animationFrame);
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full"></canvas>

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.html
@@ -1,1 +1,1 @@
-<canvas class="w-full h-full"></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.ts
@@ -1,5 +1,5 @@
 import { perlin2d } from '@typegpu/noise';
-import tgpu, { d } from 'typegpu';
+import tgpu, { common, d } from 'typegpu';
 import * as m from 'wgpu-matrix';
 import { defineControls } from '../../common/defineControls.ts';
 import { setupOrbitCamera } from '../../common/setup-orbit-camera.ts';
@@ -197,6 +197,8 @@ function frame() {
 
 requestAnimationFrame(frame);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls and cleanup
 
 export const controls = defineControls({
@@ -220,5 +222,6 @@ export function onCleanup() {
   cleanupCamera();
   perlinCache.destroy();
   depthTexture.destroy();
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.ts
@@ -201,7 +201,7 @@ function frame() {
 
 requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -232,6 +232,6 @@ export function onCleanup() {
   cleanupCamera();
   perlinCache.destroy();
   depthTexture.destroy();
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.ts
@@ -147,11 +147,7 @@ setCubeCount(INITIAL_CUBE_COUNT);
 
 let useBundles = true;
 
-let disposed = false;
-
-function frame() {
-  if (disposed) return;
-
+function render() {
   if (depthTexture.width !== canvas.width || depthTexture.height !== canvas.height) {
     depthTexture.destroy();
     depthTexture = root.device.createTexture({
@@ -191,13 +187,27 @@ function frame() {
 
   pass.end();
   root.device.queue.submit([encoder.finish()]);
+}
+
+let disposed = false;
+
+function frame() {
+  if (disposed) return;
+
+  render();
 
   requestAnimationFrame(frame);
 }
 
 requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    render();
+  },
+});
 
 // #region Example controls and cleanup
 

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles/index.ts
@@ -201,7 +201,7 @@ function frame() {
 
 requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -230,7 +230,7 @@ export const controls = defineControls({
 export function onCleanup() {
   disposed = true;
   cleanupCamera();
-  detachAutoResizer();
+  autoResizer.detach();
   perlinCache.destroy();
   depthTexture.destroy();
   root.destroy();

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles/index.ts
@@ -147,9 +147,7 @@ let useBundles = true;
 
 let disposed = false;
 
-function frame() {
-  if (disposed) return;
-
+function render() {
   if (depthTexture.width !== canvas.width || depthTexture.height !== canvas.height) {
     depthTexture.destroy();
     depthTexture = root.device.createTexture({
@@ -191,6 +189,12 @@ function frame() {
       }
     }
   });
+}
+
+function frame() {
+  if (disposed) return;
+
+  render();
 
   requestAnimationFrame(frame);
 }
@@ -200,6 +204,9 @@ requestAnimationFrame(frame);
 const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
+  onResize() {
+    render();
+  },
 });
 
 // #region Example controls and cleanup

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles/index.ts
@@ -1,5 +1,5 @@
 import { perlin2d } from '@typegpu/noise';
-import tgpu, { d } from 'typegpu';
+import tgpu, { common, d } from 'typegpu';
 import * as m from 'wgpu-matrix';
 import { defineControls } from '../../common/defineControls.ts';
 import { setupOrbitCamera } from '../../common/setup-orbit-camera.ts';
@@ -197,6 +197,11 @@ function frame() {
 
 requestAnimationFrame(frame);
 
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+});
+
 // #region Example controls and cleanup
 
 export const controls = defineControls({
@@ -218,6 +223,7 @@ export const controls = defineControls({
 export function onCleanup() {
   disposed = true;
   cleanupCamera();
+  detachAutoResizer();
   perlinCache.destroy();
   depthTexture.destroy();
   root.destroy();

--- a/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full"></canvas>

--- a/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.html
@@ -1,1 +1,1 @@
-<canvas class="w-full h-full"></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.ts
@@ -344,7 +344,7 @@ function frame() {
 }
 frameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -460,6 +460,6 @@ export function onCleanup() {
   if (frameId !== null) {
     cancelAnimationFrame(frameId);
   }
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import { mat4 } from 'wgpu-matrix';
 import { createCuboid, createPlane } from './geometry.ts';
 import {
@@ -340,21 +340,24 @@ function render() {
 }
 frameId = requestAnimationFrame(render);
 
-const resizeObserver = new ResizeObserver(() => {
-  canvasTextures = createCanvasTextures();
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    canvasTextures = createCanvasTextures();
 
-  const newProjection = mat4.perspective(
-    Math.PI / 4,
-    canvas.width / canvas.height,
-    0.1,
-    100,
-    d.mat4x4f(),
-  );
-  cameraUniform.patch({
-    projection: newProjection,
-  });
+    const newProjection = mat4.perspective(
+      Math.PI / 4,
+      canvas.width / canvas.height,
+      0.1,
+      100,
+      d.mat4x4f(),
+    );
+    cameraUniform.patch({
+      projection: newProjection,
+    });
+  },
 });
-resizeObserver.observe(canvas);
 
 export const controls = defineControls({
   'camera X': {
@@ -451,6 +454,6 @@ export function onCleanup() {
   if (frameId !== null) {
     cancelAnimationFrame(frameId);
   }
-  resizeObserver.disconnect();
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.ts
@@ -280,11 +280,7 @@ function updateLightDirection(dir: d.v3f) {
   });
 }
 
-// Render loop
-let frameId: number | null = null;
 function render() {
-  frameId = requestAnimationFrame(render);
-
   root['~unstable'].beginRenderPass(
     {
       colorAttachments: [],
@@ -338,7 +334,15 @@ function render() {
     },
   );
 }
-frameId = requestAnimationFrame(render);
+
+// Render loop
+let frameId: number | null = null;
+function frame() {
+  frameId = requestAnimationFrame(frame);
+
+  render();
+}
+frameId = requestAnimationFrame(frame);
 
 const detachAutoResizer = common.attachAutoResizer({
   root,
@@ -356,6 +360,8 @@ const detachAutoResizer = common.attachAutoResizer({
     cameraUniform.patch({
       projection: newProjection,
     });
+
+    render();
   },
 });
 

--- a/apps/typegpu-docs/src/examples/rendering/smoky-triangle/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/smoky-triangle/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/rendering/smoky-triangle/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/smoky-triangle/index.ts
@@ -1,5 +1,5 @@
 import { perlin3d } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 
 const Params = d.struct({
   fromColor: d.vec3f,
@@ -93,6 +93,8 @@ function frame(timestamp: number) {
 }
 frameId = requestAnimationFrame(frame);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 export const controls = {
   Distortion: {
     initial: 0.05,
@@ -164,5 +166,6 @@ export const controls = {
 
 export function onCleanup() {
   cancelAnimationFrame(frameId);
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/smoky-triangle/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/smoky-triangle/index.ts
@@ -97,7 +97,7 @@ function frame(timestamp: number) {
 }
 frameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -180,6 +180,6 @@ export const controls = {
 
 export function onCleanup() {
   cancelAnimationFrame(frameId);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/smoky-triangle/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/smoky-triangle/index.ts
@@ -80,6 +80,10 @@ const pipeline = root.pipe(perlinCache.inject()).createRenderPipeline({
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
 const context = root.configureContext({ canvas, alphaMode: 'premultiplied' });
 
+function render() {
+  pipeline.withColorAttachment({ view: context }).draw(3);
+}
+
 let frameId: number;
 function frame(timestamp: number) {
   paramsUniform.patch({
@@ -87,13 +91,23 @@ function frame(timestamp: number) {
     grainSeed: Math.floor(Math.random() * 100),
   });
 
-  pipeline.withColorAttachment({ view: context }).draw(3);
+  render();
 
   frameId = requestAnimationFrame(frame);
 }
 frameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    render();
+  },
+});
 
 export const controls = {
   Distortion: {

--- a/apps/typegpu-docs/src/examples/rendering/suika-sdf/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/suika-sdf/index.html
@@ -1,4 +1,4 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />
 
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap" />
 

--- a/apps/typegpu-docs/src/examples/rendering/suika-sdf/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/suika-sdf/index.ts
@@ -414,7 +414,7 @@ const renderPipeline = root.createRenderPipeline({
   },
 });
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -688,6 +688,6 @@ export const controls = defineControls({
 export function onCleanup() {
   cleanupController.abort();
   cancelAnimationFrame(animationFrameId);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/suika-sdf/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/suika-sdf/index.ts
@@ -1,5 +1,5 @@
 import * as sdf from '@typegpu/sdf';
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import { fullScreenTriangle } from 'typegpu/common';
 import {
   DROP_Y,
@@ -414,18 +414,21 @@ const renderPipeline = root.createRenderPipeline({
   },
 });
 
-const resizeObserver = new ResizeObserver(() => {
-  mergedField.distance.destroy();
-  mergedField.info.destroy();
-  mergedField = createMergedFieldResources();
-  distanceView = mergedField.distance.createView(d.texture2d());
-  infoView = mergedField.info.createView(d.texture2d());
-  mergedFieldBindGroup = root.createBindGroup(mergedFieldLayout, {
-    distance: distanceView,
-    info: infoView,
-  });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    mergedField.distance.destroy();
+    mergedField.info.destroy();
+    mergedField = createMergedFieldResources();
+    distanceView = mergedField.distance.createView(d.texture2d());
+    infoView = mergedField.info.createView(d.texture2d());
+    mergedFieldBindGroup = root.createBindGroup(mergedFieldLayout, {
+      distance: distanceView,
+      info: infoView,
+    });
+  },
 });
-resizeObserver.observe(canvas);
 
 canvas.addEventListener('touchstart', (e) => e.preventDefault(), { passive: false, signal });
 canvas.addEventListener('touchmove', (e) => e.preventDefault(), { passive: false, signal });
@@ -676,6 +679,6 @@ export const controls = defineControls({
 export function onCleanup() {
   cleanupController.abort();
   cancelAnimationFrame(animationFrameId);
-  resizeObserver.disconnect();
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/suika-sdf/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/suika-sdf/index.ts
@@ -427,6 +427,8 @@ const detachAutoResizer = common.attachAutoResizer({
       distance: distanceView,
       info: infoView,
     });
+
+    render();
   },
 });
 
@@ -529,6 +531,24 @@ function restart() {
     circleData[i] = { ...INACTIVE_CIRCLE };
   }
   circleUniform.write(circleData);
+}
+
+function render() {
+  frameUniform.patch({
+    canvasAspect: canvas.width / canvas.height,
+  });
+
+  mergedFieldPipeline
+    .withColorAttachment({
+      distance: { view: distanceView },
+      info: { view: infoView },
+    })
+    .draw(3);
+
+  renderPipeline
+    .with(mergedFieldBindGroup)
+    .withColorAttachment({ view: context, clearValue: { r: 0, g: 0, b: 0, a: 1 } })
+    .draw(3);
 }
 
 let lastTime = 0;
@@ -645,18 +665,7 @@ function frame(now: number) {
         },
   });
 
-  mergedFieldPipeline
-    .withColorAttachment({
-      distance: { view: distanceView },
-      info: { view: infoView },
-    })
-    .draw(3);
-
-  renderPipeline
-    .with(mergedFieldBindGroup)
-    .withColorAttachment({ view: context, clearValue: { r: 0, g: 0, b: 0, a: 1 } })
-    .draw(3);
-
+  render();
   animationFrameId = requestAnimationFrame(frame);
 }
 animationFrameId = requestAnimationFrame(frame);

--- a/apps/typegpu-docs/src/examples/rendering/two-boxes/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/two-boxes/index.html
@@ -27,4 +27,4 @@
   <p class="controls"><b>Right Mouse Button:</b> Rotate cubes</p>
   <p class="controls"><b>Scroll / Two-Finger Drag:</b> Zoom</p>
 </div>
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/rendering/two-boxes/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/two-boxes/index.ts
@@ -460,7 +460,7 @@ canvas.addEventListener(
   { passive: false },
 );
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -479,7 +479,7 @@ export function onCleanup() {
   window.removeEventListener('mousemove', mouseMoveEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
   window.removeEventListener('touchmove', touchMoveEventListener);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/two-boxes/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/two-boxes/index.ts
@@ -30,7 +30,7 @@ const vertexLayout = tgpu.vertexLayout(d.arrayOf(Vertex));
 
 // Scene Setup
 
-const aspect = canvas.clientWidth / canvas.clientHeight;
+const aspect = 1;
 const target = d.vec3f(0, 0, 0);
 const cameraInitialPos = d.vec4f(12, 5, 12, 1);
 
@@ -460,12 +460,18 @@ canvas.addEventListener(
   { passive: false },
 );
 
-const resizeObserver = new ResizeObserver(() => {
-  createDepthAndMsaaTextures();
-});
-resizeObserver.observe(canvas);
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+    createDepthAndMsaaTextures();
+  },
+});
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameId);
@@ -473,7 +479,6 @@ export function onCleanup() {
   window.removeEventListener('mousemove', mouseMoveEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
   window.removeEventListener('touchmove', touchMoveEventListener);
-  resizeObserver.disconnect();
   detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/rendering/two-boxes/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/two-boxes/index.ts
@@ -1,5 +1,5 @@
 import type { RenderFlag, TgpuBindGroup, TgpuBuffer, TgpuTexture, VertexFlag } from 'typegpu';
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import * as m from 'wgpu-matrix';
 
 // Initialization
@@ -465,6 +465,8 @@ const resizeObserver = new ResizeObserver(() => {
 });
 resizeObserver.observe(canvas);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 export function onCleanup() {
   cancelAnimationFrame(animationFrameId);
   window.removeEventListener('mouseup', mouseUpEventListener);
@@ -472,6 +474,7 @@ export function onCleanup() {
   window.removeEventListener('touchend', touchEndEventListener);
   window.removeEventListener('touchmove', touchMoveEventListener);
   resizeObserver.disconnect();
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/xor-dev-centrifuge-2/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/xor-dev-centrifuge-2/index.html
@@ -1,4 +1,4 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />
 <p class="absolute px-2 py-1 rounded-xl top-2 mx-auto text-lg text-center text-white bg-black/50">
   Port of "Centrifuge 2" by XorDev (<a
     class="text-purple-300"

--- a/apps/typegpu-docs/src/examples/rendering/xor-dev-centrifuge-2/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/xor-dev-centrifuge-2/index.ts
@@ -120,7 +120,7 @@ function draw(timestamp: number) {
 
 requestAnimationFrame(draw);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const autoResizer = common.attachAutoResizer({ root, canvas });
 
 // #region Example controls and cleanup
 
@@ -180,7 +180,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   isRunning = false;
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/xor-dev-centrifuge-2/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/xor-dev-centrifuge-2/index.ts
@@ -10,7 +10,7 @@
  * ```
  */
 
-import tgpu, { d } from 'typegpu';
+import tgpu, { common, d } from 'typegpu';
 import { abs, atan2, cos, gt, length, normalize, select, sign, tanh } from 'typegpu/std';
 import { defineControls } from '../../common/defineControls.ts';
 
@@ -120,6 +120,8 @@ function draw(timestamp: number) {
 
 requestAnimationFrame(draw);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls and cleanup
 
 export const controls = defineControls({
@@ -178,6 +180,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   isRunning = false;
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/xor-dev-runner/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/xor-dev-runner/index.html
@@ -1,4 +1,4 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />
 <p class="absolute px-2 py-1 rounded-xl top-2 mx-auto text-lg text-center text-white bg-black/50">
   Port of "Runner" by XorDev (<a
     class="text-purple-300"

--- a/apps/typegpu-docs/src/examples/rendering/xor-dev-runner/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/xor-dev-runner/index.ts
@@ -172,7 +172,7 @@ function draw() {
 
 requestAnimationFrame(draw);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
 });
@@ -215,7 +215,7 @@ export const controls = defineControls({
 export function onCleanup() {
   isRunning = false;
   cleanupCamera();
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/rendering/xor-dev-runner/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/xor-dev-runner/index.ts
@@ -12,7 +12,7 @@
  * ```
  */
 
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import { abs, add, cos, max, min, mul, select, sign, sin, sub, tanh } from 'typegpu/std';
 import { defineControls } from '../../common/defineControls.ts';
 import { Camera, setupFirstPersonCamera } from '../../common/setup-first-person-camera.ts';
@@ -172,6 +172,11 @@ function draw() {
 
 requestAnimationFrame(draw);
 
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+});
+
 // #region Example controls and cleanup
 
 export const controls = defineControls({
@@ -210,6 +215,7 @@ export const controls = defineControls({
 export function onCleanup() {
   isRunning = false;
   cleanupCamera();
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simple/gradient-tiles/index.html
+++ b/apps/typegpu-docs/src/examples/simple/gradient-tiles/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simple/gradient-tiles/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/gradient-tiles/index.ts
@@ -33,7 +33,13 @@ function draw(spanXValue: number, spanYValue: number) {
 let spanX = 10;
 let spanY = 10;
 
-draw(spanX, spanY);
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    draw(spanX, spanY);
+  },
+});
 
 // #region Example controls and cleanup
 
@@ -62,6 +68,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simple/gradient-tiles/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/gradient-tiles/index.ts
@@ -37,6 +37,10 @@ const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
     draw(spanX, spanY);
   },
 });

--- a/apps/typegpu-docs/src/examples/simple/gradient-tiles/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/gradient-tiles/index.ts
@@ -33,7 +33,7 @@ function draw(spanXValue: number, spanYValue: number) {
 let spanX = 10;
 let spanY = 10;
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -72,7 +72,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simple/liquid-glass/index.html
+++ b/apps/typegpu-docs/src/examples/simple/liquid-glass/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simple/liquid-glass/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/liquid-glass/index.ts
@@ -187,6 +187,8 @@ function render() {
 }
 frameId = requestAnimationFrame(render);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 export const controls = defineControls({
   'Rectangle dims': {
     initial: defaultParams.rectDims,
@@ -305,5 +307,6 @@ export function onCleanup() {
     cancelAnimationFrame(frameId);
   }
   window.removeEventListener('mousemove', handleMouseMove);
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simple/liquid-glass/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/liquid-glass/index.ts
@@ -191,7 +191,7 @@ function frame() {
 }
 frameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -321,6 +321,6 @@ export function onCleanup() {
     cancelAnimationFrame(frameId);
   }
   window.removeEventListener('mousemove', handleMouseMove);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simple/liquid-glass/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/liquid-glass/index.ts
@@ -180,14 +180,28 @@ canvas.addEventListener('touchmove', handleTouchMove, { passive: true });
 canvas.addEventListener('touchstart', handleTouchStart, { passive: true });
 canvas.addEventListener('click', handleClick);
 
-let frameId: number;
 function render() {
-  frameId = requestAnimationFrame(render);
   pipeline.withColorAttachment({ view: context }).draw(3);
 }
-frameId = requestAnimationFrame(render);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+let frameId: number;
+function frame() {
+  frameId = requestAnimationFrame(frame);
+  render();
+}
+frameId = requestAnimationFrame(frame);
+
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    render();
+  },
+});
 
 export const controls = defineControls({
   'Rectangle dims': {

--- a/apps/typegpu-docs/src/examples/simple/mesh-skinning/index.html
+++ b/apps/typegpu-docs/src/examples/simple/mesh-skinning/index.html
@@ -1,4 +1,4 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />
 
 <style>
   #attribution {

--- a/apps/typegpu-docs/src/examples/simple/mesh-skinning/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/mesh-skinning/index.ts
@@ -525,6 +525,8 @@ function render(frameTimeMs: number) {
 let animationId: number | undefined;
 animationId = requestAnimationFrame(render);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 export const controls = defineControls({
   Animation: {
     initial: toLabel(selectedVariant.id),
@@ -561,5 +563,6 @@ export function onCleanup() {
   }
   resizeObserver.disconnect();
   cleanupCamera();
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simple/mesh-skinning/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/mesh-skinning/index.ts
@@ -112,7 +112,7 @@ const context = root.configureContext({ canvas });
 const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
 function createDepthTexture() {
-  return root['~unstable']
+  return root
     .createTexture({
       size: [canvas.width, canvas.height],
       format: 'depth24plus',
@@ -122,7 +122,7 @@ function createDepthTexture() {
 }
 
 function createMsaaTexture() {
-  return root['~unstable']
+  return root
     .createTexture({
       size: [canvas.width, canvas.height],
       format: presentationFormat,
@@ -274,12 +274,6 @@ const pipelineConfig = {
 
 const lbsPipeline = root.createRenderPipeline({ vertex, ...pipelineConfig });
 const dqsPipeline = root.createRenderPipeline({ vertex: dqsVertex, ...pipelineConfig });
-
-const resizeObserver = new ResizeObserver(() => {
-  depthTexture = createDepthTexture();
-  msaaTexture = createMsaaTexture();
-});
-resizeObserver.observe(canvas);
 
 const state = {
   selectedVariantId,
@@ -525,7 +519,14 @@ function render(frameTimeMs: number) {
 let animationId: number | undefined;
 animationId = requestAnimationFrame(render);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    depthTexture = createDepthTexture();
+    msaaTexture = createMsaaTexture();
+  },
+});
 
 export const controls = defineControls({
   Animation: {
@@ -561,7 +562,6 @@ export function onCleanup() {
   if (animationId !== undefined) {
     cancelAnimationFrame(animationId);
   }
-  resizeObserver.disconnect();
   cleanupCamera();
   detachAutoResizer();
   root.destroy();

--- a/apps/typegpu-docs/src/examples/simple/mesh-skinning/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/mesh-skinning/index.ts
@@ -519,7 +519,7 @@ function render(frameTimeMs: number) {
 let animationId: number | undefined;
 animationId = requestAnimationFrame(render);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -563,6 +563,6 @@ export function onCleanup() {
     cancelAnimationFrame(animationId);
   }
   cleanupCamera();
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simple/oklab/index.html
+++ b/apps/typegpu-docs/src/examples/simple/oklab/index.html
@@ -26,6 +26,8 @@
     font-size: small;
   }
 </style>
-<canvas></canvas>
-<div id="css-probe"></div>
+<div class="relative w-full h-full">
+  <canvas class="w-full h-full object-contain" />
+  <div id="css-probe"></div>
+</div>
 <div id="probe-position"></div>

--- a/apps/typegpu-docs/src/examples/simple/oklab/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/oklab/index.ts
@@ -158,7 +158,7 @@ function draw() {
   pipeline.withColorAttachment({ view: context }).draw(3);
 }
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -234,7 +234,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer();
   root.destroy();
   cleanupController.abort();
 }

--- a/apps/typegpu-docs/src/examples/simple/oklab/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/oklab/index.ts
@@ -234,7 +234,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  autoResizer();
+  autoResizer.detach();
   root.destroy();
   cleanupController.abort();
 }

--- a/apps/typegpu-docs/src/examples/simple/oklab/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/oklab/index.ts
@@ -143,9 +143,13 @@ function draw() {
   pipeline.withColorAttachment({ view: context }).draw(3);
 }
 
-setTimeout(() => {
-  draw();
-}, 100);
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    draw();
+  },
+});
 
 // #region Example controls and cleanup
 
@@ -211,6 +215,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
   cleanupController.abort();
 }

--- a/apps/typegpu-docs/src/examples/simple/oklab/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/oklab/index.ts
@@ -27,8 +27,15 @@ document.addEventListener(
   'mousemove',
   (ev) => {
     const rect = canvas.getBoundingClientRect();
-    cssProbePosition.x = (ev.clientX - rect.x) / rect.width;
-    cssProbePosition.y = 1 - (ev.clientY - rect.y) / rect.height;
+
+    const centerX = rect.x + rect.width / 2;
+    const centerY = rect.y + rect.height / 2;
+    const size = Math.min(rect.width, rect.height);
+    const squareLeft = centerX - size / 2;
+    const squareTop = centerY - size / 2;
+
+    cssProbePosition.x = std.saturate((ev.clientX - squareLeft) / size);
+    cssProbePosition.y = std.saturate(1 - (ev.clientY - squareTop) / size);
     draw();
   },
   {
@@ -129,8 +136,16 @@ function draw() {
   const chroma = pos.x;
   const a = chroma * Math.cos(uniformsValue.hue);
   const b = chroma * Math.sin(uniformsValue.hue);
-  cssProbe.style.setProperty('--x', `${cssProbePosition.x * 100}%`);
-  cssProbe.style.setProperty('--y', `${cssProbePosition.y * 100}%`);
+
+  const rect = canvas.getBoundingClientRect();
+  const centerX = rect.x + rect.width / 2;
+  const centerY = rect.y + rect.height / 2;
+  const size = Math.min(rect.width, rect.height);
+  const squareLeft = centerX - size / 2;
+  const squareTop = centerY - size / 2;
+
+  cssProbe.style.setProperty('--x', `${squareLeft - rect.left + cssProbePosition.x * size}px`);
+  cssProbe.style.setProperty('--y', `${squareTop - rect.top + cssProbePosition.y * size}px`);
   canvas.parentElement?.style.setProperty('--l', `${lightness}`);
   canvas.parentElement?.style.setProperty('--a', `${a}`);
   canvas.parentElement?.style.setProperty('--b', `${b}`);
@@ -147,6 +162,10 @@ const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
     draw();
   },
 });

--- a/apps/typegpu-docs/src/examples/simple/ripple-cube/index.html
+++ b/apps/typegpu-docs/src/examples/simple/ripple-cube/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/simple/ripple-cube/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/ripple-cube/index.ts
@@ -1,6 +1,6 @@
 import { perlin3d, randf } from '@typegpu/noise';
 import * as sdf from '@typegpu/sdf';
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import { Camera, setupOrbitCamera } from '../../common/setup-orbit-camera.ts';
 import { createBackgroundCubemap } from './background.ts';
 import { GRID_SIZE, halton, LIGHT_COUNT, MAX_DIST, MAX_STEPS, SURF_DIST } from './constants.ts';
@@ -223,6 +223,8 @@ function run(timestamp: number) {
 
 animationFrame = requestAnimationFrame(run);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 export const controls = defineControls({
   metallic: {
     min: 0,
@@ -299,5 +301,6 @@ export const controls = defineControls({
 export function onCleanup() {
   cancelAnimationFrame(animationFrame);
   cameraResult.cleanupCamera();
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simple/ripple-cube/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/ripple-cube/index.ts
@@ -234,7 +234,7 @@ function run(timestamp: number) {
 
 animationFrame = requestAnimationFrame(run);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -319,6 +319,6 @@ export const controls = defineControls({
 export function onCleanup() {
   cancelAnimationFrame(animationFrame);
   cameraResult.cleanupCamera();
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simple/ripple-cube/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/ripple-cube/index.ts
@@ -19,7 +19,7 @@ const perlinCache = perlin3d.staticCache({
   size: d.vec3u(32, 32, 32),
 });
 
-const [width, height] = [canvas.width / 1.4, canvas.height / 1.4];
+const resolutionScale = 1 / 1.4;
 
 const cameraUniform = root.createUniform(Camera);
 const timeUniform = root.createUniform(d.f32);
@@ -112,7 +112,12 @@ const envMapBindGroup = root.createBindGroup(envMapLayout, {
   }),
 });
 
-const postProcessing = createPostProcessingPipelines(root, width, height, initialBloom);
+const postProcessing = createPostProcessingPipelines(
+  root,
+  canvas.width * resolutionScale,
+  canvas.height * resolutionScale,
+  initialBloom,
+);
 
 const cameraResult = setupOrbitCamera(
   canvas,
@@ -138,7 +143,7 @@ const rayMarchPipeline = root
   .createGuardedComputePipeline((x, y) => {
     'use gpu';
     randf.seed2(d.vec2f(d.f32(x), d.f32(y)).add(timeUniform.$));
-    const textureSize = std.textureDimensions(postProcessing.result.writeView.$);
+    const textureSize = std.textureDimensions(postProcessing.$.result);
     const uv = d.vec2f(x, y).add(0.5).div(d.vec2f(textureSize));
     const ray = getRayForUV(uv);
 
@@ -186,7 +191,7 @@ const rayMarchPipeline = root
       finalColor = std.mix(fogColor, sceneColor, fog);
     }
 
-    std.textureStore(postProcessing.result.writeView.$, d.vec2u(x, y), d.vec4f(finalColor, 1));
+    std.textureStore(postProcessing.$.result, d.vec2u(x, y), d.vec4f(finalColor, 1));
   });
 
 let animationFrame: number;
@@ -196,6 +201,25 @@ let accumulatedTime = 0;
 let lastTimestamp = 0;
 let isExtendedRipplesEnabled = false;
 
+function render() {
+  const jitterX = (halton(frameIndex % 16, 2) - 0.5) / postProcessing.width;
+  const jitterY = (halton(frameIndex % 16, 3) - 0.5) / postProcessing.height;
+  jitterUniform.write(d.vec2f(jitterX, jitterY));
+  frameIndex++;
+
+  sdfPrecalcPipeline.dispatchThreads(GRID_SIZE / 2, GRID_SIZE / 2, GRID_SIZE / 2);
+
+  rayMarchPipeline
+    .with(envMapBindGroup)
+    .with(sdfBindGroup)
+    .with(postProcessing.userGroup)
+    .dispatchThreads(postProcessing.width, postProcessing.height);
+
+  postProcessing.runTaa();
+  postProcessing.runBloom();
+  postProcessing.render(context);
+}
+
 function run(timestamp: number) {
   const deltaTime = lastTimestamp === 0 ? 0 : (timestamp - lastTimestamp) / 1000;
   lastTimestamp = timestamp;
@@ -203,27 +227,21 @@ function run(timestamp: number) {
   accumulatedTime = Math.min(maxTime, Math.max(0, accumulatedTime + deltaTime * timeScale));
   timeUniform.write(accumulatedTime);
 
-  const jitterX = (halton(frameIndex % 16, 2) - 0.5) / width;
-  const jitterY = (halton(frameIndex % 16, 3) - 0.5) / height;
-  jitterUniform.write(d.vec2f(jitterX, jitterY));
-  frameIndex++;
-
-  sdfPrecalcPipeline.dispatchThreads(GRID_SIZE / 2, GRID_SIZE / 2, GRID_SIZE / 2);
-
-  rayMarchPipeline.with(envMapBindGroup).with(sdfBindGroup).dispatchThreads(width, height);
-
-  postProcessing.runTaa();
-
-  postProcessing.runBloom();
-
-  postProcessing.render(context);
+  render();
 
   animationFrame = requestAnimationFrame(run);
 }
 
 animationFrame = requestAnimationFrame(run);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    postProcessing.resize(canvas.width * resolutionScale, canvas.height * resolutionScale);
+    render();
+  },
+});
 
 export const controls = defineControls({
   metallic: {

--- a/apps/typegpu-docs/src/examples/simple/ripple-cube/post-processing.ts
+++ b/apps/typegpu-docs/src/examples/simple/ripple-cube/post-processing.ts
@@ -6,6 +6,10 @@ import { BloomParams } from './types.ts';
 
 export const bloomParamsAccess = tgpu.accessor(BloomParams);
 
+const userLayout = tgpu.bindGroupLayout({
+  resultTexture: { storageTexture: d.textureStorage2d('rgba16float') },
+});
+
 const taaResolveLayout = tgpu.bindGroupLayout({
   currentTexture: { texture: d.texture2d() },
   historyTexture: { texture: d.texture2d() },
@@ -41,19 +45,11 @@ function createProcessingTexture(root: TgpuRoot, width: number, height: number) 
 
 export function createPostProcessingPipelines(
   root: TgpuRoot,
-  width: number,
-  height: number,
+  initialWidth: number,
+  initialHeight: number,
   initialBloom: d.Infer<typeof BloomParams>,
 ) {
   const bloomUniform = root.createUniform(BloomParams, initialBloom);
-  const bloomWidth = Math.max(1, Math.floor(width / 2));
-  const bloomHeight = Math.max(1, Math.floor(height / 2));
-
-  const result = createProcessingTexture(root, width, height);
-  const bloom = createProcessingTexture(root, bloomWidth, bloomHeight);
-  const blurTemp = createProcessingTexture(root, bloomWidth, bloomHeight);
-  const history = createProcessingTexture(root, width, height);
-  const taaOutput = createProcessingTexture(root, width, height);
 
   const sampler = root.createSampler({
     magFilter: 'linear',
@@ -63,6 +59,7 @@ export function createPostProcessingPipelines(
   const taaResolve = root.createGuardedComputePipeline((x, y) => {
     'use gpu';
     const coord = d.vec2i(d.i32(x), d.i32(y));
+    const dims = std.textureDimensions(taaResolveLayout.$.currentTexture);
     const current = std.textureLoad(taaResolveLayout.$.currentTexture, coord, 0);
     const historyColor = std.textureLoad(taaResolveLayout.$.historyTexture, coord, 0);
 
@@ -75,7 +72,7 @@ export function createPostProcessingPipelines(
         const clampedCoord = std.clamp(
           sampleCoord,
           d.vec2i(0, 0),
-          d.vec2i(d.i32(width) - 1, d.i32(height) - 1),
+          d.vec2i(d.i32(dims.x) - 1, d.i32(dims.y) - 1),
         );
         const neighbor = std.textureLoad(taaResolveLayout.$.currentTexture, clampedCoord, 0).rgb;
         minColor = std.min(minColor, neighbor);
@@ -144,56 +141,109 @@ export function createPostProcessingPipelines(
     fragment: fragmentMain,
   });
 
-  const taaBindGroup = root.createBindGroup(taaResolveLayout, {
-    currentTexture: result.sampleView,
-    historyTexture: history.sampleView,
-    outputTexture: taaOutput.writeView,
-  });
+  let width = initialWidth;
+  let height = initialHeight;
+  function createResolutionDependantResources() {
+    const bloomWidth = Math.max(1, Math.floor(width / 2));
+    const bloomHeight = Math.max(1, Math.floor(height / 2));
 
-  const copyBindGroup = root.createBindGroup(processLayout, {
-    inputTexture: taaOutput.sampleView,
-    outputTexture: history.writeView,
-    sampler,
-  });
+    const result = createProcessingTexture(root, width, height);
+    const bloom = createProcessingTexture(root, bloomWidth, bloomHeight);
+    const blurTemp = createProcessingTexture(root, bloomWidth, bloomHeight);
+    const history = createProcessingTexture(root, width, height);
+    const taaOutput = createProcessingTexture(root, width, height);
 
-  const extractBindGroup = root.createBindGroup(processLayout, {
-    inputTexture: result.sampleView,
-    outputTexture: bloom.writeView,
-    sampler,
-  });
+    return {
+      bloomWidth,
+      bloomHeight,
 
-  const blurHorizontalBindGroup = root.createBindGroup(processLayout, {
-    inputTexture: bloom.sampleView,
-    outputTexture: blurTemp.writeView,
-    sampler,
-  });
+      taaBindGroup: root.createBindGroup(taaResolveLayout, {
+        currentTexture: result.sampleView,
+        historyTexture: history.sampleView,
+        outputTexture: taaOutput.writeView,
+      }),
 
-  const blurVerticalBindGroup = root.createBindGroup(processLayout, {
-    inputTexture: blurTemp.sampleView,
-    outputTexture: bloom.writeView,
-    sampler,
-  });
+      copyBindGroup: root.createBindGroup(processLayout, {
+        inputTexture: taaOutput.sampleView,
+        outputTexture: history.writeView,
+        sampler,
+      }),
 
-  const compositeBindGroup = root.createBindGroup(compositeLayout, {
-    colorTexture: taaOutput.sampleView,
-    bloomTexture: bloom.sampleView,
-    sampler,
-  });
+      extractBindGroup: root.createBindGroup(processLayout, {
+        inputTexture: result.sampleView,
+        outputTexture: bloom.writeView,
+        sampler,
+      }),
+
+      blurHorizontalBindGroup: root.createBindGroup(processLayout, {
+        inputTexture: bloom.sampleView,
+        outputTexture: blurTemp.writeView,
+        sampler,
+      }),
+
+      blurVerticalBindGroup: root.createBindGroup(processLayout, {
+        inputTexture: blurTemp.sampleView,
+        outputTexture: bloom.writeView,
+        sampler,
+      }),
+
+      compositeBindGroup: root.createBindGroup(compositeLayout, {
+        colorTexture: taaOutput.sampleView,
+        bloomTexture: bloom.sampleView,
+        sampler,
+      }),
+
+      userBindGroup: root.createBindGroup(userLayout, {
+        resultTexture: result.writeView,
+      }),
+    };
+  }
+
+  let resources = createResolutionDependantResources();
 
   return {
-    result,
     bloomUniform,
+    get $() {
+      return {
+        result: userLayout.$.resultTexture,
+      };
+    },
+    get userGroup() {
+      return resources.userBindGroup;
+    },
+    get width() {
+      return width;
+    },
+    get height() {
+      return height;
+    },
+    resize: (newWidth: number, newHeight: number) => {
+      if (newWidth !== width || newHeight !== height) {
+        width = newWidth;
+        height = newHeight;
+        resources = createResolutionDependantResources();
+      }
+    },
     runTaa: () => {
-      taaResolve.with(taaBindGroup).dispatchThreads(width, height);
-      copyToHistory.with(copyBindGroup).dispatchThreads(width, height);
+      taaResolve.with(resources.taaBindGroup).dispatchThreads(width, height);
+      copyToHistory.with(resources.copyBindGroup).dispatchThreads(width, height);
     },
     runBloom: () => {
-      extractBright.with(extractBindGroup).dispatchThreads(bloomWidth, bloomHeight);
-      blurHorizontal.with(blurHorizontalBindGroup).dispatchThreads(bloomWidth, bloomHeight);
-      blurVertical.with(blurVerticalBindGroup).dispatchThreads(bloomWidth, bloomHeight);
+      extractBright
+        .with(resources.extractBindGroup)
+        .dispatchThreads(resources.bloomWidth, resources.bloomHeight);
+      blurHorizontal
+        .with(resources.blurHorizontalBindGroup)
+        .dispatchThreads(resources.bloomWidth, resources.bloomHeight);
+      blurVertical
+        .with(resources.blurVerticalBindGroup)
+        .dispatchThreads(resources.bloomWidth, resources.bloomHeight);
     },
     render: (targetView: ColorAttachment['view']) => {
-      renderPipeline.with(compositeBindGroup).withColorAttachment({ view: targetView }).draw(3);
+      renderPipeline
+        .with(resources.compositeBindGroup)
+        .withColorAttachment({ view: targetView })
+        .draw(3);
     },
   };
 }

--- a/apps/typegpu-docs/src/examples/simple/square/index.html
+++ b/apps/typegpu-docs/src/examples/simple/square/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simple/square/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/square/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import tgpu, { common, d } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();
@@ -61,7 +61,14 @@ const pipeline = root
 function render() {
   pipeline.with(vertexLayout, colorBuffer).withColorAttachment({ view: context }).drawIndexed(6);
 }
-render();
+
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    render();
+  },
+});
 
 // #region Example controls & Cleanup
 
@@ -92,6 +99,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
 }
 // #endregion

--- a/apps/typegpu-docs/src/examples/simple/square/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/square/index.ts
@@ -62,7 +62,7 @@ function render() {
   pipeline.with(vertexLayout, colorBuffer).withColorAttachment({ view: context }).drawIndexed(6);
 }
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -103,7 +103,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 // #endregion

--- a/apps/typegpu-docs/src/examples/simple/square/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/square/index.ts
@@ -66,6 +66,10 @@ const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
     render();
   },
 });

--- a/apps/typegpu-docs/src/examples/simple/stencil/index.html
+++ b/apps/typegpu-docs/src/examples/simple/stencil/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simple/stencil/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/stencil/index.ts
@@ -103,28 +103,34 @@ function frame(timestamp: number) {
 }
 frameId = requestAnimationFrame(frame);
 
-const resizeObserver = new ResizeObserver(() => {
-  stencilTexture = root
-    .createTexture({
-      size: [canvas.width, canvas.height],
-      format: 'stencil8',
-    })
-    .$usage('render');
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
 
-  rotationUniform.write(d.mat2x2f.identity());
+    stencilTexture = root
+      .createTexture({
+        size: [canvas.width, canvas.height],
+        format: 'stencil8',
+      })
+      .$usage('render');
 
-  writeStencilPipeline
-    .withDepthStencilAttachment({
-      view: stencilTexture,
-      stencilClearValue: 0,
-      stencilLoadOp: 'clear',
-      stencilStoreOp: 'store',
-    })
-    .draw(3);
+    rotationUniform.write(d.mat2x2f.identity());
+
+    writeStencilPipeline
+      .withDepthStencilAttachment({
+        view: stencilTexture,
+        stencilClearValue: 0,
+        stencilLoadOp: 'clear',
+        stencilStoreOp: 'store',
+      })
+      .draw(3);
+  },
 });
-resizeObserver.observe(canvas);
-
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
 
 export function onCleanup() {
   if (frameId) {

--- a/apps/typegpu-docs/src/examples/simple/stencil/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/stencil/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import tgpu, { common, d } from 'typegpu';
 
 const root = await tgpu.init();
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
@@ -124,9 +124,12 @@ const resizeObserver = new ResizeObserver(() => {
 });
 resizeObserver.observe(canvas);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 export function onCleanup() {
   if (frameId) {
     cancelAnimationFrame(frameId);
   }
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simple/stencil/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/stencil/index.ts
@@ -103,7 +103,7 @@ function frame(timestamp: number) {
 }
 frameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -136,6 +136,6 @@ export function onCleanup() {
   if (frameId) {
     cancelAnimationFrame(frameId);
   }
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simple/triangle/index.html
+++ b/apps/typegpu-docs/src/examples/simple/triangle/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simple/triangle/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/triangle/index.ts
@@ -47,7 +47,7 @@ const context = root.configureContext({
   alphaMode: 'premultiplied',
 });
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -64,7 +64,7 @@ const detachAutoResizer = common.attachAutoResizer({
 // #region Cleanup
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simple/triangle/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/triangle/index.ts
@@ -51,6 +51,11 @@ const detachAutoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+
     // Drawing once, and then each time the canvas resizes
     pipeline.withColorAttachment({ view: context }).draw(3);
   },

--- a/apps/typegpu-docs/src/examples/simple/triangle/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/triangle/index.ts
@@ -1,22 +1,22 @@
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 
 // Constants and helper functions
 
 const purple = d.vec4f(0.769, 0.392, 1, 1);
 const blue = d.vec4f(0.114, 0.447, 0.941, 1);
 
-const getGradientColor = (ratio: number) => {
+function getGradientColor(ratio: number) {
   'use gpu';
   return std.mix(purple, blue, ratio);
-};
+}
 
-const pos = tgpu.const(d.arrayOf(d.vec2f, 3), [
+const pos = tgpu.const(d.arrayOf(d.vec2f), [
   d.vec2f(0.0, 0.5),
   d.vec2f(-0.5, -0.5),
   d.vec2f(0.5, -0.5),
 ]);
 
-const uv = tgpu.const(d.arrayOf(d.vec2f, 3), [
+const uv = tgpu.const(d.arrayOf(d.vec2f), [
   d.vec2f(0.5, 1.0),
   d.vec2f(0.0, 0.0),
   d.vec2f(1.0, 0.0),
@@ -39,18 +39,27 @@ const pipeline = root.createRenderPipeline({
   },
 });
 
-// Setting up the canvas and drawing to it
+// Setting up the canvas
 
+const canvas = document.querySelector('canvas') as HTMLCanvasElement;
 const context = root.configureContext({
-  canvas: document.querySelector('canvas') as HTMLCanvasElement,
+  canvas,
   alphaMode: 'premultiplied',
 });
 
-pipeline.withColorAttachment({ view: context }).draw(3);
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Drawing once, and then each time the canvas resizes
+    pipeline.withColorAttachment({ view: context }).draw(3);
+  },
+});
 
 // #region Cleanup
 
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simple/vaporrave/index.html
+++ b/apps/typegpu-docs/src/examples/simple/vaporrave/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/simple/vaporrave/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/vaporrave/index.ts
@@ -1,6 +1,6 @@
 import { perlin3d } from '@typegpu/noise';
 import { sdPlane } from '@typegpu/sdf';
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 
 import * as c from './constants.ts';
 import { circles, grid } from './floor.ts';
@@ -157,10 +157,13 @@ function run(timestamp: number) {
 
 animationFrame = requestAnimationFrame(run);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls and cleanup
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrame);
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simple/vaporrave/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/vaporrave/index.ts
@@ -161,7 +161,7 @@ function run(timestamp: number) {
 
 animationFrame = requestAnimationFrame(run);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -173,7 +173,7 @@ const detachAutoResizer = common.attachAutoResizer({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrame);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simple/vaporrave/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/vaporrave/index.ts
@@ -132,6 +132,14 @@ let renderPipeline = root
     fragment: fragmentMain,
   });
 
+function render() {
+  floorAngleUniform.write(floorAngle);
+  sphereAngleUniform.write(sphereAngle);
+  resolutionUniform.write(d.vec2f(canvas.width, canvas.height));
+
+  renderPipeline.withColorAttachment({ view: context }).draw(3);
+}
+
 let animationFrame: number;
 let floorAngle = 0;
 let sphereAngle = 0;
@@ -146,18 +154,20 @@ function run(timestamp: number) {
   sphereAngle += delta * sphereSpeed;
   sphereAngle %= c.NUM_CYCLES * Math.PI * 2;
 
-  floorAngleUniform.write(floorAngle);
-  sphereAngleUniform.write(sphereAngle);
-  resolutionUniform.write(d.vec2f(canvas.width, canvas.height));
-
-  renderPipeline.withColorAttachment({ view: context }).draw(3);
+  render();
 
   animationFrame = requestAnimationFrame(run);
 }
 
 animationFrame = requestAnimationFrame(run);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    render();
+  },
+});
 
 // #region Example controls and cleanup
 

--- a/apps/typegpu-docs/src/examples/simulation/boids/index.html
+++ b/apps/typegpu-docs/src/examples/simulation/boids/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simulation/boids/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/boids/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const triangleAmount = 1000;
@@ -242,6 +242,8 @@ function frame() {
 
 animationFrameId = requestAnimationFrame(frame);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls and cleanup
 
 export const controls = defineControls({
@@ -288,6 +290,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameId);
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/boids/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/boids/index.ts
@@ -222,13 +222,8 @@ const computeBindGroups = [0, 1].map((idx) =>
 );
 
 let even = false;
-let animationFrameId: number;
 
-function frame() {
-  even = !even;
-
-  simulatePipeline.with(computeBindGroups[even ? 0 : 1]).dispatchThreads(triangleAmount);
-
+function render() {
   renderPipeline
     .withColorAttachment({
       view: context,
@@ -236,13 +231,33 @@ function frame() {
     })
     .with(instanceLayout, trianglePosBuffers[even ? 1 : 0])
     .draw(3, triangleAmount);
+}
+
+let animationFrameId: number;
+
+function frame() {
+  even = !even;
+
+  simulatePipeline.with(computeBindGroups[even ? 0 : 1]).dispatchThreads(triangleAmount);
+
+  render();
 
   animationFrameId = requestAnimationFrame(frame);
 }
 
 animationFrameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    render();
+  },
+});
 
 // #region Example controls and cleanup
 

--- a/apps/typegpu-docs/src/examples/simulation/boids/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/boids/index.ts
@@ -247,7 +247,7 @@ function frame() {
 
 animationFrameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -305,7 +305,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameId);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/confetti/index.html
+++ b/apps/typegpu-docs/src/examples/simulation/confetti/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full"></canvas>

--- a/apps/typegpu-docs/src/examples/simulation/confetti/index.html
+++ b/apps/typegpu-docs/src/examples/simulation/confetti/index.html
@@ -1,1 +1,1 @@
-<canvas class="w-full h-full"></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/simulation/confetti/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/confetti/index.ts
@@ -151,7 +151,7 @@ const runner = (timestamp: number) => {
 
 animationFrameId = requestAnimationFrame(runner);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const autoResizer = common.attachAutoResizer({ root, canvas });
 
 // example controls and cleanup
 
@@ -163,6 +163,6 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameId);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simulation/confetti/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/confetti/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 // constants
@@ -151,6 +151,8 @@ const runner = (timestamp: number) => {
 
 animationFrameId = requestAnimationFrame(runner);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // example controls and cleanup
 
 export const controls = defineControls({
@@ -161,5 +163,6 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameId);
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simulation/fluid-double-buffering/index.html
+++ b/apps/typegpu-docs/src/examples/simulation/fluid-double-buffering/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simulation/fluid-double-buffering/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/fluid-double-buffering/index.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { d, std, type TgpuBufferMutable, type TgpuBufferReadonly } from 'typegpu';
+import tgpu, { common, d, std, type TgpuBufferMutable, type TgpuBufferReadonly } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const MAX_GRID_SIZE = 1024;
@@ -537,6 +537,8 @@ const runner = (timestamp: number) => {
 
 animationFrameId = requestAnimationFrame(runner);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 export const controls = defineControls({
   'source intensity': {
     initial: sourceIntensity,
@@ -598,5 +600,6 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameId);
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simulation/fluid-double-buffering/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/fluid-double-buffering/index.ts
@@ -537,7 +537,7 @@ const runner = (timestamp: number) => {
 
 animationFrameId = requestAnimationFrame(runner);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -610,6 +610,6 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrameId);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simulation/fluid-double-buffering/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/fluid-double-buffering/index.ts
@@ -537,7 +537,17 @@ const runner = (timestamp: number) => {
 
 animationFrameId = requestAnimationFrame(runner);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    primary.render();
+  },
+});
 
 export const controls = defineControls({
   'source intensity': {

--- a/apps/typegpu-docs/src/examples/simulation/fluid-with-atomics/index.html
+++ b/apps/typegpu-docs/src/examples/simulation/fluid-with-atomics/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simulation/fluid-with-atomics/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/fluid-with-atomics/index.ts
@@ -625,7 +625,7 @@ function run(timestamp: number) {
 }
 animationFrame = requestAnimationFrame(run);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -706,7 +706,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrame);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/fluid-with-atomics/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/fluid-with-atomics/index.ts
@@ -625,6 +625,8 @@ function run(timestamp: number) {
 }
 animationFrame = requestAnimationFrame(run);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 export const controls = defineControls({
   size: {
     initial: 32,
@@ -694,6 +696,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(animationFrame);
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/fluid-with-atomics/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/fluid-with-atomics/index.ts
@@ -625,7 +625,17 @@ function run(timestamp: number) {
 }
 animationFrame = requestAnimationFrame(run);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    drawFrame();
+  },
+});
 
 export const controls = defineControls({
   size: {

--- a/apps/typegpu-docs/src/examples/simulation/game-of-life/index.html
+++ b/apps/typegpu-docs/src/examples/simulation/game-of-life/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simulation/game-of-life/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/game-of-life/index.ts
@@ -345,6 +345,16 @@ const stepOnce = (timestamp: number) => {
     );
 };
 
+function render() {
+  const chosenDisplayPipeline =
+    chosenPipeline === 'bitpacked' ? bitpackedDisplayPipeline : displayPipeline;
+
+  chosenDisplayPipeline
+    .withColorAttachment({ view: context })
+    .with(displayBindGroups[1 - even])
+    .draw(3);
+}
+
 let frameId: number;
 
 function frame(timestamp: number) {
@@ -390,19 +400,23 @@ function frame(timestamp: number) {
     }
   }
 
-  const chosenDisplayPipeline =
-    chosenPipeline === 'bitpacked' ? bitpackedDisplayPipeline : displayPipeline;
-
-  chosenDisplayPipeline
-    .withColorAttachment({ view: context })
-    .with(displayBindGroups[1 - even])
-    .draw(3);
+  render();
 
   frameId = requestAnimationFrame(frame);
 }
 frameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    render();
+  },
+});
 
 // #region Example controls & Cleanup
 

--- a/apps/typegpu-docs/src/examples/simulation/game-of-life/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/game-of-life/index.ts
@@ -402,6 +402,8 @@ function frame(timestamp: number) {
 }
 frameId = requestAnimationFrame(frame);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls & Cleanup
 
 export const controls = defineControls({
@@ -506,6 +508,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(frameId);
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/game-of-life/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/game-of-life/index.ts
@@ -406,7 +406,7 @@ function frame(timestamp: number) {
 }
 frameId = requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -522,7 +522,7 @@ export const controls = defineControls({
 
 export function onCleanup() {
   cancelAnimationFrame(frameId);
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/game-of-life/input.ts
+++ b/apps/typegpu-docs/src/examples/simulation/game-of-life/input.ts
@@ -1,3 +1,5 @@
+import { std } from 'typegpu';
+
 export interface InputState {
   drawPos: { x: number; y: number } | null;
   lastDrawPos: { x: number; y: number } | null;
@@ -23,10 +25,17 @@ export function setupInput(canvas: HTMLCanvasElement): InputState {
     y: (sy - 0.5) / state.zoomLevel + state.zoomCenter.y,
   });
   const toScreen = (clientX: number, clientY: number) => {
-    const r = canvas.getBoundingClientRect();
+    const rect = canvas.getBoundingClientRect();
+
+    const centerX = rect.x + rect.width / 2;
+    const centerY = rect.y + rect.height / 2;
+    const size = Math.min(rect.width, rect.height);
+    const squareLeft = centerX - size / 2;
+    const squareTop = centerY - size / 2;
+
     return {
-      x: Math.min(1, Math.max(0, (clientX - r.left) / r.width)),
-      y: Math.min(1, Math.max(0, (clientY - r.top) / r.height)),
+      x: std.saturate((clientX - squareLeft) / size),
+      y: std.saturate((clientY - squareTop) / size),
     };
   };
 

--- a/apps/typegpu-docs/src/examples/simulation/gravity/index.html
+++ b/apps/typegpu-docs/src/examples/simulation/gravity/index.html
@@ -38,4 +38,4 @@
     under CC BY 4.0
   </p>
 </div>
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/simulation/gravity/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/gravity/index.ts
@@ -250,7 +250,7 @@ export const controls = defineControls({
   },
 });
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -276,7 +276,7 @@ for (const eventName of ['click', 'keydown', 'wheel', 'touchstart']) {
 export function onCleanup() {
   destroyed = true;
   cleanupCamera();
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/gravity/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/gravity/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, type StorageFlag, type TgpuBindGroup, type TgpuBuffer } from 'typegpu';
+import tgpu, { common, d, type StorageFlag, type TgpuBindGroup, type TgpuBuffer } from 'typegpu';
 import { computeCollisionsShader, computeGravityShader } from './compute.ts';
 import {
   collisionBehaviors,
@@ -260,6 +260,8 @@ const resizeObserver = new ResizeObserver(() => {
 });
 resizeObserver.observe(canvas);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 function hideHelp() {
   const helpElem = document.getElementById('help');
   if (helpElem) {
@@ -274,6 +276,7 @@ export function onCleanup() {
   destroyed = true;
   cleanupCamera();
   resizeObserver.unobserve(canvas);
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/gravity/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/gravity/index.ts
@@ -250,17 +250,18 @@ export const controls = defineControls({
   },
 });
 
-const resizeObserver = new ResizeObserver(() => {
-  depthTexture.destroy();
-  depthTexture = root.device.createTexture({
-    size: [canvas.width, canvas.height, 1],
-    format: 'depth24plus',
-    usage: GPUTextureUsage.RENDER_ATTACHMENT,
-  });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    depthTexture.destroy();
+    depthTexture = root.device.createTexture({
+      size: [canvas.width, canvas.height, 1],
+      format: 'depth24plus',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+  },
 });
-resizeObserver.observe(canvas);
-
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
 
 function hideHelp() {
   const helpElem = document.getElementById('help');
@@ -275,7 +276,6 @@ for (const eventName of ['click', 'keydown', 'wheel', 'touchstart']) {
 export function onCleanup() {
   destroyed = true;
   cleanupCamera();
-  resizeObserver.unobserve(canvas);
   detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simulation/slime-mold-3d/index.html
+++ b/apps/typegpu-docs/src/examples/simulation/slime-mold-3d/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simulation/slime-mold-3d/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/slime-mold-3d/index.ts
@@ -475,7 +475,7 @@ function frame(timestamp: number) {
 }
 requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -636,7 +636,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/slime-mold-3d/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/slime-mold-3d/index.ts
@@ -43,7 +43,7 @@ const Camera = d.struct({
 const cameraTarget = resolution.div(2);
 const cameraUp = d.vec3f(0, 1, 0);
 const fov = (CAMERA_FOV_DEGREES * Math.PI) / 180;
-const aspect = canvas.width / canvas.height;
+const aspect = 1;
 const near = 0.1;
 const far = 1000.0;
 
@@ -439,9 +439,16 @@ const renderBindGroups = [0, 1].map((i) =>
   }),
 );
 
-let lastTime: number | null = null;
 let currentTexture = 0;
 
+function render() {
+  renderPipeline
+    .withColorAttachment({ view: context })
+    .with(renderBindGroups[1 - currentTexture])
+    .draw(3);
+}
+
+let lastTime: number | null = null;
 function frame(timestamp: number) {
   const deltaTime = Math.min(lastTime !== null ? (timestamp - lastTime) / 1000 : 0, 0.1);
   lastTime = timestamp;
@@ -460,10 +467,7 @@ function frame(timestamp: number) {
     .with(bindGroups[currentTexture])
     .dispatchWorkgroups(Math.ceil(NUM_AGENTS / AGENT_WORKGROUP_SIZE));
 
-  renderPipeline
-    .withColorAttachment({ view: context })
-    .with(renderBindGroups[1 - currentTexture])
-    .draw(3);
+  render();
 
   currentTexture = 1 - currentTexture;
 
@@ -471,7 +475,17 @@ function frame(timestamp: number) {
 }
 requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    render();
+  },
+});
 
 // #region Example controls and cleanup
 

--- a/apps/typegpu-docs/src/examples/simulation/slime-mold-3d/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/slime-mold-3d/index.ts
@@ -471,6 +471,8 @@ function frame(timestamp: number) {
 }
 requestAnimationFrame(frame);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls and cleanup
 
 let isDragging = false;
@@ -620,6 +622,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/slime-mold/index.html
+++ b/apps/typegpu-docs/src/examples/simulation/slime-mold/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simulation/slime-mold/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/slime-mold/index.ts
@@ -247,7 +247,7 @@ function frame(now: number) {
 }
 requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -310,7 +310,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/slime-mold/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/slime-mold/index.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import tgpu, { common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();
@@ -243,6 +243,8 @@ function frame(now: number) {
 }
 requestAnimationFrame(frame);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls and cleanup
 
 export const controls = defineControls({
@@ -294,6 +296,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/slime-mold/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/slime-mold/index.ts
@@ -7,7 +7,7 @@ const canvas = document.querySelector('canvas') as HTMLCanvasElement;
 const context = root.configureContext({ canvas, alphaMode: 'premultiplied' });
 const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
-const resolution = d.vec2f(canvas.width, canvas.height);
+const resolution = d.vec2f(1024, 1024);
 
 const Agent = d.struct({
   position: d.vec2f,
@@ -217,9 +217,16 @@ const renderBindGroups = [0, 1].map((i) =>
   }),
 );
 
-let lastTime: number | null = null;
 let currentTexture = 0;
 
+function render() {
+  renderPipeline
+    .withColorAttachment({ view: context })
+    .with(renderBindGroups[1 - currentTexture])
+    .draw(3);
+}
+
+let lastTime: number | null = null;
 function frame(now: number) {
   const deltaTimeValue = Math.min(lastTime !== null ? (now - lastTime) / 1000 : 0, 0.1);
   lastTime = now;
@@ -232,10 +239,7 @@ function frame(now: number) {
 
   computePipeline.with(bindGroups[currentTexture]).dispatchWorkgroups(Math.ceil(NUM_AGENTS / 64));
 
-  renderPipeline
-    .withColorAttachment({ view: context })
-    .with(renderBindGroups[1 - currentTexture])
-    .draw(3);
+  render();
 
   currentTexture = 1 - currentTexture;
 
@@ -243,7 +247,17 @@ function frame(now: number) {
 }
 requestAnimationFrame(frame);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    render();
+  },
+});
 
 // #region Example controls and cleanup
 

--- a/apps/typegpu-docs/src/examples/simulation/stable-fluid/index.html
+++ b/apps/typegpu-docs/src/examples/simulation/stable-fluid/index.html
@@ -27,4 +27,4 @@
   <h3 class="controls-header">Controls (click to dismiss)</h3>
   <p class="controls">Drag to stir the fluid.</p>
 </div>
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simulation/stable-fluid/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/stable-fluid/index.ts
@@ -1,4 +1,5 @@
 import tgpu, {
+  common,
   d,
   type TgpuBindGroup,
   type TgpuComputeFn,
@@ -362,6 +363,8 @@ function loop() {
 
 loop();
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls and cleanup
 
 canvas.addEventListener('mousedown', (e) => {
@@ -484,6 +487,7 @@ export const controls = defineControls({
 export function onCleanup() {
   window.removeEventListener('mouseup', mouseUpEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/stable-fluid/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/stable-fluid/index.ts
@@ -32,9 +32,18 @@ function createComputePipeline(fn: TgpuComputeFn) {
   return root.createComputePipeline({ compute: fn });
 }
 
-function toGrid(x: number, y: number): [number, number] {
-  const gx = Math.floor((x / canvas.width) * p.SIM_N);
-  const gy = Math.floor(((canvas.height - y) / canvas.height) * p.SIM_N);
+function toGrid(clientX: number, clientY: number): [number, number] {
+  const rect = canvas.getBoundingClientRect();
+
+  // Taking into account the square aspect ratio
+  const centerX = rect.x + rect.width / 2;
+  const centerY = rect.y + rect.height / 2;
+  const size = Math.min(rect.width, rect.height);
+  const squareLeft = centerX - size / 2;
+  const squareTop = centerY - size / 2;
+
+  const gx = Math.floor(((clientX - squareLeft) / size) * p.SIM_N);
+  const gy = Math.floor((1 - (clientY - squareTop) / size) * p.SIM_N);
   return [gx, gy];
 }
 
@@ -273,10 +282,39 @@ const renderBindGroups = {
   ],
 };
 
+function render() {
+  let renderBG: TgpuBindGroup<{
+    result: { texture: d.WgslTexture2d<d.F32> };
+    background: { texture: d.WgslTexture2d<d.F32> };
+  }>;
+  let pipeline: TgpuRenderPipeline<d.Vec4f>;
+
+  switch (p.params.displayMode) {
+    case 'ink':
+      renderBG = renderBindGroups.ink[inkBuffer.currentIndex];
+      pipeline = renderPipelineInk;
+      break;
+    case 'image':
+      renderBG = renderBindGroups.ink[inkBuffer.currentIndex];
+      pipeline = renderPipelineImage;
+      break;
+    case 'velocity':
+      renderBG = renderBindGroups.velocity[velBuffer.currentIndex];
+      pipeline = renderPipelineVel;
+      break;
+    default:
+      throw new Error('Invalid display mode');
+  }
+
+  pipeline.withColorAttachment({ view: context }).with(renderBG).draw(3);
+}
+
 // Main rendering loop
+let handle: number;
 function loop() {
+  handle = requestAnimationFrame(loop);
+
   if (p.params.paused) {
-    requestAnimationFrame(loop);
     return;
   }
 
@@ -333,45 +371,28 @@ function loop() {
     .dispatchWorkgroups(dispatchX, dispatchY);
   inkBuffer.swap();
 
-  let renderBG: TgpuBindGroup<{
-    result: { texture: d.WgslTexture2d<d.F32> };
-    background: { texture: d.WgslTexture2d<d.F32> };
-  }>;
-  let pipeline: TgpuRenderPipeline<d.Vec4f>;
-
-  switch (p.params.displayMode) {
-    case 'ink':
-      renderBG = renderBindGroups.ink[inkBuffer.currentIndex];
-      pipeline = renderPipelineInk;
-      break;
-    case 'image':
-      renderBG = renderBindGroups.ink[inkBuffer.currentIndex];
-      pipeline = renderPipelineImage;
-      break;
-    case 'velocity':
-      renderBG = renderBindGroups.velocity[velBuffer.currentIndex];
-      pipeline = renderPipelineVel;
-      break;
-    default:
-      throw new Error('Invalid display mode');
-  }
-
-  pipeline.withColorAttachment({ view: context }).with(renderBG).draw(3);
-
-  requestAnimationFrame(loop);
+  render();
 }
 
-loop();
+handle = requestAnimationFrame(loop);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    render();
+  },
+});
 
 // #region Example controls and cleanup
 
 canvas.addEventListener('mousedown', (e) => {
-  const x = e.offsetX * devicePixelRatio;
-  const y = e.offsetY * devicePixelRatio;
   brushState = {
-    pos: toGrid(x, y),
+    pos: toGrid(e.clientX, e.clientY),
     delta: [0, 0],
     isDown: true,
   };
@@ -381,11 +402,8 @@ canvas.addEventListener(
   (e) => {
     e.preventDefault();
     const touch = e.touches[0];
-    const rect = canvas.getBoundingClientRect();
-    const x = (touch.clientX - rect.left) * devicePixelRatio;
-    const y = (touch.clientY - rect.top) * devicePixelRatio;
     brushState = {
-      pos: toGrid(x, y),
+      pos: toGrid(touch.clientX, touch.clientY),
       delta: [0, 0],
       isDown: true,
     };
@@ -404,9 +422,7 @@ const touchEndEventListener = () => {
 window.addEventListener('touchend', touchEndEventListener);
 
 canvas.addEventListener('mousemove', (e) => {
-  const x = e.offsetX * devicePixelRatio;
-  const y = e.offsetY * devicePixelRatio;
-  const [newX, newY] = toGrid(x, y);
+  const [newX, newY] = toGrid(e.clientX, e.clientY);
   brushState.delta = [newX - brushState.pos[0], newY - brushState.pos[1]];
   brushState.pos = [newX, newY];
 });
@@ -415,10 +431,7 @@ canvas.addEventListener(
   (e) => {
     e.preventDefault();
     const touch = e.touches[0];
-    const rect = canvas.getBoundingClientRect();
-    const x = (touch.clientX - rect.left) * devicePixelRatio;
-    const y = (touch.clientY - rect.top) * devicePixelRatio;
-    const [newX, newY] = toGrid(x, y);
+    const [newX, newY] = toGrid(touch.clientX, touch.clientY);
     brushState.delta = [newX - brushState.pos[0], newY - brushState.pos[1]];
     brushState.pos = [newX, newY];
   },
@@ -488,6 +501,7 @@ export function onCleanup() {
   window.removeEventListener('mouseup', mouseUpEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
   detachAutoResizer();
+  cancelAnimationFrame(handle);
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/simulation/stable-fluid/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/stable-fluid/index.ts
@@ -376,7 +376,7 @@ function loop() {
 
 handle = requestAnimationFrame(loop);
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -500,7 +500,7 @@ export const controls = defineControls({
 export function onCleanup() {
   window.removeEventListener('mouseup', mouseUpEventListener);
   window.removeEventListener('touchend', touchEndEventListener);
-  detachAutoResizer();
+  autoResizer.detach();
   cancelAnimationFrame(handle);
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/simulation/wind-map/index.html
+++ b/apps/typegpu-docs/src/examples/simulation/wind-map/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full object-contain" />

--- a/apps/typegpu-docs/src/examples/simulation/wind-map/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/wind-map/index.ts
@@ -6,7 +6,7 @@ import {
   polylineVariableWidth,
   startCapSlot,
 } from '@typegpu/geometry';
-import tgpu from 'typegpu';
+import tgpu, { common } from 'typegpu';
 import { arrayOf, builtin, f32, i32, struct, u16, u32, vec2f, vec4f } from 'typegpu/data';
 import { clamp, mix, normalize, select } from 'typegpu/std';
 import { defineControls } from '../../common/defineControls.ts';
@@ -267,6 +267,8 @@ const runAnimationFrame = () => {
 };
 runAnimationFrame();
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 // #region Example controls & Cleanup
 
 export const controls = defineControls({
@@ -279,6 +281,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
   root.device.destroy();
   cancelAnimationFrame(frameId);

--- a/apps/typegpu-docs/src/examples/simulation/wind-map/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/wind-map/index.ts
@@ -267,7 +267,7 @@ const runAnimationFrame = () => {
 };
 runAnimationFrame();
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -291,7 +291,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
   root.device.destroy();
   cancelAnimationFrame(frameId);

--- a/apps/typegpu-docs/src/examples/simulation/wind-map/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/wind-map/index.ts
@@ -267,7 +267,17 @@ const runAnimationFrame = () => {
 };
 runAnimationFrame();
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    // Keeping the aspect ratio 1:1
+    const size = Math.min(canvas.width, canvas.height);
+    canvas.width = size;
+    canvas.height = size;
+    draw();
+  },
+});
 
 // #region Example controls & Cleanup
 

--- a/apps/typegpu-docs/src/examples/tests/log-test/index.html
+++ b/apps/typegpu-docs/src/examples/tests/log-test/index.html
@@ -1,3 +1,3 @@
 Press buttons to run the tests! Check logs for results.
 
-<canvas width="16" height="16"></canvas>
+<canvas width="16" height="16" />

--- a/apps/typegpu-docs/src/examples/tests/log-test/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/log-test/index.ts
@@ -288,10 +288,10 @@ export const controls = defineControls({
   },
 });
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const autoResizer = common.attachAutoResizer({ root, canvas });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/tests/log-test/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/log-test/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std, type TgpuVertexFn } from 'typegpu';
+import tgpu, { common, d, std, type TgpuVertexFn } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init({
@@ -288,7 +288,10 @@ export const controls = defineControls({
   },
 });
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/tests/rc-docs-examples/index.html
+++ b/apps/typegpu-docs/src/examples/tests/rc-docs-examples/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/tests/rc-docs-examples/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/rc-docs-examples/index.ts
@@ -270,7 +270,7 @@ function frame() {
   frameId = requestAnimationFrame(frame);
 }
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const autoResizer = common.attachAutoResizer({ root, canvas });
 
 function setSnippet(snippet: RcSnippet) {
   snippetMode.write(RC_SNIPPETS.indexOf(snippet));
@@ -285,7 +285,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   cancelAnimationFrame(frameId);
   basicRunner.destroy();
   customRunner.destroy();

--- a/apps/typegpu-docs/src/examples/tests/rc-docs-examples/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/rc-docs-examples/index.ts
@@ -270,6 +270,8 @@ function frame() {
   frameId = requestAnimationFrame(frame);
 }
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 function setSnippet(snippet: RcSnippet) {
   snippetMode.write(RC_SNIPPETS.indexOf(snippet));
 }
@@ -283,6 +285,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
+  detachAutoResizer();
   cancelAnimationFrame(frameId);
   basicRunner.destroy();
   customRunner.destroy();

--- a/apps/typegpu-docs/src/examples/tests/sdf-docs-examples/index.html
+++ b/apps/typegpu-docs/src/examples/tests/sdf-docs-examples/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/tests/sdf-docs-examples/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/sdf-docs-examples/index.ts
@@ -291,6 +291,8 @@ function frame() {
   frameId = requestAnimationFrame(frame);
 }
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 function setSnippet(snippet: SdfSnippet) {
   snippetMode.write(SDF_SNIPPETS.indexOf(snippet));
 }
@@ -304,6 +306,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
+  detachAutoResizer();
   cancelAnimationFrame(frameId);
   floodRunner.destroy();
   sourceTexture.destroy();

--- a/apps/typegpu-docs/src/examples/tests/sdf-docs-examples/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/sdf-docs-examples/index.ts
@@ -291,7 +291,7 @@ function frame() {
   frameId = requestAnimationFrame(frame);
 }
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const autoResizer = common.attachAutoResizer({ root, canvas });
 
 function setSnippet(snippet: SdfSnippet) {
   snippetMode.write(SDF_SNIPPETS.indexOf(snippet));
@@ -306,7 +306,7 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   cancelAnimationFrame(frameId);
   floodRunner.destroy();
   sourceTexture.destroy();

--- a/apps/typegpu-docs/src/examples/tests/texture-test/index.html
+++ b/apps/typegpu-docs/src/examples/tests/texture-test/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/tests/texture-test/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/texture-test/index.ts
@@ -135,7 +135,7 @@ function render() {
 }
 requestAnimationFrame(render);
 
-const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+const autoResizer = common.attachAutoResizer({ root, canvas });
 
 export const controls = defineControls({
   Format: {
@@ -181,6 +181,6 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/tests/texture-test/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/texture-test/index.ts
@@ -135,6 +135,8 @@ function render() {
 }
 requestAnimationFrame(render);
 
+const detachAutoResizer = common.attachAutoResizer({ root, canvas });
+
 export const controls = defineControls({
   Format: {
     initial: currentFormat,
@@ -179,5 +181,6 @@ export const controls = defineControls({
 });
 
 export function onCleanup() {
+  detachAutoResizer();
   root.destroy();
 }

--- a/apps/typegpu-docs/src/examples/tests/uniformity/index.html
+++ b/apps/typegpu-docs/src/examples/tests/uniformity/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/tests/uniformity/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/uniformity/index.ts
@@ -83,7 +83,7 @@ export const controls = defineControls({
   },
 });
 
-const detachAutoResizer = common.attachAutoResizer({
+const autoResizer = common.attachAutoResizer({
   root,
   canvas,
   onResize() {
@@ -93,7 +93,7 @@ const detachAutoResizer = common.attachAutoResizer({
 });
 
 export function onCleanup() {
-  detachAutoResizer();
+  autoResizer.detach();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/tests/uniformity/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/uniformity/index.ts
@@ -83,14 +83,17 @@ export const controls = defineControls({
   },
 });
 
-const resizeObserver = new ResizeObserver(() => {
-  canvasRatioUniform.write(canvas.width / canvas.height);
-  redraw();
+const detachAutoResizer = common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    canvasRatioUniform.write(canvas.width / canvas.height);
+    redraw();
+  },
 });
-resizeObserver.observe(canvas);
 
 export function onCleanup() {
-  resizeObserver.disconnect();
+  detachAutoResizer();
   root.destroy();
 }
 

--- a/apps/typegpu-docs/src/examples/threejs/attractors/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/attractors/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full"></canvas>

--- a/apps/typegpu-docs/src/examples/threejs/attractors/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/attractors/index.html
@@ -1,1 +1,1 @@
-<canvas class="w-full h-full"></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/threejs/compute-cloth/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/compute-cloth/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full"></canvas>

--- a/apps/typegpu-docs/src/examples/threejs/compute-cloth/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/compute-cloth/index.html
@@ -1,1 +1,1 @@
-<canvas class="w-full h-full"></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/threejs/compute-geometry/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/compute-geometry/index.html
@@ -1,5 +1,5 @@
 <div class="loading">Model is loading...</div>
-<canvas class="w-full h-full"></canvas>
+<canvas class="w-full h-full" />
 <style>
   .loading {
     position: absolute;

--- a/apps/typegpu-docs/src/examples/threejs/compute-geometry/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/compute-geometry/index.html
@@ -1,5 +1,5 @@
 <div class="loading">Model is loading...</div>
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full"></canvas>
 <style>
   .loading {
     position: absolute;

--- a/apps/typegpu-docs/src/examples/threejs/compute-particles-snow/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/compute-particles-snow/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full"></canvas>

--- a/apps/typegpu-docs/src/examples/threejs/compute-particles-snow/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/compute-particles-snow/index.html
@@ -1,1 +1,1 @@
-<canvas class="w-full h-full"></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/threejs/compute-particles/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/compute-particles/index.html
@@ -1,1 +1,1 @@
-<canvas data-fit-to-container></canvas>
+<canvas class="w-full h-full"></canvas>

--- a/apps/typegpu-docs/src/examples/threejs/compute-particles/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/compute-particles/index.html
@@ -1,1 +1,1 @@
-<canvas class="w-full h-full"></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/threejs/simple/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/simple/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/threejs/test-mismatched-types/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/test-mismatched-types/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/threejs/test-reused-functions/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/test-reused-functions/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full" />

--- a/apps/typegpu-docs/src/examples/threejs/varyings/index.html
+++ b/apps/typegpu-docs/src/examples/threejs/varyings/index.html
@@ -1,1 +1,1 @@
-<canvas></canvas>
+<canvas class="w-full h-full" />

--- a/packages/typegpu-cli/templates/template-vite-complex/src/main.ts
+++ b/packages/typegpu-cli/templates/template-vite-complex/src/main.ts
@@ -17,6 +17,9 @@ const time = root.createUniform(d.f32);
 const canvas = document.querySelector<HTMLCanvasElement>('#canvas') as HTMLCanvasElement;
 const context = root.configureContext({ canvas });
 
+// Adjusting the resolution when the physical size of the canvas changes
+common.attachAutoResizer({ root, canvas });
+
 function noise(v: d.v2f) {
   'use gpu';
   return perlin2d.sample(v);
@@ -114,7 +117,7 @@ const pipeline = root.createRenderPipeline({
 let elapsed = 0;
 let lastTimestamp: number | null = null;
 
-function render(timestamp: number) {
+function frame(timestamp: number) {
   if (lastTimestamp !== null) {
     elapsed += ((timestamp - lastTimestamp) / 1000.0) * speed;
   }
@@ -123,26 +126,7 @@ function render(timestamp: number) {
   time.write(elapsed);
   pipeline.withColorAttachment({ view: context }).draw(3);
 
-  requestAnimationFrame(render);
+  requestAnimationFrame(frame);
 }
 
-const observer = new ResizeObserver(([entry]) => {
-  if (!entry) {
-    return;
-  }
-  const width =
-    entry.devicePixelContentBoxSize?.[0].inlineSize ||
-    entry.contentBoxSize[0].inlineSize * window.devicePixelRatio;
-  const height =
-    entry.devicePixelContentBoxSize?.[0].blockSize ||
-    entry.contentBoxSize[0].blockSize * window.devicePixelRatio;
-  canvas.width = Math.max(1, Math.min(width, root.device.limits.maxTextureDimension2D));
-  canvas.height = Math.max(1, Math.min(height, root.device.limits.maxTextureDimension2D));
-});
-try {
-  observer.observe(canvas, { box: 'device-pixel-content-box' });
-} catch {
-  observer.observe(canvas, { box: 'content-box' });
-}
-
-requestAnimationFrame(render);
+requestAnimationFrame(frame);

--- a/packages/typegpu-cli/templates/template-vite-simple/src/main.ts
+++ b/packages/typegpu-cli/templates/template-vite-simple/src/main.ts
@@ -16,22 +16,13 @@ const pipeline = root.createRenderPipeline({
 function render() {
   pipeline.withColorAttachment({ view: context }).draw(3);
 }
-const observer = new ResizeObserver(([entry]) => {
-  if (!entry) {
-    return;
-  }
-  const width =
-    entry.devicePixelContentBoxSize?.[0].inlineSize ||
-    entry.contentBoxSize[0].inlineSize * window.devicePixelRatio;
-  const height =
-    entry.devicePixelContentBoxSize?.[0].blockSize ||
-    entry.contentBoxSize[0].blockSize * window.devicePixelRatio;
-  canvas.width = Math.max(1, Math.min(width, root.device.limits.maxTextureDimension2D));
-  canvas.height = Math.max(1, Math.min(height, root.device.limits.maxTextureDimension2D));
-  render();
+
+// Adjusting the resolution when the physical size of the canvas changes,
+// and re-rendering the content.
+common.attachAutoResizer({
+  root,
+  canvas,
+  onResize() {
+    render();
+  },
 });
-try {
-  observer.observe(canvas, { box: 'device-pixel-content-box' });
-} catch {
-  observer.observe(canvas, { box: 'content-box' });
-}

--- a/packages/typegpu/src/common/attachAutoResizer.ts
+++ b/packages/typegpu/src/common/attachAutoResizer.ts
@@ -1,0 +1,42 @@
+import type { TgpuRoot } from '../core/root/rootTypes.ts';
+
+export interface AttachAutoResizerOptions {
+  root: TgpuRoot;
+  canvas: HTMLCanvasElement;
+  onResize?(): void;
+}
+
+export function attachAutoResizer({
+  root,
+  canvas,
+  onResize,
+}: AttachAutoResizerOptions): () => void {
+  const observer = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      if (!entry) {
+        return;
+      }
+      const width =
+        entry.devicePixelContentBoxSize?.[0]?.inlineSize ||
+        (entry.contentBoxSize[0]?.inlineSize ?? 0) * window.devicePixelRatio;
+      const height =
+        entry.devicePixelContentBoxSize?.[0]?.blockSize ||
+        (entry.contentBoxSize[0]?.blockSize ?? 0) * window.devicePixelRatio;
+      const canvas = entry.target as HTMLCanvasElement;
+      canvas.width = Math.max(1, Math.min(width, root.device.limits.maxTextureDimension2D));
+      canvas.height = Math.max(1, Math.min(height, root.device.limits.maxTextureDimension2D));
+
+      onResize?.();
+    }
+  });
+
+  try {
+    observer.observe(canvas, { box: 'device-pixel-content-box' });
+  } catch {
+    observer.observe(canvas, { box: 'content-box' });
+  }
+
+  return () => {
+    observer.disconnect();
+  };
+}

--- a/packages/typegpu/src/common/attachAutoResizer.ts
+++ b/packages/typegpu/src/common/attachAutoResizer.ts
@@ -3,7 +3,7 @@ import type { TgpuRoot } from '../core/root/rootTypes.ts';
 export interface AttachAutoResizerOptions {
   root: TgpuRoot;
   canvas: HTMLCanvasElement;
-  onResize?(): void;
+  onResize?: (() => void) | undefined;
 }
 
 export function attachAutoResizer({

--- a/packages/typegpu/src/common/attachAutoResizer.ts
+++ b/packages/typegpu/src/common/attachAutoResizer.ts
@@ -6,11 +6,15 @@ export interface AttachAutoResizerOptions {
   onResize?: (() => void) | undefined;
 }
 
+export interface AutoResizer {
+  detach: () => void;
+}
+
 export function attachAutoResizer({
   root,
   canvas,
   onResize,
-}: AttachAutoResizerOptions): () => void {
+}: AttachAutoResizerOptions): AutoResizer {
   const observer = new ResizeObserver((entries) => {
     for (const entry of entries) {
       if (!entry) {
@@ -36,7 +40,9 @@ export function attachAutoResizer({
     observer.observe(canvas, { box: 'content-box' });
   }
 
-  return () => {
-    observer.disconnect();
+  return {
+    detach: () => {
+      observer.disconnect();
+    },
   };
 }

--- a/packages/typegpu/src/common/index.ts
+++ b/packages/typegpu/src/common/index.ts
@@ -1,5 +1,9 @@
 // NOTE: This is a barrel file, internal files should not import things from this file
 
 export { fullScreenTriangle } from './fullScreenTriangle.ts';
-export { attachAutoResizer } from './attachAutoResizer.ts';
+export {
+  attachAutoResizer,
+  type AutoResizer,
+  type AttachAutoResizerOptions,
+} from './attachAutoResizer.ts';
 export { writeSoA } from './writeSoA.ts';

--- a/packages/typegpu/src/common/index.ts
+++ b/packages/typegpu/src/common/index.ts
@@ -1,4 +1,5 @@
 // NOTE: This is a barrel file, internal files should not import things from this file
 
 export { fullScreenTriangle } from './fullScreenTriangle.ts';
+export { attachAutoResizer } from './attachAutoResizer.ts';
 export { writeSoA } from './writeSoA.ts';


### PR DESCRIPTION
This PR adds a new common helper called `attachAutoResizer` which adapts the canvas' internal resolution to match its physical pixel size, with additional safe-guards. It's a web only helper, not to be used in React Native apps.

The examples were updated to use this helper, which replaces the need for the example environment to handle the canvas resizing. This also makes the examples much more portable, as resizing a canvas can be tricky to get right, and now it's solved in every example. 