### PR TITLE
fix(cli): improve create flow ergonomics

### DIFF
--- a/packages/typegpu-cli/src/create.ts
+++ b/packages/typegpu-cli/src/create.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import * as p from '@clack/prompts';
 
-import { pmFromUserAgent, pmInstall, pmRun } from './utils/pm.ts';
+import { pmFromUserAgent, pmInstall } from './utils/pm.ts';
 import { cancelExit, confirmStep, rgbText } from './utils/prompts.ts';
 import { copyTemplate, prepareDirectory } from './utils/files.ts';
 import { getPackageName, getProjectDirectory } from './utils/inputs.ts';
@@ -46,13 +46,11 @@ export async function createProject(cwd: string) {
 
   const detected = await detect({ cwd });
   const pm = detected?.agent ?? pmFromUserAgent(process.env.npm_config_user_agent);
-  const installAndRun = await confirmStep(`Install with ${pm} and start now?`, true);
+  const install = await confirmStep(`Install with ${pm} now?`, true);
 
-  if (installAndRun) {
+  if (install) {
     process.chdir(root);
     pmInstall(pm);
-    pmRun(pm, ['dev']);
-    return;
   }
 
   let msg = 'Done!\n';
@@ -60,10 +58,12 @@ export async function createProject(cwd: string) {
   const installCmd = resolveCommand(pm, 'install', []);
   const runCmd = resolveCommand(pm, 'run', ['dev']);
 
-  if (installCmd && runCmd) {
+  if (runCmd) {
     msg += `   To have a shaderful experience run:\n\n`;
     msg += `   cd ${cdPath}\n`;
-    msg += `   ${installCmd.command} ${installCmd.args.join(' ')}\n`;
+    if (!install && installCmd) {
+      msg += `   ${installCmd.command} ${installCmd.args.join(' ')}\n`;
+    }
     msg += `   ${runCmd.command} ${runCmd.args.join(' ')}`;
   }
 

--- a/packages/typegpu-cli/src/utils/pm.ts
+++ b/packages/typegpu-cli/src/utils/pm.ts
@@ -23,7 +23,7 @@ export function pmFromUserAgent(userAgent: string | undefined) {
 
 function runCommand(command: string, args: string[], interactive?: boolean) {
   const { status, error } = spawn.sync(command, args, {
-    stdio: interactive ? 'inherit' : ['inherit', 'ignore', 'inherit'],
+    stdio: interactive ? 'inherit' : ['inherit', 'inherit', 'inherit'],
   });
 
   const label = `${command}${args.length ? ` ${args.join(' ')}` : ''}`;


### PR DESCRIPTION
## Summary
- show package installation output instead of hiding stdout behind the spinner
- stop auto-starting the dev server after scaffolding
- print the next command(s) to run after optional dependency installation

Closes #2544

## Verification
- Checking formatting...

All matched files use the correct format.
Finished in 90ms on 2 files using 12 threads.
- Found 0 warnings and 0 errors.
Finished in 496ms on 2 files with 133 rules using 12 threads.
- 
> @typegpu/cli@0.11.0-alpha.0 test:types /home/fadhlan/Documents/Codingan/oss/TypeGPU/packages/typegpu-cli
> pnpm tsc --p ./tsconfig.json --noEmit