### PR TITLE
fix: scrollable examples layout on mobile

### DIFF
--- a/apps/typegpu-docs/src/components/ControlPanel.tsx
+++ b/apps/typegpu-docs/src/components/ControlPanel.tsx
@@ -312,7 +312,7 @@ export function ControlPanel() {
       {isGPUSupported && (
         <>
           <h2 className="m-0 font-medium text-xl">Example controls</h2>
-          <div className="grid grid-cols-2 items-center gap-4 overflow-auto p-1 pb-2">
+          <div className="relative grid grid-cols-2 items-center gap-4 overflow-auto p-1 pb-2">
             {exampleControlParams.map(paramToControlRow)}
           </div>
         </>


### PR DESCRIPTION
Opus did that, but it seems to work:

Before:

https://github.com/user-attachments/assets/c2622098-0944-45ae-a2d8-d9ae2f12a19e

After:

https://github.com/user-attachments/assets/5be6a8d5-b79d-43a1-8a0a-bb3b288a3bc8
