### PR TITLE
fix(@typegpu/cli): use one project prompt

### DIFF
--- a/packages/typegpu-cli/src/create.ts
+++ b/packages/typegpu-cli/src/create.ts
@@ -4,7 +4,7 @@ import * as p from '@clack/prompts';
 import { pmFromUserAgent, pmInstall, pmRun } from './utils/pm.ts';
 import { cancelExit, confirmStep, rgbText } from './utils/prompts.ts';
 import { copyTemplate, prepareDirectory } from './utils/files.ts';
-import { getPackageName, getProjectDirectory } from './utils/inputs.ts';
+import { getProjectName } from './utils/inputs.ts';
 import { detect, resolveCommand } from 'package-manager-detector';
 
 const DEFAULT_PROJECT_DIR = 'tgpu-project';
@@ -19,11 +19,12 @@ const PROJECT_TEMPLATES = [
 export async function createProject(cwd: string) {
   p.intro('Creating a new TypeGPU project.');
 
-  const projectDir = await getProjectDirectory(DEFAULT_PROJECT_DIR);
+  const projectName = await getProjectName(DEFAULT_PROJECT_DIR);
+  const projectDir = projectName;
 
   const root = await prepareDirectory(cwd, projectDir);
 
-  const packageName = await getPackageName(projectDir);
+  const packageName = projectName;
 
   const projectTemplate = await p.select({
     message: 'Select a template:',

--- a/packages/typegpu-cli/src/utils/inputs.ts
+++ b/packages/typegpu-cli/src/utils/inputs.ts
@@ -9,37 +9,25 @@ function isValidPackageName(packageName: string) {
   return /^(?:@[a-z\d][a-z\d\-._]*\/)?[a-z\d][a-z\d\-._]*$/.test(packageName.trim());
 }
 
-export async function getProjectDirectory(initialValue: string) {
-  let projectDir = await p.text({
-    message: 'Project directory:',
+export async function getProjectName(initialValue: string) {
+  const projectName = await p.text({
+    message: 'Project name:',
     placeholder: initialValue,
     initialValue,
     validate: (value) => {
-      return value && !isValidProjectDirectory(value) ? 'Invalid project directory.' : undefined;
+      if (!value) {
+        return 'Invalid project name.';
+      }
+
+      return !isValidProjectDirectory(value) || !isValidPackageName(value)
+        ? 'Invalid project name.'
+        : undefined;
     },
   });
 
-  if (p.isCancel(projectDir)) {
+  if (p.isCancel(projectName)) {
     cancelExit();
   }
 
-  projectDir ??= '.';
-  return projectDir.trim();
-}
-
-export async function getPackageName(initialValue: string) {
-  const packageName = await p.text({
-    message: 'Package name:',
-    placeholder: initialValue,
-    initialValue,
-    validate: (value) => {
-      return !value || !isValidPackageName(value) ? 'Invalid package name.' : undefined;
-    },
-  });
-
-  if (p.isCancel(packageName)) {
-    cancelExit();
-  }
-
-  return packageName.trim();
+  return projectName.trim();
 }


### PR DESCRIPTION
## Summary
- replace the separate project directory and package name prompts with a single project name prompt
- reuse the project name for both the generated directory and package.json name
- validate the entered project name against both directory and package-name constraints

Fixes #2543

## Validation
- corepack pnpm exec tsc -p packages/typegpu-cli/tsconfig.json --noEmit
- corepack pnpm exec oxfmt --check packages/typegpu-cli/src/create.ts packages/typegpu-cli/src/utils/inputs.ts
- corepack pnpm --filter @typegpu/cli build
- corepack pnpm exec oxlint -c oxlint.config.ts --max-warnings=0 --type-aware --report-unused-disable-directives packages/typegpu-cli/src/create.ts packages/typegpu-cli/src/utils/inputs.ts

Note: local validation ran on Node v22.21.1, while the repo currently declares Node >=24.0.0; pnpm emitted engine warnings, but the focused checks above passed.