### PR TITLE
chore: remove duplicate "to" in two codegen comments

### DIFF
--- a/packages/typegpu/src/core/buffer/bufferUsage.ts
+++ b/packages/typegpu/src/core/buffer/bufferUsage.ts
@@ -198,7 +198,7 @@ class TgpuFixedBufferImpl<TData extends BaseData, TUsage extends BindableBufferU
 
     if (mode.type === 'codegen') {
       // The WGSL generator handles buffer assignment, and does not defer to
-      // whatever's being assigned to to generate the WGSL.
+      // whatever's being assigned to generate the WGSL.
       throw new Error('Unreachable bufferUsage.ts#TgpuFixedBufferImpl/$');
     }
 

--- a/packages/typegpu/src/core/variable/tgpuVariable.ts
+++ b/packages/typegpu/src/core/variable/tgpuVariable.ts
@@ -166,7 +166,7 @@ class TgpuVarImpl<TScope extends VariableScope, TDataType extends BaseData>
 
     if (mode.type === 'codegen') {
       // The WGSL generator handles variable assignment, and does not defer to
-      // whatever's being assigned to to generate the WGSL.
+      // whatever's being assigned to generate the WGSL.
       throw new Error('Unreachable tgpuVariable.ts#TgpuVarImpl/$');
     }
 


### PR DESCRIPTION
## Summary

Two near-identical comment typos in the WGSL codegen guards:

- `packages/typegpu/src/core/buffer/bufferUsage.ts:201`
- `packages/typegpu/src/core/variable/tgpuVariable.ts:169`

Both said "assigned to to generate the WGSL"; removes the second "to". Comment-only.