### PR TITLE
fix(@typegpu/cli): show install output and don't auto-start dev server

### DIFF
--- a/packages/typegpu-cli/src/create.ts
+++ b/packages/typegpu-cli/src/create.ts
@@ -57,16 +57,22 @@ export async function createProject(cwd: string) {
   const installCmd = resolveCommand(pm, 'install', []);
   const runCmd = resolveCommand(pm, 'run', ['dev']);
 
-  let msg = 'Done!\n';
-  msg += `   To get started run:\n\n`;
+  const steps: string[] = [];
+  const shouldCd = (!shouldInstall && !!installCmd) || !!runCmd || !!cdPath;
+  if (shouldCd && cdPath) {
+    steps.push(`   cd ${cdPath}`);
+  }
   if (!shouldInstall && installCmd) {
-    msg += `   cd ${cdPath}\n`;
-    msg += `   ${installCmd.command} ${installCmd.args.join(' ')}\n`;
-  } else if (cdPath) {
-    msg += `   cd ${cdPath}\n`;
+    steps.push(`   ${installCmd.command} ${installCmd.args.join(' ')}`);
   }
   if (runCmd) {
-    msg += `   ${runCmd.command} ${runCmd.args.join(' ')}`;
+    steps.push(`   ${runCmd.command} ${runCmd.args.join(' ')}`);
+  }
+
+  let msg = 'Done!\n';
+  if (steps.length > 0) {
+    msg += `   To get started run:\n\n`;
+    msg += steps.join('\n');
   }
 
   p.outro(msg);

--- a/packages/typegpu-cli/src/create.ts
+++ b/packages/typegpu-cli/src/create.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import * as p from '@clack/prompts';
 
-import { pmFromUserAgent, pmInstall, pmRun } from './utils/pm.ts';
+import { pmFromUserAgent, pmInstall } from './utils/pm.ts';
 import { cancelExit, confirmStep, rgbText } from './utils/prompts.ts';
 import { copyTemplate, prepareDirectory } from './utils/files.ts';
 import { getPackageName, getProjectDirectory } from './utils/inputs.ts';
@@ -46,24 +46,26 @@ export async function createProject(cwd: string) {
 
   const detected = await detect({ cwd });
   const pm = detected?.agent ?? pmFromUserAgent(process.env.npm_config_user_agent);
-  const installAndRun = await confirmStep(`Install with ${pm} and start now?`, true);
+  const shouldInstall = await confirmStep(`Install dependencies with ${pm}?`, true);
 
-  if (installAndRun) {
+  if (shouldInstall) {
     process.chdir(root);
     pmInstall(pm);
-    pmRun(pm, ['dev']);
-    return;
   }
 
-  let msg = 'Done!\n';
   const cdPath = path.relative(cwd, root);
   const installCmd = resolveCommand(pm, 'install', []);
   const runCmd = resolveCommand(pm, 'run', ['dev']);
 
-  if (installCmd && runCmd) {
-    msg += `   To have a shaderful experience run:\n\n`;
+  let msg = 'Done!\n';
+  msg += `   To get started run:\n\n`;
+  if (!shouldInstall && installCmd) {
     msg += `   cd ${cdPath}\n`;
     msg += `   ${installCmd.command} ${installCmd.args.join(' ')}\n`;
+  } else if (cdPath) {
+    msg += `   cd ${cdPath}\n`;
+  }
+  if (runCmd) {
     msg += `   ${runCmd.command} ${runCmd.args.join(' ')}`;
   }
 

--- a/packages/typegpu-cli/src/utils/pm.ts
+++ b/packages/typegpu-cli/src/utils/pm.ts
@@ -58,10 +58,10 @@ export function pmInstall(pm: Agent) {
     failAndExit(`Cannot resolve install command for ${pm}`);
   }
 
-  const s = p.spinner();
-  s.start('Installing dependencies');
-  runCommand(cmd.command, cmd.args);
-  s.stop('Installed dependencies');
+  const label = `${cmd.command} ${cmd.args.join(' ')}`;
+  p.log.step(`Running ${label}...`);
+  runCommand(cmd.command, cmd.args, true);
+  p.log.success('Installed dependencies.');
 }
 
 export function pmRun(pm: Agent, args: string[]) {

--- a/packages/typegpu-cli/src/utils/pm.ts
+++ b/packages/typegpu-cli/src/utils/pm.ts
@@ -58,7 +58,7 @@ export function pmInstall(pm: Agent) {
     failAndExit(`Cannot resolve install command for ${pm}`);
   }
 
-  const label = `${cmd.command} ${cmd.args.join(' ')}`;
+  const label = `${cmd.command}${cmd.args.length ? ` ${cmd.args.join(' ')}` : ''}`;
   p.log.step(`Running ${label}...`);
   runCommand(cmd.command, cmd.args, true);
   p.log.success('Installed dependencies.');


### PR DESCRIPTION
## What

Two ergonomic improvements to the `tgpu` create command:

1. **Show installation output**: Replace the spinner-based `pmInstall` with interactive mode so users can see `npm`/`pnpm` install progress instead of staring at a spinner with no feedback.

2. **Don't auto-start dev server**: Replace the combined "Install with X and start now?" prompt with just "Install dependencies with X?". After scaffolding (and optional install), always show the next steps so users know what to do without the CLI hijacking their terminal.

## Why

- When running `tgpu` to create a new project, the installation step shows a spinner but no actual output, leaving users wondering if anything is happening.
- The current flow auto-starts the dev server (`pnpm dev`) which takes over the terminal. Users should be told what to do next instead.

## Changes

### `packages/typegpu-cli/src/utils/pm.ts`
- `pmInstall`: Replaced spinner wrapper with `p.log.step()` + interactive `runCommand` call so install output is visible to the user

### `packages/typegpu-cli/src/create.ts`
- Changed prompt from "Install with X and start now?" to "Install dependencies with X?"
- Removed auto-start of dev server (`pmRun(pm, ['dev'])`)
- Always show next-step instructions in the outro, adjusting based on whether install was run
- Removed unused `pmRun` import

Fixes #2544