### PR TITLE
impr: Unnamed externals

### DIFF
--- a/apps/typegpu-docs/tests/individual-example-tests/slime-mold-3d.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/slime-mold-3d.test.ts
@@ -62,17 +62,17 @@ describe('slime mold 3d example', () => {
         direction: vec3f,
       }
 
-      @group(0) @binding(1) var<storage, read_write> 0: array<Agent, 800000>;
+      @group(0) @binding(1) var<storage, read_write> item: array<Agent, 800000>;
 
-      @group(0) @binding(2) var<storage, read_write> 1: array<Agent, 800000>;
+      @group(0) @binding(2) var<storage, read_write> item_1: array<Agent, 800000>;
 
       fn wrappedCallback(x: u32, _arg_1: u32, _arg_2: u32) {
         randSeed((f32(x) / 8e+5f));
         let pos = ((randInUnitSphere() * 64f) + vec3f(128));
         let center = vec3f(128);
         let dir = normalize((center - pos));
-        0[x] = Agent(pos, dir);
-        1[x] = Agent(pos, dir);
+        item[x] = Agent(pos, dir);
+        item_1[x] = Agent(pos, dir);
       }
 
       @compute @workgroup_size(256, 1, 1) fn mainCompute(@builtin(global_invocation_id) id: vec3u) {

--- a/apps/typegpu-docs/tests/individual-example-tests/slime-mold-3d.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/slime-mold-3d.test.ts
@@ -62,17 +62,17 @@ describe('slime mold 3d example', () => {
         direction: vec3f,
       }
 
-      @group(0) @binding(1) var<storage, read_write> item: array<Agent, 800000>;
+      @group(0) @binding(1) var<storage, read_write> 0: array<Agent, 800000>;
 
-      @group(0) @binding(2) var<storage, read_write> item_1: array<Agent, 800000>;
+      @group(0) @binding(2) var<storage, read_write> 1: array<Agent, 800000>;
 
       fn wrappedCallback(x: u32, _arg_1: u32, _arg_2: u32) {
         randSeed((f32(x) / 8e+5f));
         let pos = ((randInUnitSphere() * 64f) + vec3f(128));
         let center = vec3f(128);
         let dir = normalize((center - pos));
-        item[x] = Agent(pos, dir);
-        item_1[x] = Agent(pos, dir);
+        0[x] = Agent(pos, dir);
+        1[x] = Agent(pos, dir);
       }
 
       @compute @workgroup_size(256, 1, 1) fn mainCompute(@builtin(global_invocation_id) id: vec3u) {

--- a/packages/typegpu/src/core/declare/tgpuDeclare.ts
+++ b/packages/typegpu/src/core/declare/tgpuDeclare.ts
@@ -2,7 +2,11 @@ import { type ResolvedSnippet, snip } from '../../data/snippet.ts';
 import { Void } from '../../data/wgslTypes.ts';
 import { $internal, $resolve } from '../../shared/symbols.ts';
 import type { ResolutionCtx, SelfResolvable } from '../../types.ts';
-import { mergeExternals, type ExternalMap, replaceExternalsInWgsl } from '../resolve/externals.ts';
+import {
+  renameAndMergeExternals,
+  type ExternalMap,
+  replaceExternalsInWgsl,
+} from '../resolve/externals.ts';
 
 // ----------
 // Public API
@@ -49,7 +53,7 @@ class TgpuDeclareImpl implements TgpuDeclare, SelfResolvable {
     const externalMap: ExternalMap = {};
 
     for (const externals of this.#externalsToApply) {
-      mergeExternals(externalMap, externals);
+      renameAndMergeExternals(externalMap, externals);
     }
 
     const replacedDeclaration = replaceExternalsInWgsl(ctx, externalMap, this.#declaration);

--- a/packages/typegpu/src/core/function/fnCore.ts
+++ b/packages/typegpu/src/core/function/fnCore.ts
@@ -6,7 +6,11 @@ import { validateIdentifier } from '../../nameUtils.ts';
 import { getFunctionMetadata, getName } from '../../shared/meta.ts';
 import { $getNameForward } from '../../shared/symbols.ts';
 import type { ResolutionCtx, TgpuShaderStage } from '../../types.ts';
-import { mergeExternals, type ExternalMap, replaceExternalsInWgsl } from '../resolve/externals.ts';
+import {
+  renameAndMergeExternals,
+  type ExternalMap,
+  replaceExternalsInWgsl,
+} from '../resolve/externals.ts';
 import { extractArgs } from './extractArgs.ts';
 import type { Implementation, SeparatedEntryArgs } from './fnTypes.ts';
 
@@ -71,7 +75,7 @@ export function createFnCore(
       }
 
       for (const externals of externalsToApply) {
-        mergeExternals(externalMap, externals);
+        renameAndMergeExternals(externalMap, externals);
       }
 
       const id = ctx.makeUniqueIdentifier(getName(this), 'global');
@@ -91,7 +95,7 @@ export function createFnCore(
             }
           }
 
-          mergeExternals(externalMap, {
+          renameAndMergeExternals(externalMap, {
             in: Object.fromEntries(
               entryInput.positionalArgs.map((a) => [a.schemaKey, a.schemaKey]),
             ),
@@ -174,7 +178,7 @@ export function createFnCore(
           Object.entries(pluginExternals).filter(([name]) => !(name in externalMap)),
         );
 
-        mergeExternals(externalMap, missing);
+        renameAndMergeExternals(externalMap, missing);
       }
 
       const ast = pluginData?.ast;
@@ -188,7 +192,7 @@ export function createFnCore(
       // We look at the identifier chosen by the user and add it to externals.
       const maybeSecondArg = ast.params[1];
       if (maybeSecondArg && maybeSecondArg.type === 'i' && functionType !== 'normal') {
-        mergeExternals(externalMap, {
+        renameAndMergeExternals(externalMap, {
           // oxlint-disable-next-line typescript/no-non-null-assertion -- entry functions cannot be shellless
           [maybeSecondArg.name]: undecorate(returnType!),
         });

--- a/packages/typegpu/src/core/rawCodeSnippet/tgpuRawCodeSnippet.ts
+++ b/packages/typegpu/src/core/rawCodeSnippet/tgpuRawCodeSnippet.ts
@@ -5,7 +5,11 @@ import { inCodegenMode } from '../../execMode.ts';
 import type { InferGPU } from '../../shared/repr.ts';
 import { $gpuValueOf, $internal, $ownSnippet, $resolve } from '../../shared/symbols.ts';
 import type { ResolutionCtx, SelfResolvable } from '../../types.ts';
-import { mergeExternals, type ExternalMap, replaceExternalsInWgsl } from '../resolve/externals.ts';
+import {
+  renameAndMergeExternals,
+  type ExternalMap,
+  replaceExternalsInWgsl,
+} from '../resolve/externals.ts';
 import { valueProxyHandler } from '../valueProxyUtils.ts';
 
 // ----------
@@ -112,7 +116,7 @@ class TgpuRawCodeSnippetImpl<TDataType extends BaseData>
     const externalMap: ExternalMap = {};
 
     for (const externals of this.#externalsToApply) {
-      mergeExternals(externalMap, externals);
+      renameAndMergeExternals(externalMap, externals);
     }
 
     const replacedExpression = replaceExternalsInWgsl(ctx, externalMap, this.#expression);

--- a/packages/typegpu/src/core/resolve/externals.ts
+++ b/packages/typegpu/src/core/resolve/externals.ts
@@ -13,19 +13,23 @@ function isResolvable(value: unknown) {
   return isWgsl(value) || isLooseData(value) || hasTinyestMetadata(value);
 }
 
-/**
- * Merges two external maps into one.
- * If the external value is a namable object, it is given a name if it does not already have one.
- * @param existing - The existing external map.
- * @param newExternals - The new external map.
- *
- * NOTE:
- * This function attempts to avoid accidental reference modification
- * by performing a shallow copy before each modification,
- * but it cannot avoid `existing` modification.
- * Make sure that `existing` is created internally, instead of being passed in by users.
- */
-export function mergeExternals(existing: ExternalMap, newExternals: ExternalMap) {
+function renameExternals(externals: ExternalMap) {
+  for (const [key, value] of Object.entries(externals)) {
+    if (value !== null && typeof value === 'object' && !isResolvable(value)) {
+      renameExternals(value as ExternalMap);
+    } else {
+      if (
+        value &&
+        (typeof value === 'object' || typeof value === 'function') &&
+        getName(value) === undefined
+      ) {
+        setName(value, key);
+      }
+    }
+  }
+}
+
+function mergeExternals(existing: ExternalMap, newExternals: ExternalMap) {
   for (const [key, value] of Object.entries(newExternals)) {
     const existingValue = existing[key];
     if (
@@ -42,16 +46,23 @@ export function mergeExternals(existing: ExternalMap, newExternals: ExternalMap)
     } else {
       existing[key] = value;
     }
-
-    // Giving name to external value, if it does not already have one.
-    if (
-      value &&
-      (typeof value === 'object' || typeof value === 'function') &&
-      getName(value) === undefined
-    ) {
-      setName(value, key);
-    }
   }
+}
+
+/**
+ * Traverses the second map and renames unnamed externals, then merges the second map into the first one.
+ * @param existing - The existing external map.
+ * @param newExternals - The new external map.
+ *
+ * NOTE:
+ * This function attempts to avoid accidental reference modification
+ * by performing a shallow copy before each modification,
+ * but it cannot avoid `existing` modification.
+ * Make sure that `existing` is created internally, instead of being passed in by users.
+ */
+export function renameAndMergeExternals(existing: ExternalMap, newExternals: ExternalMap) {
+  renameExternals(newExternals);
+  mergeExternals(existing, newExternals);
 }
 
 export function addArgTypesToExternals(

--- a/packages/typegpu/src/core/resolve/externals.ts
+++ b/packages/typegpu/src/core/resolve/externals.ts
@@ -15,7 +15,12 @@ function isResolvable(value: unknown) {
 
 function renameExternals(externals: ExternalMap) {
   for (const [key, value] of Object.entries(externals)) {
-    if (value !== null && typeof value === 'object' && !isResolvable(value)) {
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !isResolvable(value) &&
+      !Array.isArray(value) // TODO(#2592): remove this check
+    ) {
       renameExternals(value as ExternalMap);
     } else {
       if (

--- a/packages/typegpu/src/core/resolve/tgpuResolve.ts
+++ b/packages/typegpu/src/core/resolve/tgpuResolve.ts
@@ -8,7 +8,7 @@ import type { ResolvableObject, SelfResolvable, Wgsl } from '../../types.ts';
 import type { WgslEnableExtension } from '../../wgslExtensions.ts';
 import { isPipeline } from '../pipeline/typeGuards.ts';
 import type { Configurable, ExperimentalTgpuRoot } from '../root/rootTypes.ts';
-import { mergeExternals, replaceExternalsInWgsl } from './externals.ts';
+import { renameAndMergeExternals, replaceExternalsInWgsl } from './externals.ts';
 import { type Namespace, namespace } from './namespace.ts';
 
 export interface TgpuResolveOptions {
@@ -196,7 +196,7 @@ function resolveFromTemplate(options: TgpuExtendedResolveOptions): ResolutionRes
   }
 
   const dependencies = {} as Record<string, Wgsl>;
-  mergeExternals(dependencies, externals ?? {});
+  renameAndMergeExternals(dependencies, externals ?? {});
 
   const resolutionObj: SelfResolvable = {
     [$internal]: true,

--- a/packages/typegpu/tests/function.test.ts
+++ b/packages/typegpu/tests/function.test.ts
@@ -1,10 +1,11 @@
 import { attest } from '@ark/attest';
-import { describe, expect, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf } from 'vitest';
 import type { InferIO, InheritArgNames, IOLayout } from '../src/core/function/fnTypes.ts';
 import * as d from '../src/data/index.ts';
 import { Void } from '../src/data/wgslTypes.ts';
-import tgpu, { type TgpuFn, type TgpuFnShell } from '../src/index.js';
+import tgpu, { type TgpuFn, type TgpuFnShell, type TgpuUniform } from '../src/index.js';
 import type { Prettify } from '../src/shared/utilityTypes.ts';
+import { it } from 'typegpu-testing-utility';
 
 const empty = tgpu.fn([])`() {
   // do nothing
@@ -187,6 +188,44 @@ describe('tgpu.fn', () => {
     expect(tgpu.resolve([fn])).toMatchInlineSnapshot(`
       "fn fn_1() {
         let a = 1;
+      }"
+    `);
+  });
+
+  it('renames nested externals', ({ root }) => {
+    const uniform = (() => root.createUniform(d.u32))();
+    const fn = tgpu.fn([])`() {
+  let a = ext.prop;
+}`.$uses({ ext: { prop: uniform } });
+
+    expect(tgpu.resolve([fn])).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<uniform> prop: u32;
+
+      fn fn_1() {
+        let a = prop;
+      }"
+    `);
+  });
+
+  it('does not rename arrays', ({ root }) => {
+    const uniforms = [0, 1].map(() => root.createUniform(d.u32)) as [
+      TgpuUniform<d.U32>,
+      TgpuUniform<d.U32>,
+    ];
+    const fn = () => {
+      'use gpu';
+      const a = uniforms[0].$;
+      const b = uniforms[1].$;
+    };
+
+    expect(tgpu.resolve([fn])).toMatchInlineSnapshot(`
+      "@group(0) @binding(0) var<uniform> 0: u32;
+
+      @group(0) @binding(1) var<uniform> 1: u32;
+
+      fn fn_1() {
+        let a = 0;
+        let b = 1;
       }"
     `);
   });

--- a/packages/typegpu/tests/function.test.ts
+++ b/packages/typegpu/tests/function.test.ts
@@ -219,13 +219,13 @@ describe('tgpu.fn', () => {
     };
 
     expect(tgpu.resolve([fn])).toMatchInlineSnapshot(`
-      "@group(0) @binding(0) var<uniform> 0: u32;
+      "@group(0) @binding(0) var<uniform> item: u32;
 
-      @group(0) @binding(1) var<uniform> 1: u32;
+      @group(0) @binding(1) var<uniform> item_1: u32;
 
       fn fn_1() {
-        let a = 0;
-        let b = 1;
+        let a = item;
+        let b = item_1;
       }"
     `);
   });


### PR DESCRIPTION
Right now, in `mergeExternals`, we only name some of the unnamed externals. This PR makes it so we actually traverse all of it.