### PR TITLE
fix(@typegpu/cli): remove default name suggestion, leave just placeholder

### DIFF
--- a/packages/typegpu-cli/src/utils/inputs.ts
+++ b/packages/typegpu-cli/src/utils/inputs.ts
@@ -9,11 +9,10 @@ function isValidPackageName(packageName: string) {
   return /^(?:@[a-z\d][a-z\d\-._]*\/)?[a-z\d][a-z\d\-._]*$/.test(packageName.trim());
 }
 
-export async function getProjectDirectory(initialValue: string) {
+export async function getProjectDirectory(defaultValue: string) {
   let projectDir = await p.text({
     message: 'Project directory:',
-    placeholder: initialValue,
-    initialValue,
+    placeholder: defaultValue,
     validate: (value) => {
       return value && !isValidProjectDirectory(value) ? 'Invalid project directory.' : undefined;
     },
@@ -23,17 +22,16 @@ export async function getProjectDirectory(initialValue: string) {
     cancelExit();
   }
 
-  projectDir ??= '.';
-  return projectDir.trim();
+  projectDir = projectDir?.trim() || defaultValue;
+  return projectDir;
 }
 
-export async function getPackageName(initialValue: string) {
+export async function getPackageName(defaultValue: string) {
   const packageName = await p.text({
     message: 'Package name:',
-    placeholder: initialValue,
-    initialValue,
+    placeholder: defaultValue,
     validate: (value) => {
-      return !value || !isValidPackageName(value) ? 'Invalid package name.' : undefined;
+      return value && !isValidPackageName(value) ? 'Invalid package name.' : undefined;
     },
   });
 
@@ -41,5 +39,5 @@ export async function getPackageName(initialValue: string) {
     cancelExit();
   }
 
-  return packageName.trim();
+  return packageName?.trim() || defaultValue;
 }


### PR DESCRIPTION
## What

Remove `initialValue` from the `p.text()` prompts in `getProjectDirectory` and `getPackageName`, keeping only the `placeholder` (grey hint text).

## Why

Currently both prompts pre-fill the input field with a default value (`tgpu-project`). This makes it easy to accidentally accept the default without thinking about a good project name. Showing only the placeholder as a hint encourages users to choose their own name while still providing a suggestion.

## Changes

- `getProjectDirectory`: Removed `initialValue` from `p.text()` options; empty input falls back to the default value
- `getPackageName`: Removed `initialValue` from `p.text()` options; empty input falls back to the default value
- Renamed parameter from `initialValue` to `defaultValue` for clarity

Fixes #2542