### PR TITLE
fix(cli): derive package name from project directory

### DIFF
--- a/packages/typegpu-cli/src/create.ts
+++ b/packages/typegpu-cli/src/create.ts
@@ -4,7 +4,7 @@ import * as p from '@clack/prompts';
 import { pmFromUserAgent, pmInstall } from './utils/pm.ts';
 import { cancelExit, confirmStep, rgbText } from './utils/prompts.ts';
 import { copyTemplate, prepareDirectory } from './utils/files.ts';
-import { getPackageName, getProjectDirectory } from './utils/inputs.ts';
+import { getProjectDirectory } from './utils/inputs.ts';
 import { detect, resolveCommand } from 'package-manager-detector';
 
 const DEFAULT_PROJECT_DIR = 'tgpu-project';
@@ -23,7 +23,7 @@ export async function createProject(cwd: string) {
 
   const root = await prepareDirectory(cwd, projectDir);
 
-  const packageName = await getPackageName(projectDir);
+  const packageName = path.basename(root);
 
   const projectTemplate = await p.select({
     message: 'Select a template:',

--- a/packages/typegpu-cli/src/utils/inputs.ts
+++ b/packages/typegpu-cli/src/utils/inputs.ts
@@ -5,10 +5,6 @@ function isValidProjectDirectory(projectDir: string) {
   return !/[<>:"\\|?*\s]|\/+$/.test(projectDir.trim());
 }
 
-function isValidPackageName(packageName: string) {
-  return /^(?:@[a-z\d][a-z\d\-._]*\/)?[a-z\d][a-z\d\-._]*$/.test(packageName.trim());
-}
-
 export async function getProjectDirectory(initialValue: string) {
   let projectDir = await p.text({
     message: 'Project directory:',
@@ -25,21 +21,4 @@ export async function getProjectDirectory(initialValue: string) {
 
   projectDir ??= '.';
   return projectDir.trim();
-}
-
-export async function getPackageName(initialValue: string) {
-  const packageName = await p.text({
-    message: 'Package name:',
-    placeholder: initialValue,
-    initialValue,
-    validate: (value) => {
-      return !value || !isValidPackageName(value) ? 'Invalid package name.' : undefined;
-    },
-  });
-
-  if (p.isCancel(packageName)) {
-    cancelExit();
-  }
-
-  return packageName.trim();
 }


### PR DESCRIPTION
## Summary
- remove the separate package name prompt from the project creation flow
- derive the package name from the selected project directory
- keep scaffolding behavior unchanged after the directory step

Fixes #2543

## Tests
- corepack pnpm exec tsc --p packages/typegpu-cli/tsconfig.json --noEmit
- corepack pnpm oxfmt --check packages/typegpu-cli/src/create.ts packages/typegpu-cli/src/utils/inputs.ts

Note: local Node is v22.21.1, while the repo asks for >=24.0.0; commands completed with the engine warning.