### PR TITLE
fix(cli): leave package name prompt empty

### DIFF
--- a/packages/typegpu-cli/src/utils/inputs.ts
+++ b/packages/typegpu-cli/src/utils/inputs.ts
@@ -31,7 +31,6 @@ export async function getPackageName(initialValue: string) {
   const packageName = await p.text({
     message: 'Package name:',
     placeholder: initialValue,
-    initialValue,
     validate: (value) => {
       return !value || !isValidPackageName(value) ? 'Invalid package name.' : undefined;
     },


### PR DESCRIPTION
## Summary
- remove the pre-filled initial value from the package name prompt
- keep the generated name visible as placeholder only

Fixes #2542

## Tests
- corepack pnpm exec tsc --p packages/typegpu-cli/tsconfig.json --noEmit
- corepack pnpm oxfmt --check packages/typegpu-cli/src/utils/inputs.ts

Note: local Node is v22.21.1, while the repo asks for >=24.0.0; commands completed with the engine warning.