### PR TITLE
impr: Use named tgpu export

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ compute shaders, and `@abc/plot` is a library for plots and visualization using
 WebGPU.
 
 ```ts
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import gen from '@xyz/gen';
 import plot from '@abc/plot';
 

--- a/apps/bun-example/index.ts
+++ b/apps/bun-example/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { randf } from '@typegpu/noise';
 
 const Boid = d.struct({

--- a/apps/react-prerendering-test/components/Shader.tsx
+++ b/apps/react-prerendering-test/components/Shader.tsx
@@ -2,7 +2,7 @@
 
 import { useConfigureContext, useFrame, useRoot, useUniform } from '@typegpu/react';
 import { useMemo } from 'react';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { perlin2d } from '@typegpu/noise';
 import { hexToOklab, oklabToRgb } from '@typegpu/color';
 

--- a/apps/resolution-time/procedural.ts
+++ b/apps/resolution-time/procedural.ts
@@ -1,6 +1,6 @@
 import { writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import tgpu, { d, std, type TgpuComptime } from 'typegpu';
+import { tgpu, d, std, type TgpuComptime } from 'typegpu';
 
 interface ProcGenConfig {
   mainBranching: number;

--- a/apps/treeshake-test/tests/namespace/STATIC_allImports.ts
+++ b/apps/treeshake-test/tests/namespace/STATIC_allImports.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu/$built$';
+import { tgpu } from 'typegpu/$built$';
 import * as d from 'typegpu/data/$built$';
 import * as std from 'typegpu/std/$built$';
 import * as common from 'typegpu/common/$built$';

--- a/apps/treeshake-test/tests/namespace/STATIC_tgpu.ts
+++ b/apps/treeshake-test/tests/namespace/STATIC_tgpu.ts
@@ -1,3 +1,3 @@
-import tgpu from 'typegpu/$built$';
+import { tgpu } from 'typegpu/$built$';
 
 console.log(tgpu);

--- a/apps/typegpu-docs/src/components/ComputeShadersArrayExample.tsx
+++ b/apps/typegpu-docs/src/components/ComputeShadersArrayExample.tsx
@@ -10,7 +10,7 @@ import {
 const VALUE_COUNT = 16;
 const ValuesSchema = d.arrayOf(d.u32, VALUE_COUNT);
 
-export const COMPUTE_SHADER_ARRAY_SNIPPET = `import tgpu, { d } from 'typegpu';
+export const COMPUTE_SHADER_ARRAY_SNIPPET = `import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 

--- a/apps/typegpu-docs/src/components/ComputeShadersBindGroupsExample.tsx
+++ b/apps/typegpu-docs/src/components/ComputeShadersBindGroupsExample.tsx
@@ -14,7 +14,7 @@ const BUFFER_OPTIONS: readonly BufferOption[] = [
   { colorCss: '#bef264', label: 'Buffer C', name: 'Burst' },
 ];
 
-export const COMPUTE_SHADER_BIND_GROUPS_SNIPPET = `import tgpu, { d, std } from 'typegpu';
+export const COMPUTE_SHADER_BIND_GROUPS_SNIPPET = `import { tgpu, d, std } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -98,11 +98,10 @@ function BufferControls({ onSelect, runner, selected }: BufferControlsProps) {
           return (
             <button
               aria-pressed={isSelected}
-              className={`grid min-w-0 grid-cols-[auto_1fr] items-center gap-1.5 rounded-sm border px-2 py-1 text-left text-xs font-medium transition-colors ${
-                isSelected
+              className={`grid min-w-0 grid-cols-[auto_1fr] items-center gap-1.5 rounded-sm border px-2 py-1 text-left text-xs font-medium transition-colors ${isSelected
                   ? 'border-[var(--sl-color-text-accent)] text-[var(--sl-color-text-accent)]'
                   : 'border-[var(--sl-color-gray-5)] text-[var(--sl-color-text)] hover:text-[var(--sl-color-text-accent)]'
-              }`}
+                }`}
               key={option.label}
               onClick={() => onSelect(index as BufferIndex)}
               type="button"

--- a/apps/typegpu-docs/src/components/ComputeShadersBindGroupsExample.tsx
+++ b/apps/typegpu-docs/src/components/ComputeShadersBindGroupsExample.tsx
@@ -98,10 +98,11 @@ function BufferControls({ onSelect, runner, selected }: BufferControlsProps) {
           return (
             <button
               aria-pressed={isSelected}
-              className={`grid min-w-0 grid-cols-[auto_1fr] items-center gap-1.5 rounded-sm border px-2 py-1 text-left text-xs font-medium transition-colors ${isSelected
+              className={`grid min-w-0 grid-cols-[auto_1fr] items-center gap-1.5 rounded-sm border px-2 py-1 text-left text-xs font-medium transition-colors ${
+                isSelected
                   ? 'border-[var(--sl-color-text-accent)] text-[var(--sl-color-text-accent)]'
                   : 'border-[var(--sl-color-gray-5)] text-[var(--sl-color-text)] hover:text-[var(--sl-color-text-accent)]'
-                }`}
+              }`}
               key={option.label}
               onClick={() => onSelect(index as BufferIndex)}
               type="button"

--- a/apps/typegpu-docs/src/components/ComputeShadersBindGroupsRuntime.ts
+++ b/apps/typegpu-docs/src/components/ComputeShadersBindGroupsRuntime.ts
@@ -1,5 +1,5 @@
 import { sdBox2d } from '@typegpu/sdf';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { createExampleRoot } from './runnable/index.ts';
 
 const PARTICLE_COUNT = 96;

--- a/apps/typegpu-docs/src/components/ComputeShadersGridExample.tsx
+++ b/apps/typegpu-docs/src/components/ComputeShadersGridExample.tsx
@@ -11,7 +11,7 @@ const GRID_WIDTH = 8;
 const GRID_HEIGHT = 6;
 const GridSchema = d.arrayOf(d.arrayOf(d.u32, GRID_HEIGHT), GRID_WIDTH);
 
-export const COMPUTE_SHADER_GRID_SNIPPET = `import tgpu, { d } from 'typegpu';
+export const COMPUTE_SHADER_GRID_SNIPPET = `import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 

--- a/apps/typegpu-docs/src/components/FirstGpuProgramExample.tsx
+++ b/apps/typegpu-docs/src/components/FirstGpuProgramExample.tsx
@@ -8,7 +8,7 @@ const CounterState = d.struct({
 });
 
 export const FIRST_GPU_PROGRAM_SNIPPETS = {
-  consoleLog: `import tgpu, { d } from 'typegpu';
+  consoleLog: `import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -31,7 +31,7 @@ export function execute() {
 }
 `,
 
-  readValue: `import tgpu, { d } from 'typegpu';
+  readValue: `import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -54,7 +54,7 @@ export async function execute() {
 }
 `,
 
-  updateIncrementBy: `import tgpu, { d } from 'typegpu';
+  updateIncrementBy: `import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -104,15 +104,15 @@ async function createCounterProgram(withLog: boolean): Promise<CounterProgram> {
   const program = root.createGuardedComputePipeline(
     withLog
       ? () => {
-          'use gpu';
-          const currentCount = countMutable.$;
-          console.log('current count:', currentCount);
-          countMutable.$++;
-        }
+        'use gpu';
+        const currentCount = countMutable.$;
+        console.log('current count:', currentCount);
+        countMutable.$++;
+      }
       : () => {
-          'use gpu';
-          countMutable.$++;
-        },
+        'use gpu';
+        countMutable.$++;
+      },
   );
   return { countMutable, program, root };
 }

--- a/apps/typegpu-docs/src/components/FirstGpuProgramExample.tsx
+++ b/apps/typegpu-docs/src/components/FirstGpuProgramExample.tsx
@@ -104,15 +104,15 @@ async function createCounterProgram(withLog: boolean): Promise<CounterProgram> {
   const program = root.createGuardedComputePipeline(
     withLog
       ? () => {
-        'use gpu';
-        const currentCount = countMutable.$;
-        console.log('current count:', currentCount);
-        countMutable.$++;
-      }
+          'use gpu';
+          const currentCount = countMutable.$;
+          console.log('current count:', currentCount);
+          countMutable.$++;
+        }
       : () => {
-        'use gpu';
-        countMutable.$++;
-      },
+          'use gpu';
+          countMutable.$++;
+        },
   );
   return { countMutable, program, root };
 }

--- a/apps/typegpu-docs/src/components/runnable/RunnableSnippet.tsx
+++ b/apps/typegpu-docs/src/components/runnable/RunnableSnippet.tsx
@@ -1,6 +1,6 @@
 import { Play } from 'lucide-react';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
-import tgpu, { type TgpuRoot } from 'typegpu';
+import { tgpu, type TgpuRoot } from 'typegpu';
 import { useConsoleCapture } from './useConsoleCapture.ts';
 
 const unsupportedMessage =

--- a/apps/typegpu-docs/src/components/translator/lib/constants.ts
+++ b/apps/typegpu-docs/src/components/translator/lib/constants.ts
@@ -20,7 +20,7 @@ fn fs_main() -> @location(0) vec4<f32> {
   return vec4<f32>(1.0, 0.0, 0.0, 1.0);
 }`;
 
-export const DEFAULT_TGSL = `import tgpu, { d } from 'typegpu';
+export const DEFAULT_TGSL = `import { tgpu, d } from 'typegpu';
 
 const Particle = d.struct({
   position: d.vec3f,

--- a/apps/typegpu-docs/src/components/translator/lib/tgslExecutor.ts
+++ b/apps/typegpu-docs/src/components/translator/lib/tgslExecutor.ts
@@ -23,7 +23,7 @@ async function executeTgslModule(
       '/shader.ts': { content: tgslCode },
       '/index.ts': {
         content: `
-          import tgpu from 'typegpu';
+          import { tgpu } from 'typegpu';
           import * as exports from './shader.ts';
 
           const shaderCode = tgpu.resolve({ externals: exports });

--- a/apps/typegpu-docs/src/content/docs/apis/accessors.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/accessors.mdx
@@ -6,7 +6,7 @@ description: Accessors are schema-aware typed placeholders for GPU resources, al
 When writing reusable GPU functions in TypeGPU, you often need to reference "some global value" without coupling to a specific buffer, texture or variable. [Slots](/TypeGPU/apis/slots) seem like the right tool for the job, but they encode the delivery mechanism into the slot type (e.g. a buffer or texture), making it inflexible for reusable functions.
 
 ```ts twoslash
-import tgpu, { type TgpuUniform, d } from 'typegpu';
+import { tgpu, type TgpuUniform, d } from 'typegpu';
 // ---cut---
 // 👎 only works with JS literals
 const staticColorSlot = tgpu.slot<d.v3f>();
@@ -28,7 +28,7 @@ const colorAccess = tgpu.accessor(d.vec3f);
 Create an accessor with `tgpu.accessor(schema)`. Optionally pass a default value as the second argument:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 // No default — must be bound before resolving.
 const colorAccess = tgpu.accessor(d.vec3f);
@@ -40,7 +40,7 @@ const colorWithDefault = tgpu.accessor(d.vec3f, d.vec3f(1, 0, 0));
 Inside a GPU function, read the accessor's value using `.$`:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const colorAccess = tgpu.accessor(d.vec3f, d.vec3f(1, 0, 0));
 // ---cut---
@@ -58,7 +58,7 @@ Accessing it outside GPU context throws a runtime error.
 If no default is set and no binding is provided at resolution time, TypeGPU throws a descriptive error:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const colorAccess = tgpu.accessor(d.vec3f);
 
@@ -79,7 +79,7 @@ tgpu.resolve([getColor]);
 Use `.with(accessor, value)` on a function or pipeline — the same pattern as [slots](/apis/slots):
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const RED = d.vec3f(1, 0, 0);
 const GREEN = d.vec3f(0, 1, 0);
@@ -112,7 +112,7 @@ fn getColor_1() -> vec3f {
 You can also override on a pipeline:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -136,7 +136,7 @@ Accessors accept several types of GPU resources as values.
 The simplest binding — the value is resolved at compile time and inlined directly into the WGSL:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const colorAccess = tgpu.accessor(d.vec3f);
 const multiplierAccess = tgpu.accessor(d.f32);
@@ -168,7 +168,7 @@ Notice how, because the values are known at compile time, the result is precompu
 Resolves to a function call in the generated WGSL:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const colorAccess = tgpu.accessor(d.vec3f, () => {
   'use gpu';
@@ -196,7 +196,7 @@ fn getColor() -> vec3f {
 Resolves to the WGSL variable declaration for that buffer binding:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 const RED = d.vec3f(1, 0, 0);
@@ -225,7 +225,7 @@ fn getColor() -> vec3f {
 A common pattern for library-style code: use a bind group layout entry as the default, making it easy to swap the resource via `.with()`:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const ImageData = (count: number) =>
   d.struct({
@@ -247,7 +247,7 @@ const imageAccess = tgpu.accessor(ImageData, () => layout.$.image);
 Bind a private or workgroup variable:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const colorAccess = tgpu.accessor(d.vec3f);
 
@@ -280,7 +280,7 @@ fn getColor_1() -> vec3f {
 ### Constant
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const colorAccess = tgpu.accessor(d.vec3f);
 
@@ -304,7 +304,7 @@ fn getColor() -> vec3f {
 ### Texture view
 
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -335,7 +335,7 @@ fn main() {
 Because accessors know the schema of their resource, you can access struct fields directly through `.$`:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const ImageData = (count: number) =>
   d.struct({
@@ -379,7 +379,7 @@ fn getPixel(x: i32, y: i32) -> vec4f {
 You can also access deeply nested references — e.g., a specific element of a buffer's array field:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -415,7 +415,7 @@ fn main() {
 Use `tgpu.mutableAccessor` when you need to *write* to the resource:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -447,7 +447,7 @@ The split between `tgpu.accessor` and `tgpu.mutableAccessor` is useful, as the r
 You can also mutate fields of a non-primitive struct:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 

--- a/apps/typegpu-docs/src/content/docs/apis/bind-groups.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/bind-groups.mdx
@@ -12,7 +12,7 @@ A bind group is a collection of resources that are bound to a shader. These reso
 It's a way to define what resources are available to a shader and how they are accessed.
 
 ```ts
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 // Defining the layout of resources we want the shader to
 // have access to.

--- a/apps/typegpu-docs/src/content/docs/apis/buffers.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/buffers.mdx
@@ -19,7 +19,7 @@ results of parallel computation back to JS. When creating a buffer, a schema for
 As an example, let's create a buffer for storing particles.
 
 ```ts twoslash {22-28}
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 // Defining a struct type
 const Particle = d.struct({
@@ -66,7 +66,7 @@ To create a buffer, you will need to define its schema by composing data types i
 structs and arrays. They will be explored in more detail in [a following chapter](/TypeGPU/apis/data-schemas).
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const countBuffer = root.createBuffer(d.u32);
@@ -85,7 +85,7 @@ To be able to use these buffers in WGSL shaders, we have to declare their usage 
 
 ```ts twoslash
 // @noErrors
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const buffer = root.createBuffer(d.u32)
@@ -98,7 +98,7 @@ You can also add all flags in a single `$usage()`.
 
 ```ts twoslash
 // @noErrors
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const buffer = root.createBuffer(d.u32)
@@ -109,7 +109,7 @@ const buffer = root.createBuffer(d.u32)
 :::note
 Along with passing the appropriate flags to WebGPU, the methods will also embed type information into the buffer.
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 
@@ -126,7 +126,7 @@ or indirectly through the `.$usage` method.
 
 ```ts twoslash
 /// <reference types="@webgpu/types" />
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 const buffer = root.createBuffer(d.f32);
 // ---cut---
@@ -147,7 +147,7 @@ You can also pass an initial value to the `root.createBuffer` function.
 When the buffer is created, it will be mapped at creation, and the initial value will be written to the buffer.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 // Will be initialized to `100`
@@ -164,7 +164,7 @@ For cases where a plain typed value is not enough, you can also pass an initiali
 It receives the newly created typed buffer while it is still mapped, so you can populate it with multiple writes or helper utilities before the first upload.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -186,7 +186,7 @@ You can also create a buffer using an existing WebGPU buffer. This is useful whe
 
 ```ts twoslash {7}
 /// <reference types="@webgpu/types" />
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 const device = root.device;
 // ---cut---
@@ -212,7 +212,7 @@ method's arguments.
 
 ```ts twoslash
 // @noErrors
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const Particle = d.struct({
@@ -255,7 +255,7 @@ The same API is used internally for buffer writes.
 When data already lives in tuples or typed arrays, skipping typed instance construction avoids allocating TypeGPU wrapper objects, which can reduce garbage-collector pressure in hot paths such as per-frame updates or simulation ticks.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const vecBuffer = root.createBuffer(d.vec3f);
@@ -278,7 +278,7 @@ WGSL matrices are stored by columns, not rows.
 For `mat3x3f`, use packed `number[]` (9 floats) or padded `Float32Array` (12 floats, one padding float per column).
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const mat3Buffer = root.createBuffer(d.mat3x3f);
@@ -303,7 +303,7 @@ mat3Buffer.write(new Float32Array([
 Wherever a `TypedArray` or `ArrayBuffer` is passed, the bytes are copied directly without any interpretation. The data must already match the GPU memory layout, including any padding. For example, each element in `d.arrayOf(d.vec3f, N)` occupies **16 bytes** (12 bytes of data + 4 bytes of padding), so the input must include those padding bytes.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const arrBuffer = root.createBuffer(d.arrayOf(d.vec3f, 2));
@@ -329,7 +329,7 @@ Use `d.memoryLayoutOf` to obtain the correct byte offset for a given schema elem
 :::
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const schema = d.arrayOf(d.u32, 6);
@@ -351,7 +351,7 @@ Both offsets are **byte-based**. Any component whose byte position falls at or b
 :::
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const schema = d.arrayOf(d.vec3u, 4);
@@ -386,7 +386,7 @@ The format of the `data` value depends on your schema type:
   a plain array for full replacement, or a `TypedArray` for byte-level replacement.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const Planet = d.struct({
@@ -413,7 +413,7 @@ When the buffer schema is an `array<struct<...>>`, you can write the data in a s
 This is useful when your CPU-side data is already stored per-field, such as simulation attributes kept in separate typed arrays.
 
 ```ts twoslash
-import tgpu, { d, common } from 'typegpu';
+import { tgpu, d, common } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -455,7 +455,7 @@ TypeGPU inserts the required WGSL padding while scattering the data into the tar
 You can also restrict the write to a slice of the destination buffer:
 
 ```ts twoslash
-import tgpu, { d, common } from 'typegpu';
+import { tgpu, d, common } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -498,7 +498,7 @@ There's also an option to copy value from another typed buffer using the `.copyF
 as long as both buffers have a matching data schema.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 
 const Particle = d.struct({
@@ -518,7 +518,7 @@ To read data from a buffer on the CPU, you can use the `.read()` method.
 It returns a promise that resolves to the data read from the buffer.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const buffer = root.createBuffer(d.arrayOf(d.u32, 10));
@@ -549,7 +549,7 @@ TypeGPU also allows for the use of index buffers. An index buffer is a buffer co
 You may refer to the [pipelines](/TypeGPU/apis/pipelines/#drawing-with-drawindexed) section for usage details.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -570,7 +570,7 @@ The default option is to create bind group layouts and bind your buffers via bin
 Read more in the chapter dedicated to [bind groups](/TypeGPU/apis/bind-groups).
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -608,7 +608,7 @@ Fixed buffers are created using dedicated root methods.
 | `var<storage, read_write>` | `root.createMutable()`  |
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---

--- a/apps/typegpu-docs/src/content/docs/apis/data-schemas.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/data-schemas.mdx
@@ -363,7 +363,7 @@ Texture schemas serve two main purposes:
  - providing argument types for user defined functions
 
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const root = await tgpu.init();
 const texture = root.createTexture({
@@ -479,7 +479,7 @@ const AtomicI32 = d.atomic(d.i32);
 The `std` module provides functions for manipulating atomic data in 'use gpu' functions.
 
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 // ---cut---
 const count = tgpu.workgroupVar(d.atomic(d.u32));
 
@@ -520,7 +520,7 @@ One of the biggest differences between JavaScript and WGSL is the existence of v
 Let's take a look at a simple TypeGPU function and the WGSL code it resolves to.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const MyStruct = d.struct({ n: d.u32 });
 
@@ -552,7 +552,7 @@ Even though modifying `s2` results in a change to `s1` in both cases, it happens
 
 To force an explicit copy in both cases, use a schema when the exact type is known:
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 // ---cut---
 const MyStruct = d.struct({ n: d.u32 });
 
@@ -565,7 +565,7 @@ function myFn() {
 
 Or use `std.copy` when the schema may vary:
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 // ---cut---
 function myFn(arg: d.v2u | d.v3u | d.v4u) {
   'use gpu';

--- a/apps/typegpu-docs/src/content/docs/apis/functions/index.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/functions/index.mdx
@@ -25,7 +25,7 @@ though we recommend reading through anyway.
 The simplest and most powerful way to define TypeGPU functions is to just place `'use gpu'` at the beginning of the function body.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const neighborhood = (a: number, r: number) => {
   'use gpu';
@@ -40,7 +40,7 @@ the same on the CPU and GPU.
 There are three main ways to use TypeGPU functions.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 
 const neighborhood = (a: number, r: number) => {
@@ -193,7 +193,7 @@ Since TypeScript types not taken into account when generating the shader code, t
 limitation on use of generic types.
 
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 // ---cut---
 const double = <T extends d.v2f | d.v3f | d.v4f>(a: T): T => {
   'use gpu';
@@ -247,7 +247,7 @@ After seeing this, you might be tempted to use this mechanism for sharing data b
 global variables used across functions, but values referenced by TypeGPU functions *are assumed to be constant*.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -331,7 +331,7 @@ It accepts two arguments:
 - (Optionally) a schema representing the return type.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const neighborhood = (a: number, r: number) => {
   'use gpu';
   return d.vec2f(a - r, a + r);
@@ -346,7 +346,7 @@ const neighborhoodF32 = neighborhoodShell(neighborhood);
 Although you can define the function and shell separately, the most common way to use shells is immediately wrapping functions with them:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const neighborhood = tgpu.fn([d.f32, d.f32], d.vec2f)((a, r) => {
   'use gpu';
@@ -365,7 +365,7 @@ We assume that you are familiar with the following concepts:
 Instead of passing JavaScript functions to shells, you can pass WGSL code directly:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const neighborhood = tgpu.fn([d.f32, d.f32], d.vec2f)`(a: f32, r: f32) -> vec2f {
   return vec2f(a - r, a + r);
@@ -375,7 +375,7 @@ const neighborhood = tgpu.fn([d.f32, d.f32], d.vec2f)`(a: f32, r: f32) -> vec2f 
 Since type information is already present in the shell, the WGSL header can be simplified to include only the argument names.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 // ---cut---
 const neighborhood = tgpu.fn([d.f32, d.f32], d.vec2f)`(a, r) {
@@ -388,7 +388,7 @@ const neighborhood = tgpu.fn([d.f32, d.f32], d.vec2f)`(a, r) {
 If you're using Visual Studio Code, you can use [this extension](https://marketplace.visualstudio.com/items?itemName=ggsimm.wgsl-literal) that brings syntax highlighting to code fragments marked with `/* wgsl */` comments.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const neighborhood = tgpu.fn([d.f32, d.f32], d.vec2f)/* wgsl */`(a, r) {
   return vec2f(a - r, a + r);
@@ -402,7 +402,7 @@ Shelled WGSL functions can use external resources passed via the `$uses` method.
 *Externals* can include anything that can be resolved to WGSL by TypeGPU (numbers, vectors, matrices, constants, TypeGPU functions, buffer usages, textures, samplers, slots, accessors etc.).
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 // ---cut---
 const getBlue = tgpu.fn([], d.vec4f)`() {
@@ -488,7 +488,7 @@ Since TypeGPU wraps `IORecord`s into automatically generated structs, you can al
 - `workgroupSize` -- a JS array of 1-3 numbers that corresponds to the `@workgroup_size` attribute.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -547,7 +547,7 @@ struct mainCompute_Input {
 - `out` -- `d.vec4f`, or an `IORecord` describing the output of the function.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const getGradientColor = tgpu.fn([d.f32], d.vec4f)``;
 // ---cut---
@@ -628,7 +628,7 @@ Pipelines are an *unstable* feature. The API may be subject to change in the nea
 Typed functions are crucial for simplified [pipeline](/TypeGPU/apis/pipelines) creation offered by TypeGPU. You can define and run pipelines as follows:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const context = undefined as any;
 const presentationFormat = "rgba8unorm";

--- a/apps/typegpu-docs/src/content/docs/apis/pipelines.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/pipelines.mdx
@@ -21,7 +21,7 @@ A pipeline can be defined with one of the following methods on the [root](/TypeG
 
 ```ts twoslash
 /// <reference types="@webgpu/types" />
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -73,7 +73,7 @@ The `createRenderPipeline` method creates a render pipeline by accepting an opti
 The vertex function's input parameters (non-builtin) are matched to vertex attributes specified in the pipeline's vertex layout when executing. Vertex attributes are validated at the type level for compatibility.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 const presentationFormat = 'rgba8unorm';
@@ -123,7 +123,7 @@ When a custom location is provided by the user (via the `d.location` attribute f
 as long as there is no conflict between vertex and fragment location values.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const vertex = tgpu.vertexFn({
   out: { pos: d.builtin.position },
@@ -152,7 +152,7 @@ The `createComputePipeline` method creates a compute pipeline by accepting an op
 - `compute`: The `TgpuComputeFn` to use as the compute shader.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -176,7 +176,7 @@ Instead of dispatching workgroups, the guarded pipeline allows calling an exact 
 Under the hood, it creates a compute pipeline that calls the provided callback only if the current thread ID is within the requested range.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const data = root.createMutable(d.arrayOf(d.u32, 8), [0, 1, 2, 3, 4, 5, 6, 7]);
@@ -210,7 +210,7 @@ Buffer initialization commonly uses random number generators.
 For that, you can use the [`@typegpu/noise`](TypeGPU/ecosystem/typegpu-noise) library.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 import { randf } from '@typegpu/noise';
 
@@ -342,7 +342,7 @@ Compute pipelines are executed using the `dispatchWorkgroups` method, which acce
 The `drawIndexed` is analogous to draw, but takes advantage of [index buffer](/TypeGPU/apis/buffers/#index-buffers) to explicitly map vertex data onto primitives. When using an index buffer, you don't need to list every vertex for every primitive explicitly. Instead, you provide a list of unique vertices in a vertex buffer. Then, the index buffer defines how these vertices are connected to form primitives.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 const presentationFormat = "rgba8unorm";
@@ -428,7 +428,7 @@ That way, they can be used with a regular WebGPU API, but unlike the `root['~uns
 resources.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 

--- a/apps/typegpu-docs/src/content/docs/apis/resolve.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/resolve.mdx
@@ -15,7 +15,7 @@ The `tgpu.resolve` API takes in TypeGPU resources (and optionally a WGSL templat
 The first `tgpu.resolve` overload takes in an array of items to resolve, and an optional argument with options. Here's a simple example:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const Boid = d.struct({
   size: d.f32,
@@ -57,7 +57,7 @@ As you may note, the resolved WGSL code contains exactly the set of definitions 
 You can also resolve other resources, like consts, buffers, textures, entry point functions or even entire pipelines. Here's an example with a pipeline:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const root = await tgpu.init();
 
@@ -116,7 +116,7 @@ Use it when you are already provided with existing WGSL code and want to extend 
 Here's an example:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -156,7 +156,7 @@ As you may note, in this case `tgpu.resolve` uses the structure of the `external
 Here is another example. Assume, that the bind group index `0` is already taken by some existing code:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const LightSource = d.struct({
   ambientColor: d.vec3f,
@@ -269,7 +269,7 @@ For these cases, you can use `tgpu.resolveWithContext`, which has the same input
 An example, where the "catchall" bind group is created:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -293,7 +293,7 @@ console.log(catchall?.[1]); // the catchall bind group
 An example, where a bind group layout is automatically included via a TypeScript function:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---

--- a/apps/typegpu-docs/src/content/docs/apis/roots.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/roots.mdx
@@ -16,7 +16,7 @@ It requests a GPU device with default requirements. An optional parameter
 can be passed in with special requirements for the GPU device.
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 
 const root = await tgpu.init();
 ```
@@ -24,7 +24,7 @@ const root = await tgpu.init();
 If you already have a device that you want to use, you can pass it into `tgpu.initFromDevice` instead.
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 
 const adapter = await navigator.gpu.requestAdapter();
 const device = await adapter?.requestDevice() as GPUDevice;
@@ -42,7 +42,7 @@ To retrieve the device that is associated with a root, you can use the `root.dev
 In order to draw on a canvas, you need to create and configure a context that will be later passed to a pipeline. 
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 const root = await tgpu.init();
 const canvas = {} as HTMLCanvasElement;
 // ---cut---
@@ -56,7 +56,7 @@ context.configure({
 ```
 TypeGPU streamlines this process with `root.configureContext` method.
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 const root = await tgpu.init();
 const canvas = {} as HTMLCanvasElement;
 // ---cut---

--- a/apps/typegpu-docs/src/content/docs/apis/slots.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/slots.mdx
@@ -20,7 +20,7 @@ Main use cases for slots include:
 A slot is created using the `tgpu.slot()` function and can optionally take a default value:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const filterColorSlot = tgpu.slot<d.v3f>(); // Slot for a 3D vector.
 const mySlot = tgpu.slot<number>(42); // Slot with a default value.
@@ -53,7 +53,7 @@ Instead, you can bind it in one of two ways.
 The first way to bind a value to a slot is to call the `with` method on a wrapped TypeGPU function:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const filterColorSlot = tgpu.slot<d.v3f>();
 
@@ -91,7 +91,7 @@ fn filter_1(color: vec3f) ->  vec3f{
 The other way to fill in a slot is to call the `with` method during the creation of a `TgpuComputePipeline` or `TgpuRenderPipeline`:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -129,7 +129,7 @@ They enable internal behavior to be modified without sacrificing type safety or 
 
 ```ts twoslash
 // physics.ts
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { add, mul } from 'typegpu/std';
 
 const root = await tgpu.init();
@@ -186,7 +186,7 @@ Slots can be used for conditional compilation of segments of shaders.
 When the slot holding a boolean value is filled with `false`, all `if` statements depending on the value of that slot will be pruned by our tree-shaking mechanism.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { max } from 'typegpu/std';
 
 const root = await tgpu.init();
@@ -222,7 +222,7 @@ const processObjects = tgpu.fn([])(() => {
 It is possible to use slots even in TypeGPU functions that are implemented in WGSL:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const colorSlot = tgpu.slot(d.vec3f(1, 0, 0));
 

--- a/apps/typegpu-docs/src/content/docs/apis/textures.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/textures.mdx
@@ -17,7 +17,7 @@ TypeGPU textures serve as a wrapper that provides type safety and higher level u
 Let's look at an example of creating and using a typed texture.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -54,7 +54,7 @@ type TextureProps = {
 ```
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const texture = root.createTexture({
@@ -71,7 +71,7 @@ const texture = root.createTexture({
 Similar to buffers, textures need usage flags to specify how they will be used. You can add usage flags using the `.$usage(...)` method.
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const texture = root.createTexture({
@@ -86,7 +86,7 @@ const texture = root.createTexture({
 You can also add multiple flags at once:
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const texture = root.createTexture({
@@ -119,7 +119,7 @@ You can write various image sources to textures. `ExternalImageSource` includes:
 - `VideoFrame`
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const texture = root.createTexture({
@@ -149,7 +149,7 @@ If image dimensions don't match the texture size, the image will be automaticall
 For 3D textures or texture arrays, you can write multiple images:
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 const root = await tgpu.init();
 declare const imageBitmap1: ImageBitmap;
 declare const imageBitmap2: ImageBitmap;
@@ -170,7 +170,7 @@ texture3d.write([imageBitmap1, imageBitmap2, imageBitmap3]);
 You can write raw binary data directly to textures using `ArrayBuffer`, typed arrays, or `DataView`:
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const texture = root.createTexture({
@@ -195,7 +195,7 @@ texture.write(mipData, 1); // Write to mip level 1
 You can also copy from another texture:
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const sourceTexture = root.createTexture({
@@ -216,7 +216,7 @@ targetTexture.copyFrom(sourceTexture);
 TypeGPU provides automatic mipmap generation for textures:
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 const root = await tgpu.init();
 declare const imageBitmap: ImageBitmap;
 // ---cut---
@@ -239,7 +239,7 @@ The `generateMipmaps()` method requires both `'sampled'` and `'render'` usage fl
 To create a view - which will also serve as fixed texture usage - you can use one of the available [texture schemas](/TypeGPU/apis/data-schemas/#textures). You can pass it to the `.createView` method of the texture.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const texture = root.createTexture({
@@ -257,7 +257,7 @@ const sampledView = texture.createView(d.texture2d(d.f32));
 If type information is available the view schema will be staticly checked against the texture properties.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const texture = root.createTexture({
@@ -270,7 +270,7 @@ const sampledView = texture.createView(d.texture2d(d.f32));
 ```
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const texture = root.createTexture({
@@ -288,7 +288,7 @@ const sampledView = texture.createView(d.textureStorage2d('rgba8unorm')); // <--
 To sample textures in shaders, you'll often need a sampler that defines how the texture should be filtered and addressed. The `createSampler` method accepts the same descriptor as the vanilla WebGPU `GPUSamplerDescriptor`:
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const sampler = root.createSampler({
@@ -309,7 +309,7 @@ Textures can be used in shaders through bind groups or as fixed resources, simil
 ### Manual binding
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const texture = root.createTexture({
@@ -340,7 +340,7 @@ const bindGroup = root.createBindGroup(bindGroupLayout, {
 For textures that remain consistent across operations, you can create fixed texture views:
 
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const texture = root.createTexture({

--- a/apps/typegpu-docs/src/content/docs/apis/utils.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/utils.mdx
@@ -9,7 +9,7 @@ When working on top of some existing shader code, sometimes you may know for cer
 In such scenario you can use `tgpu['~unstable'].rawCodeSnippet` -- an advanced API that creates a typed shader expression which can be injected into the final shader bundle upon use.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 // ---cut---
 // `EXISTING_GLOBAL` is an identifier that we know will be in the
@@ -62,7 +62,7 @@ tgpu.resolve([innerPipeline]);
 This can be used to precompute and inject a value into the final shader code.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 // ---cut---
 const color = tgpu.comptime((int: number) => {
@@ -98,7 +98,7 @@ Comptime-known conditions include:
 - values returned by `comptime` functions.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 // ---cut---
 const counterEnabledSlot = tgpu.slot<boolean>(false);
@@ -129,7 +129,7 @@ since we treat `tgpu.const` as a way to opt-out of inlining.
 Branch pruning also works for ternary operators.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 const counterEnabledSlot = tgpu.slot<boolean>(false);
 const counter = root.createMutable(d.u32);
@@ -150,7 +150,7 @@ When working on top of some existing shader code, sometimes you may know for cer
 In such scenario you can use `tgpu['~unstable'].rawCodeSnippet` -- an advanced API that creates a typed shader expression which can be injected into the final shader bundle upon use.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 // ---cut---
 // `EXISTING_GLOBAL` is an identifier that we know will be in the
@@ -193,7 +193,7 @@ Yes, you read that correctly, TypeGPU implements logging to the console on the G
 Just call `console.log` like you would in plain JavaScript, and open the console to see the results.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -220,7 +220,7 @@ The buffer is of fixed size, which may limit the total amount of information tha
 If that's an issue, you may specify the size manually when creating the `root` object.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const presentationFormat = undefined as any;
 const canvas = undefined as any;
@@ -273,7 +273,7 @@ This is due to a [WebGPU limitation](https://www.w3.org/TR/WGSL/#address-space) 
 TypeGPU supports `for...of...` loops in shader functions. The only constraints are that the loop variable must be declared with `const` and the iterable must be stored in a variable.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const processNeighbor = (cell: d.v2i) => {};
 
@@ -303,7 +303,7 @@ For code with small, fixed iteration counts, you can use `tgpu.unroll` to unroll
 Wrap your iterable with `tgpu.unroll()`:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const processNeighbor = (cell: d.v2i) => {};
 

--- a/apps/typegpu-docs/src/content/docs/apis/variables.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/variables.mdx
@@ -11,7 +11,7 @@ For example, in the code snippet below, the external `counter` is automatically 
 In this case, the group and index match the automatically generated "catchall" bind group, used for fixed, "bindless" resources.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -53,7 +53,7 @@ struct increment_Input {
 For variables of `private` and `workgroup` address spaces, TypeGPU provides `tgpu.privateVar()` and `tgpu.workgroupVar()` constructor functions.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -82,7 +82,7 @@ In JS, a `const` is a reference that cannot be reassigned, while in WGSL, it mea
 Therefore, to use the WGSL `const`, TypeGPU provides `tgpu.const()`, an interface analogous to `tgpu.privateVar()` and `tgpu.workgroupVar()`, with the only difference being that the previously optional init value is now required.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 const Boid = d.struct({
   pos: d.vec3f,

--- a/apps/typegpu-docs/src/content/docs/apis/vertex-layouts.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/vertex-layouts.mdx
@@ -18,7 +18,7 @@ Vertex layouts are much like bind group layouts, in that they define the relatio
 To create a vertex layout, use the `tgpu.vertexLayout` function. It takes an array schema constructor, i.e., partially applied `d.arrayOf` or `d.disarrayOf`. To determine what each element of the array corresponds to, you can pass an optional `stepMode` argument, which can be either `vertex` (default) or `instance`.
 
 ```ts
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const ParticleGeometry = d.struct({
   tilt: d.f32,

--- a/apps/typegpu-docs/src/content/docs/blog/typegpu-0.11/index.mdx
+++ b/apps/typegpu-docs/src/content/docs/blog/typegpu-0.11/index.mdx
@@ -255,7 +255,7 @@ There has been a lot of work outside of the `typegpu` package, both internally a
 Aleksander Katan ([@aleksanderkatan](https://github.com/aleksanderkatan)) has been working behind the scenes on an ESLint/Oxlint plugin, capable of catching user errors that types cannot.
 
 ```ts
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 function increment(n: number) {
   'use gpu';

--- a/apps/typegpu-docs/src/content/docs/ecosystem/typegpu-noise.mdx
+++ b/apps/typegpu-docs/src/content/docs/ecosystem/typegpu-noise.mdx
@@ -24,7 +24,7 @@ Calling utility functions from [TypeGPU functions](/TypeGPU/apis/functions/) lin
 In the example below, resolving `randomVec2f` into a shader will include the code for `randf.sample` and all of its dependencies.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 import { randf } from '@typegpu/noise';
 
@@ -50,7 +50,7 @@ import { d } from 'typegpu';
 // ---cut---
 import { randf } from '@typegpu/noise';
 // `typegpu` is necessary to inject library code into your custom shader
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 
 const shader = tgpu.resolve({
   template: `
@@ -81,7 +81,7 @@ Each call to `randf.sample` returns the next random float in the sequence, allow
 using a set of `randf.seedN` functions, where `N` is the number of components our seed has.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { randf } from '@typegpu/noise';
 
 const main = tgpu.fragmentFn({
@@ -144,7 +144,7 @@ The package exports an implementation for both 2D and 3D Perlin noise, `perlin2d
 Using it is as simple as calling the `.sample` function with the desired coordinates, and it returns a value in the range `[-1, 1]`.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 import { perlin2d } from '@typegpu/noise';
 
@@ -165,7 +165,7 @@ To improve performance, you can precompute the gradients using either a *Static*
 A static cache presumes that the domain of the noise function is fixed, and cannot change between shader invocations.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 import { perlin3d } from '@typegpu/noise';
 
@@ -189,7 +189,7 @@ Or in WebGPU:
 import { d } from 'typegpu';
 
 declare const device: GPUDevice;
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { perlin3d } from '@typegpu/noise';
 
 // ---cut---
@@ -221,7 +221,7 @@ without having to recompile the shader, you have to use a dynamic cache. With it
 complex setup.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { perlin3d } from '@typegpu/noise';
 
 const main = tgpu.computeFn({ workgroupSize: [1] })(() => {
@@ -266,7 +266,7 @@ The package provides convenient way to change PRNG as needed.
 You can easily implement your own PRNG and plug it into the pipeline.
 
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { randf } from '@typegpu/noise';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/content/docs/ecosystem/typegpu-radiance-cascades.mdx
+++ b/apps/typegpu-docs/src/content/docs/ecosystem/typegpu-radiance-cascades.mdx
@@ -29,7 +29,7 @@ The package currently focuses on 2D radiance fields. It expects distances in UV-
 ```ts twoslash
 import * as rc from '@typegpu/radiance-cascades';
 import * as sdf from '@typegpu/sdf';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const root = await tgpu.init();
 const previewSize = { width: 512, height: 512 };
@@ -87,7 +87,7 @@ A common setup is to generate an SDF texture with [`@typegpu/sdf`](/TypeGPU/ecos
 ```ts
 import * as rc from '@typegpu/radiance-cascades';
 import * as sdf from '@typegpu/sdf';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const root = await tgpu.init();
 const floodSize = { width: 2048, height: 2048 };

--- a/apps/typegpu-docs/src/content/docs/ecosystem/typegpu-sdf.mdx
+++ b/apps/typegpu-docs/src/content/docs/ecosystem/typegpu-sdf.mdx
@@ -37,7 +37,7 @@ Resolving the function includes the SDF code and its dependencies automatically.
 </div>
 
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import * as sdf from '@typegpu/sdf';
 
 const renderRoundedBox = tgpu.fn([d.vec2f], d.vec4f)((uv) => {
@@ -65,7 +65,7 @@ The package includes a few common operators. They take distances as input, so yo
 </div>
 
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import * as sdf from '@typegpu/sdf';
 
 const sceneSdf = tgpu.fn([d.vec2f], d.f32)((p) => {
@@ -102,7 +102,7 @@ The 3D primitives follow the same rules as the 2D ones. They are useful for ray 
 </div>
 
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import * as sdf from '@typegpu/sdf';
 
 const sceneSdf = tgpu.fn([d.vec3f], d.f32)((p) => {
@@ -185,7 +185,7 @@ Here the source shape is a triangle mask baked into a texture first, then jump f
 </div>
 
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import * as sdf from '@typegpu/sdf';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/content/docs/ecosystem/typegpu-three/index.mdx
+++ b/apps/typegpu-docs/src/content/docs/ecosystem/typegpu-three/index.mdx
@@ -60,7 +60,7 @@ Calling `t3.toTSL` with a TypeGPU function will return a TSL node, which can the
 <div class="flex-1 w-auto min-w-[0]">
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 import * as THREE from 'three/webgpu';
 import * as t3 from '@typegpu/three';
@@ -112,7 +112,7 @@ There are a handful of builtin TSL node accessors in the `t3` namespace:
 <div class="flex-1 w-auto min-w-[0]">
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 // ---cut---
 import * as THREE from 'three/webgpu';
 import * as t3 from '@typegpu/three';
@@ -138,7 +138,7 @@ Other TypeGPU functions (user-defined or from libraries) can be called to achiev
 <div class="flex-1 w-auto min-w-[0]">
 
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 // ---cut---
 import { perlin3d } from '@typegpu/noise';
 import * as THREE from 'three/webgpu';

--- a/apps/typegpu-docs/src/content/docs/fundamentals/compute-shaders.mdx
+++ b/apps/typegpu-docs/src/content/docs/fundamentals/compute-shaders.mdx
@@ -11,7 +11,7 @@ In the previous section, we went over the basics of creating compute shaders and
 So far, most of our shaders have looked like this:
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -45,7 +45,7 @@ We still have to be careful not to read or write outside the bounds of the array
 If the dispatch size might be larger than the buffer length, guard the array access inside the shader:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -81,7 +81,7 @@ This is a useful analogy for understanding how the thread index maps to data. Bu
 When one thread reads data that another thread may be writing, the loop analogy breaks down:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -149,7 +149,7 @@ Laid out resources split the setup into two pieces:
 The layout is created first, without providing any actual buffers. For buffers, each layout entry uses the same schema we would use to create the buffer. If the entry is a storage buffer, it can also include an access mode:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const bindGroupLayout = tgpu.bindGroupLayout({
   counter: { storage: d.u32, access: 'mutable' },
@@ -170,7 +170,7 @@ Storage entries are readonly by default, so `{ storage: d.u32 }` and `{ storage:
 To provide the resources, create a bind group with `root.createBindGroup(layout, entries)`:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -192,7 +192,7 @@ const bindGroup = root.createBindGroup(bindGroupLayout, {
 Because bind group entries are typed, providing a resource with the wrong schema or usage is a TypeScript error.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -221,7 +221,7 @@ Now the same simulation step can be written in either style. The Fixed Resources
 <Tabs>
   <TabItem label="Laid Out Resources">
     ```ts twoslash {13-16, 18-21}
-    import tgpu, { d } from 'typegpu';
+    import { tgpu, d } from 'typegpu';
 
     const root = await tgpu.init();
 
@@ -255,7 +255,7 @@ Now the same simulation step can be written in either style. The Fixed Resources
   </TabItem>
   <TabItem label="Fixed Resources">
     ```ts twoslash {10-11}
-    import tgpu, { d } from 'typegpu';
+    import { tgpu, d } from 'typegpu';
 
     const root = await tgpu.init();
 

--- a/apps/typegpu-docs/src/content/docs/fundamentals/vertices-and-fragments.mdx
+++ b/apps/typegpu-docs/src/content/docs/fundamentals/vertices-and-fragments.mdx
@@ -29,7 +29,7 @@ The code itself works on a canvas of any size.
 :::
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -70,7 +70,7 @@ Let us go through the code step by step.
 1. **Initialize the `root`**, just like we did in a previous guide.
 
    ```ts
-   import tgpu, { d } from 'typegpu';
+   import { tgpu, d } from 'typegpu';
 
    const root = await tgpu.init();
    ```
@@ -148,7 +148,7 @@ We can actually return more values.
 In the example below, we pass in an additional color prop.
 
 ```ts twoslash {12-18, 20, 22}
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
@@ -238,7 +238,7 @@ In all examples above, we draw once and stop.
 To animate, two things change: we call `pipeline.draw()` every frame, and we pass a value from JS into the shader that each frame can vary.
 
 ```ts twoslash {1, 13-15, 23-28}
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const root = await tgpu.init();
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;
@@ -291,7 +291,7 @@ To draw bigger points and lines, people usually use many triangles to approximat
 There is however a different approach, that skips the geometry altogether.
 
 ```ts twoslash
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { fullScreenTriangle } from 'typegpu/common';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/content/docs/fundamentals/your-first-gpu-program.mdx
+++ b/apps/typegpu-docs/src/content/docs/fundamentals/your-first-gpu-program.mdx
@@ -19,7 +19,7 @@ Most code snippets on this page are inspectable: hover over an identifier to see
 :::
 
 ```ts twoslash
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -84,7 +84,7 @@ That gives us a few useful properties:
 Let's use that to create a simple GPU program that actually writes data to GPU memory.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -118,7 +118,7 @@ This is useful for fast debugging, but `console.log` only displays the value. It
 In the previous examples, we used `createMutable()` without paying much attention to what it creates. In short, it allocates GPU memory that can be accessed directly from a TypeGPU shader and modified from shader code. You might wonder why you could not just do something like:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -141,7 +141,7 @@ That is why we use buffers for state that the GPU can read or write. You can thi
 The `createMutable()` function is a shorthand for creating a storage buffer and viewing it as mutable:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 
@@ -170,7 +170,7 @@ So far, we know how to allocate GPU buffers, update them from inside shaders, an
 With our current knowledge, we could just write a shader that writes some values to the buffer:
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -198,7 +198,7 @@ This will work correctly (as long as we always want to increment by 10), and som
 Because this version always increments by `10`, we could also drop the `incrementBy` field from our GPU state and capture a JavaScript constant instead. Captured constants are inlined into the generated shader, so this only works for values that do not need to change at runtime.
 
 ```ts twoslash
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ---cut---
@@ -228,7 +228,7 @@ As we can see, our program grew quite a bit. Let's examine what changed:
 1. **Add a new value to our GPU state**, which we will use to control each increment step. We used `d.struct`, which works exactly like you would expect a struct to: it lets us group data together.
 
    ```ts twoslash
-   import tgpu, { d } from 'typegpu';
+   import { tgpu, d } from 'typegpu';
 
    const root = await tgpu.init();
 
@@ -241,7 +241,7 @@ As we can see, our program grew quite a bit. Let's examine what changed:
 2. **Add initial data.** Apart from the schema, buffer constructors also take a second argument, which lets you efficiently write data at buffer creation time.
 
    ```ts twoslash
-   import tgpu, { d } from 'typegpu';
+   import { tgpu, d } from 'typegpu';
 
    const root = await tgpu.init();
 
@@ -257,7 +257,7 @@ As we can see, our program grew quite a bit. Let's examine what changed:
    This data will be typed according to the schema, so there is no byte counting involved. If you want to modify a buffer after it has been created, you can use the `.write()` method, which takes the same data shape.
 
    ```ts twoslash
-   import tgpu, { d } from 'typegpu';
+   import { tgpu, d } from 'typegpu';
 
    const root = await tgpu.init();
 
@@ -276,7 +276,7 @@ As we can see, our program grew quite a bit. Let's examine what changed:
 3. **Update the shader code** so that it uses the new field and increments `counter` by the current `incrementBy` value.
 
    ```ts twoslash
-   import tgpu, { d } from 'typegpu';
+   import { tgpu, d } from 'typegpu';
 
    const root = await tgpu.init();
 
@@ -295,7 +295,7 @@ As we can see, our program grew quite a bit. Let's examine what changed:
 4. **Use `.patch()` to update just one buffer field.** By default, `.write()` expects you to write the entire buffer at once. Since we do not have the current `counter` value available on the CPU side, we would need to read it each time (or track mirrored state on the CPU) - in short, not something we want to do. The `.patch()` API allows us to pass a subset of the buffer and write only the present values.
 
    ```ts twoslash
-   import tgpu, { d } from 'typegpu';
+   import { tgpu, d } from 'typegpu';
 
    const root = await tgpu.init();
 

--- a/apps/typegpu-docs/src/content/docs/integration/react-native/index.mdx
+++ b/apps/typegpu-docs/src/content/docs/integration/react-native/index.mdx
@@ -127,7 +127,7 @@ that you can use in your app:
 ```ts
 import { useMemo } from 'react';
 import { Canvas } from 'react-native-webgpu';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { useRoot, useFrame, useConfigureContext } from '@typegpu/react';
 
 const positions = tgpu.const(d.arrayOf(d.vec2f), [

--- a/apps/typegpu-docs/src/content/docs/integration/webgpu-interoperability.mdx
+++ b/apps/typegpu-docs/src/content/docs/integration/webgpu-interoperability.mdx
@@ -12,7 +12,7 @@ The **non-contagious** nature of TypeGPU means that ejecting out, in case raw We
 Some of the following code snippets assume that TypeGPU is already initialized.
 
 ```ts
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 // ...or pass in an existing WebGPU device

--- a/apps/typegpu-docs/src/content/docs/integration/wesl-interoperability.mdx
+++ b/apps/typegpu-docs/src/content/docs/integration/wesl-interoperability.mdx
@@ -105,7 +105,7 @@ reified references to any struct definition.
 import { Fish } from './shaders/shared.wesl?typegpu';
 // ---cut-start---
 // @filename: ./main.ts
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 const root = await tgpu.init();
 const BoidState = d.struct({
   position: d.vec3f,

--- a/apps/typegpu-docs/src/content/docs/tooling/tgpu-gen.mdx
+++ b/apps/typegpu-docs/src/content/docs/tooling/tgpu-gen.mdx
@@ -209,7 +209,7 @@ The generated TypeScript definitions look like this:
   <summary>Click to see the content</summary>
   ```typescript
   /* generated via tgpu-gen by TypeGPU */
-  import tgpu from 'typegpu';
+  import { tgpu } from 'typegpu';
   import * as d from 'typegpu/data';
 
   /* structs */

--- a/apps/typegpu-docs/src/content/docs/tooling/unplugin-typegpu.mdx
+++ b/apps/typegpu-docs/src/content/docs/tooling/unplugin-typegpu.mdx
@@ -13,7 +13,7 @@ The package includes the following functionalities:
   The parsing of JavaScript happens ahead of time, emitting a highly compact AST format, called [tinyest](https://www.npmjs.com/package/tinyest).
 
   ```ts
-  import tgpu, { d } from 'typegpu';
+  import { tgpu, d } from 'typegpu';
 
   // Found by the plugin and decorated with 'tinyest' metadata
   const add = (a: number, b: number) => {

--- a/apps/typegpu-docs/src/content/docs/tutorials/game-of-life/index.mdx
+++ b/apps/typegpu-docs/src/content/docs/tutorials/game-of-life/index.mdx
@@ -33,7 +33,7 @@ Canvas’ inner width and height need to be adjusted to its outer properties mul
 Then, start off with TypeGPU by creating its [`root`](/TypeGPU/apis/roots/) object:
 
 ```ts
-import tgpu from "typegpu";
+import { tgpu } from "typegpu";
 const root = await tgpu.init();
 ```
 

--- a/apps/typegpu-docs/src/content/docs/tutorials/triangle-to-boids/code/step1-typegpu.ts
+++ b/apps/typegpu-docs/src/content/docs/tutorials/triangle-to-boids/code/step1-typegpu.ts
@@ -2,7 +2,7 @@
 // TODO: ^ REMOVE WHEN CODE WORKS AGAIN
 
 import { addElement, onFrame } from '@typegpu/example-toolkit';
-import tgpu, { builtin } from 'typegpu/experimental';
+import { tgpu, builtin } from 'typegpu/experimental';
 
 const root = await tgpu.init();
 

--- a/apps/typegpu-docs/src/content/docs/tutorials/triangle-to-boids/index.mdx
+++ b/apps/typegpu-docs/src/content/docs/tutorials/triangle-to-boids/index.mdx
@@ -43,7 +43,7 @@ This setup will mostly look very similar in every project that draws something t
 <Tabs>
   <TabItem label="triangle.ts">
   ```ts
-  import tgpu from 'typegpu';
+  import { tgpu } from 'typegpu';
 
   // Create the root
   const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/bitonic-sort/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import {
   type BitonicSorter,
   type BitonicSorterOptions,

--- a/apps/typegpu-docs/src/examples/algorithms/concurrent-chart/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/concurrent-chart/index.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 import { performCalculationsWithTime } from './calculator.ts';
 

--- a/apps/typegpu-docs/src/examples/algorithms/genetic-racing/ga.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/genetic-racing/ga.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import type { TgpuRoot, TgpuUniform } from 'typegpu';
 
 export const MAX_POP = 65536;

--- a/apps/typegpu-docs/src/examples/algorithms/genetic-racing/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/genetic-racing/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 import { generateGridTrack, type TrackResult } from './track.ts';
 import {

--- a/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { distanceFrag } from './visualization.ts';
 import {
   BrushParams,

--- a/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/types.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/types.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, type SampledFlag, type StorageFlag, type TgpuTexture } from 'typegpu';
+import { tgpu, d, type SampledFlag, type StorageFlag, type TgpuTexture } from 'typegpu';
 
 export const VisualizationParams = d.struct({
   showInside: d.u32,

--- a/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/visualization.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/jump-flood-distance/visualization.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { distSampleLayout, paramsAccess } from './types.ts';
 
 const outsideGradient = tgpu.const(d.arrayOf(d.vec3f, 5), [

--- a/apps/typegpu-docs/src/examples/algorithms/jump-flood-voronoi/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/jump-flood-voronoi/index.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import type { SampledFlag, StorageFlag, TgpuTexture } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 

--- a/apps/typegpu-docs/src/examples/algorithms/matrix-multiplication/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/matrix-multiplication/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const WORKGROUP_SIZE = [8, 8] as [number, number];

--- a/apps/typegpu-docs/src/examples/algorithms/matrix-next/computeShared.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/matrix-next/computeShared.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { TILE_SIZE, WORKGROUP_SIZE } from './params.ts';
 import { computeLayout } from './types.ts';
 

--- a/apps/typegpu-docs/src/examples/algorithms/matrix-next/computeSimple.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/matrix-next/computeSimple.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { getIndex } from './computeShared.ts';
 import { WORKGROUP_SIZE } from './params.ts';
 import { computeLayout } from './types.ts';

--- a/apps/typegpu-docs/src/examples/algorithms/matrix-next/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/matrix-next/index.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { INITIAL_MAX_MATRIX_SIZE, TILE_SIZE } from './params.ts';
 import { type CalculationStrategy, computeLayout, createMatrixData, MatrixInfo } from './types.ts';
 import { computeSharedMemory } from './computeShared.ts';

--- a/apps/typegpu-docs/src/examples/algorithms/matrix-next/types.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/matrix-next/types.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 export type CalculationStrategy = 'gpu-optimized' | 'gpu-simple' | 'cpu';
 

--- a/apps/typegpu-docs/src/examples/algorithms/mnist-inference/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/mnist-inference/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import type { LayerData, Network } from './data.ts';
 import { downloadLayers } from './helpers.ts';
 import { defineControls } from '../../common/defineControls.ts';

--- a/apps/typegpu-docs/src/examples/algorithms/probability/executor.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/probability/executor.ts
@@ -10,7 +10,7 @@ import type {
   TgpuRoot,
   TgpuSlot,
 } from 'typegpu';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 export class Executor {
   // don't exceed max workgroup grid X dimension size

--- a/apps/typegpu-docs/src/examples/algorithms/probability/helpers.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/probability/helpers.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 import * as c from './constants.ts';
 import { Distribution, PlotType, type PRNG } from './types.ts';

--- a/apps/typegpu-docs/src/examples/algorithms/probability/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/probability/index.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 
 import { Plotter } from './plotter.ts';
 import { Executor } from './executor.ts';

--- a/apps/typegpu-docs/src/examples/geometry/circles/index.ts
+++ b/apps/typegpu-docs/src/examples/geometry/circles/index.ts
@@ -1,5 +1,5 @@
 import { circle, circleVertexCount } from '@typegpu/geometry';
-import tgpu, { d, std as s } from 'typegpu';
+import { tgpu, d, std as s } from 'typegpu';
 
 const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 const canvas = document.querySelector('canvas');

--- a/apps/typegpu-docs/src/examples/geometry/lines-combinations/index.ts
+++ b/apps/typegpu-docs/src/examples/geometry/lines-combinations/index.ts
@@ -10,7 +10,7 @@ import {
   startCapSlot,
   arrowCapParamsSlot,
 } from '@typegpu/geometry';
-import tgpu, { type ColorAttachment } from 'typegpu';
+import { tgpu, type ColorAttachment } from 'typegpu';
 import {
   arrayOf,
   builtin,

--- a/apps/typegpu-docs/src/examples/geometry/lines-combinations/testCases.ts
+++ b/apps/typegpu-docs/src/examples/geometry/lines-combinations/testCases.ts
@@ -1,6 +1,6 @@
 import { LineControlPoint } from '@typegpu/geometry';
 import { perlin2d, randf } from '@typegpu/noise';
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { arrayOf, f32, i32, mat2x2f, u32, vec2f } from 'typegpu/data';
 import { abs, clamp, cos, floor, max, pow, select, sin } from 'typegpu/std';
 import { TEST_SEGMENT_COUNT } from './constants.ts';

--- a/apps/typegpu-docs/src/examples/image-processing/ascii-filter/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/ascii-filter/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d, std, type TgpuBindGroup } from 'typegpu';
+import { tgpu, common, d, std, type TgpuBindGroup } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/image-processing/background-segmentation/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/background-segmentation/index.ts
@@ -1,5 +1,5 @@
 import type { RenderFlag, SampledFlag, StorageFlag, TgpuBindGroup, TgpuTexture } from 'typegpu';
-import tgpu, { common, d } from 'typegpu';
+import { tgpu, common, d } from 'typegpu';
 
 import { MODEL_HEIGHT, MODEL_WIDTH, MODELS, prepareSession } from './model.ts';
 import {

--- a/apps/typegpu-docs/src/examples/image-processing/background-segmentation/schemas.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/background-segmentation/schemas.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 // constants
 

--- a/apps/typegpu-docs/src/examples/image-processing/background-segmentation/shaders.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/background-segmentation/shaders.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std, type TgpuFragmentFn } from 'typegpu';
+import { tgpu, d, std, type TgpuFragmentFn } from 'typegpu';
 import { MODEL_HEIGHT, MODEL_WIDTH } from './model.ts';
 import {
   blockDim,

--- a/apps/typegpu-docs/src/examples/image-processing/blur/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/blur/index.ts
@@ -1,7 +1,7 @@
 // Original implementation:
 // https://webgpu.github.io/webgpu-samples/?sample=imageBlur
 
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/image-processing/camera-thresholding/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/camera-thresholding/index.ts
@@ -1,5 +1,5 @@
 import { rgbToYcbcrMatrix } from '@typegpu/color';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const textureLayout = tgpu.bindGroupLayout({

--- a/apps/typegpu-docs/src/examples/image-processing/chroma-keying/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/chroma-keying/index.ts
@@ -1,5 +1,5 @@
 import { rgbToYcbcrMatrix } from '@typegpu/color';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/image-processing/image-tuning/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/image-tuning/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 type LUTData = {

--- a/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/index.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import type { TgpuBindGroup } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 import {

--- a/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/inference/kernels/compute.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/inference/kernels/compute.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { BroadcastFlag } from '../bundle.ts';
 import {
   binaryLayout,

--- a/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/inference/kernels/helpers.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/inference/kernels/helpers.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { headLayout, weightedLayout } from './layouts.ts';
 
 export type Vec4Op = (value: d.v4f) => d.v4f;

--- a/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/inference/kernels/layouts.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/inference/kernels/layouts.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 export const WeightedOffsets = d.struct({
   weightBase: d.u32,

--- a/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/inference/video-preprocess.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/inference/video-preprocess.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import type { TgpuBindGroup, TgpuRoot } from 'typegpu';
 import { FrameCropParams, initialFrameCropParams, type VideoFrameCrop } from '../frame.ts';
 import { WORKGROUP_SIZE, type Vec4Buffer } from './kernels/types.ts';

--- a/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/post-processing/kernels.ts
+++ b/apps/typegpu-docs/src/examples/image-processing/selfie-segmentation/post-processing/kernels.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { initialFrameCropParams } from '../frame.ts';
 
 const MODEL_WIDTH = 256;

--- a/apps/typegpu-docs/src/examples/react/confetti/index.tsx
+++ b/apps/typegpu-docs/src/examples/react/confetti/index.tsx
@@ -1,4 +1,4 @@
-import tgpu, { d, std, type TgpuBuffer, type TgpuVertexFn } from 'typegpu';
+import { tgpu, d, std, type TgpuBuffer, type TgpuVertexFn } from 'typegpu';
 import {
   useFrame,
   useRoot,

--- a/apps/typegpu-docs/src/examples/react/spinning-triangle/index.tsx
+++ b/apps/typegpu-docs/src/examples/react/spinning-triangle/index.tsx
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { hexToOklab, oklabToRgb } from '@typegpu/color';
 import { useConfigureContext, useFrame, useRoot, useUniform } from '@typegpu/react';
 import React, { useMemo } from 'react';

--- a/apps/typegpu-docs/src/examples/rendering/3d-fish/compute.ts
+++ b/apps/typegpu-docs/src/examples/rendering/3d-fish/compute.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import * as p from './params.ts';
 import { computeBindGroupLayout as layout } from './schemas.ts';
 import { projectPointOnLine } from './tgsl-helpers.ts';

--- a/apps/typegpu-docs/src/examples/rendering/3d-fish/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/3d-fish/index.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import * as m from 'wgpu-matrix';
 import { simulate } from './compute.ts';
 import { loadModel } from './load-model.ts';

--- a/apps/typegpu-docs/src/examples/rendering/3d-fish/render.ts
+++ b/apps/typegpu-docs/src/examples/rendering/3d-fish/render.ts
@@ -1,5 +1,5 @@
 import { hsvToRgb, rgbToHsv } from '@typegpu/color';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import * as p from './params.ts';
 import { ModelVertexInput, ModelVertexOutput, renderBindGroupLayout as layout } from './schemas.ts';
 import { applySinWave, PosAndNormal } from './tgsl-helpers.ts';

--- a/apps/typegpu-docs/src/examples/rendering/3d-fish/schemas.ts
+++ b/apps/typegpu-docs/src/examples/rendering/3d-fish/schemas.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 // schemas
 

--- a/apps/typegpu-docs/src/examples/rendering/box-raytracing/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/box-raytracing/index.ts
@@ -1,5 +1,5 @@
 import { linearToSrgb, srgbToLinear } from '@typegpu/color';
-import tgpu, { d, type TgpuFragmentFn, type TgpuVertexFn } from 'typegpu';
+import { tgpu, d, type TgpuFragmentFn, type TgpuVertexFn } from 'typegpu';
 import { discard, max, min, mul, normalize, pow, sub } from 'typegpu/std';
 import { mat4 } from 'wgpu-matrix';
 import { defineControls } from '../../common/defineControls.ts';

--- a/apps/typegpu-docs/src/examples/rendering/caustics/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/caustics/index.ts
@@ -1,5 +1,5 @@
 import { perlin3d } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const mainVertex = tgpu.vertexFn({

--- a/apps/typegpu-docs/src/examples/rendering/clouds/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/clouds/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import {
   FOV_FACTOR,
   NOISE_TEXTURE_SIZE,

--- a/apps/typegpu-docs/src/examples/rendering/clouds/types.ts
+++ b/apps/typegpu-docs/src/examples/rendering/clouds/types.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 export const CloudsParams = d.struct({
   time: d.f32,

--- a/apps/typegpu-docs/src/examples/rendering/clouds/utils.ts
+++ b/apps/typegpu-docs/src/examples/rendering/clouds/utils.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import {
   CLOUD_AMPLITUDE,
   CLOUD_BRIGHT,

--- a/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/icosphere.ts
+++ b/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/icosphere.ts
@@ -1,5 +1,5 @@
 import type { TgpuBuffer, TgpuComputePipeline, TgpuRoot, UniformFlag, VertexFlag } from 'typegpu';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { ComputeVertex, Vertex } from './dataTypes.ts';
 import { calculateMidpoint, getAverageNormal, packVec2u, unpackVec2u } from './helpers.ts';
 

--- a/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import * as m from 'wgpu-matrix';
 import { type CubemapNames, cubeVertices, loadCubemap } from './cubemap.ts';
 import { Camera, CubeVertex, DirectionalLight, Material, Vertex } from './dataTypes.ts';

--- a/apps/typegpu-docs/src/examples/rendering/disco/consts.ts
+++ b/apps/typegpu-docs/src/examples/rendering/disco/consts.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 export const timeAccess = tgpu.accessor(d.f32);
 export const resolutionAccess = tgpu.accessor(d.vec2f); // (width, height)

--- a/apps/typegpu-docs/src/examples/rendering/disco/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/disco/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { resolutionAccess, timeAccess } from './consts.ts';
 import {
   mainFragment1,

--- a/apps/typegpu-docs/src/examples/rendering/disco/shaders/fragment.ts
+++ b/apps/typegpu-docs/src/examples/rendering/disco/shaders/fragment.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { resolutionAccess, timeAccess } from '../consts.ts';
 import { palette } from '../utils.ts';
 

--- a/apps/typegpu-docs/src/examples/rendering/disco/shaders/vertex.ts
+++ b/apps/typegpu-docs/src/examples/rendering/disco/shaders/vertex.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 export const mainVertex = tgpu.vertexFn({
   in: { vertexIndex: d.builtin.vertexIndex },

--- a/apps/typegpu-docs/src/examples/rendering/function-visualizer/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/function-visualizer/index.ts
@@ -1,5 +1,5 @@
 import type { TgpuGuardedComputePipeline, TgpuRawCodeSnippet } from 'typegpu';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { mat4 } from 'wgpu-matrix';
 import { defineControls } from '../../common/defineControls.ts';
 

--- a/apps/typegpu-docs/src/examples/rendering/jelly-slider/dataTypes.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-slider/dataTypes.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 export const DirectionalLight = d.struct({
   direction: d.vec3f,

--- a/apps/typegpu-docs/src/examples/rendering/jelly-slider/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-slider/index.ts
@@ -1,5 +1,5 @@
 import * as sdf from '@typegpu/sdf';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 
 import { randf } from '@typegpu/noise';
 import { Slider } from './slider.ts';

--- a/apps/typegpu-docs/src/examples/rendering/jelly-slider/taa.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-slider/taa.ts
@@ -1,5 +1,5 @@
 import type { TgpuComputePipeline, TgpuRoot, TgpuTextureView } from 'typegpu';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { taaResolveLayout } from './dataTypes.ts';
 
 export const taaResolveFn = tgpu.computeFn({

--- a/apps/typegpu-docs/src/examples/rendering/jelly-switch/dataTypes.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-switch/dataTypes.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 export const DirectionalLight = d.struct({
   direction: d.vec3f,

--- a/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-switch/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import * as sdf from '@typegpu/sdf';
 
 import { randf } from '@typegpu/noise';

--- a/apps/typegpu-docs/src/examples/rendering/jelly-switch/taa.ts
+++ b/apps/typegpu-docs/src/examples/rendering/jelly-switch/taa.ts
@@ -1,5 +1,5 @@
 import type { TgpuComputePipeline, TgpuRoot, TgpuTextureView } from 'typegpu';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { taaResolveLayout } from './dataTypes.ts';
 
 export const taaResolveFn = tgpu.computeFn({

--- a/apps/typegpu-docs/src/examples/rendering/os-awards/cubemap.ts
+++ b/apps/typegpu-docs/src/examples/rendering/os-awards/cubemap.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std, type TgpuRoot } from 'typegpu';
+import { tgpu, d, std, type TgpuRoot } from 'typegpu';
 
 const convertLayout = tgpu.bindGroupLayout({
   equirect: { texture: d.texture2d(d.f32) },

--- a/apps/typegpu-docs/src/examples/rendering/os-awards/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/os-awards/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import * as m from 'wgpu-matrix';
 import { directionToEquirectUv, loadEnvironmentCubemap } from './cubemap.ts';
 import { loadModel, ModelVertex } from './model.ts';

--- a/apps/typegpu-docs/src/examples/rendering/perlin-noise/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/perlin-noise/index.ts
@@ -1,5 +1,5 @@
 import { perlin3d } from '@typegpu/noise';
-import tgpu, { common, d } from 'typegpu';
+import { tgpu, common, d } from 'typegpu';
 import { abs, mix, mul, pow, sign, tanh } from 'typegpu/std';
 import { defineControls } from '../../common/defineControls.ts';
 

--- a/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/phong-reflection/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import * as p from './params.ts';
 import {
   ExampleControls,

--- a/apps/typegpu-docs/src/examples/rendering/phong-reflection/schemas.ts
+++ b/apps/typegpu-docs/src/examples/rendering/phong-reflection/schemas.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 // schemas
 

--- a/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { BoxGeometry } from './box-geometry.ts';
 import { Camera } from './camera.ts';
 import { PointLight } from './point-light.ts';

--- a/apps/typegpu-docs/src/examples/rendering/point-light-shadow/types.ts
+++ b/apps/typegpu-docs/src/examples/rendering/point-light-shadow/types.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 export const CameraData = d.struct({
   viewProjectionMatrix: d.mat4x4f,

--- a/apps/typegpu-docs/src/examples/rendering/pom/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/pom/index.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { d, std, type RenderFlag, type TgpuTexture } from 'typegpu';
+import { tgpu, d, std, type RenderFlag, type TgpuTexture } from 'typegpu';
 import { Camera, setupOrbitCamera } from '../../common/setup-orbit-camera.ts';
 import { defineControls } from '../../common/defineControls.ts';
 import {

--- a/apps/typegpu-docs/src/examples/rendering/pom/types.ts
+++ b/apps/typegpu-docs/src/examples/rendering/pom/types.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 export const Vertex = d.struct({
   position: d.vec3f,

--- a/apps/typegpu-docs/src/examples/rendering/radiance-cascades-drawing/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/radiance-cascades-drawing/index.ts
@@ -1,6 +1,6 @@
 import * as rc from '@typegpu/radiance-cascades';
 import * as sdf from '@typegpu/sdf';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 import { createDrawInteraction } from './drawInteraction.ts';
 

--- a/apps/typegpu-docs/src/examples/rendering/radiance-cascades/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/radiance-cascades/index.ts
@@ -4,7 +4,7 @@
 // and the packaged example:
 // https://docs.swmansion.com/TypeGPU/examples#example=rendering--radiance-cascades-drawing
 import * as sdf from '@typegpu/sdf';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 import { DragController } from './drag-controller.ts';
 import { SceneData, sceneData, sceneDataAccess, sceneSDF, updateElementPosition } from './scene.ts';

--- a/apps/typegpu-docs/src/examples/rendering/radiance-cascades/scene.ts
+++ b/apps/typegpu-docs/src/examples/rendering/radiance-cascades/scene.ts
@@ -1,5 +1,5 @@
 import * as sdf from '@typegpu/sdf';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 export interface SceneElement<T extends 'box' | 'disk'> {
   id: string;

--- a/apps/typegpu-docs/src/examples/rendering/ray-marching/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/ray-marching/index.ts
@@ -1,5 +1,5 @@
 import { sdBoxFrame3d, sdPlane, sdSphere } from '@typegpu/sdf';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const root = await tgpu.init();
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles-with/index.ts
@@ -1,5 +1,5 @@
 import { perlin2d } from '@typegpu/noise';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import * as m from 'wgpu-matrix';
 import { defineControls } from '../../common/defineControls.ts';
 import { setupOrbitCamera } from '../../common/setup-orbit-camera.ts';

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles-with/schemas.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles-with/schemas.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { Camera } from '../../common/setup-orbit-camera.ts';
 
 export { Camera };

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles-with/shaders.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles-with/shaders.ts
@@ -1,5 +1,5 @@
 import { perlin2d } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { cameraLayout, cubeLayout, terrainLayout, Vertex } from './schemas.ts';
 
 const LOW_COLOR = d.vec3f(0.28, 0.52, 0.3);

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles/index.ts
@@ -1,5 +1,5 @@
 import { perlin2d } from '@typegpu/noise';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import * as m from 'wgpu-matrix';
 import { defineControls } from '../../common/defineControls.ts';
 import { setupOrbitCamera } from '../../common/setup-orbit-camera.ts';

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles/schemas.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles/schemas.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { Camera } from '../../common/setup-orbit-camera.ts';
 
 export { Camera };

--- a/apps/typegpu-docs/src/examples/rendering/render-bundles/shaders.ts
+++ b/apps/typegpu-docs/src/examples/rendering/render-bundles/shaders.ts
@@ -1,5 +1,5 @@
 import { perlin2d } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { cameraLayout, cubeLayout, terrainLayout, Vertex } from './schemas.ts';
 
 const LOW_COLOR = d.vec3f(0.28, 0.52, 0.3);

--- a/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/simple-shadow/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { mat4 } from 'wgpu-matrix';
 import { createCuboid, createPlane } from './geometry.ts';
 import {

--- a/apps/typegpu-docs/src/examples/rendering/simple-shadow/schema.ts
+++ b/apps/typegpu-docs/src/examples/rendering/simple-shadow/schema.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 // Data structures
 export const Material = d.struct({

--- a/apps/typegpu-docs/src/examples/rendering/smoky-triangle/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/smoky-triangle/index.ts
@@ -1,5 +1,5 @@
 import { perlin3d } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const Params = d.struct({
   fromColor: d.vec3f,

--- a/apps/typegpu-docs/src/examples/rendering/suika-sdf/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/suika-sdf/index.ts
@@ -1,5 +1,5 @@
 import * as sdf from '@typegpu/sdf';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { fullScreenTriangle } from 'typegpu/common';
 import {
   DROP_Y,

--- a/apps/typegpu-docs/src/examples/rendering/suika-sdf/sdfGen.ts
+++ b/apps/typegpu-docs/src/examples/rendering/suika-sdf/sdfGen.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import type { SampledFlag, TgpuRoot, TgpuSampler, TgpuTexture } from 'typegpu';
 import { LEVEL_COUNT } from './constants.ts';
 

--- a/apps/typegpu-docs/src/examples/rendering/two-boxes/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/two-boxes/index.ts
@@ -1,5 +1,5 @@
 import type { RenderFlag, TgpuBindGroup, TgpuBuffer, TgpuTexture, VertexFlag } from 'typegpu';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import * as m from 'wgpu-matrix';
 
 // Initialization

--- a/apps/typegpu-docs/src/examples/rendering/xor-dev-centrifuge-2/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/xor-dev-centrifuge-2/index.ts
@@ -10,7 +10,7 @@
  * ```
  */
 
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { abs, atan2, cos, gt, length, normalize, select, sign, tanh } from 'typegpu/std';
 import { defineControls } from '../../common/defineControls.ts';
 

--- a/apps/typegpu-docs/src/examples/rendering/xor-dev-runner/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/xor-dev-runner/index.ts
@@ -12,7 +12,7 @@
  * ```
  */
 
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { abs, add, cos, max, min, mul, select, sign, sin, sub, tanh } from 'typegpu/std';
 import { defineControls } from '../../common/defineControls.ts';
 import { Camera, setupFirstPersonCamera } from '../../common/setup-first-person-camera.ts';

--- a/apps/typegpu-docs/src/examples/simple/gradient-tiles/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/gradient-tiles/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/simple/increment/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/increment/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/simple/liquid-glass/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/liquid-glass/index.ts
@@ -1,5 +1,5 @@
 import { sdRoundedBox2d } from '@typegpu/sdf';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/simple/mesh-skinning/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/mesh-skinning/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { common } from 'typegpu';
+import { tgpu, common } from 'typegpu';
 import * as d from 'typegpu/data';
 import * as std from 'typegpu/std';
 import { mat4, vec3 } from 'wgpu-matrix';

--- a/apps/typegpu-docs/src/examples/simple/oklab/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/oklab/index.ts
@@ -5,7 +5,7 @@ import {
   oklabToLinearRgb,
   oklabToRgb,
 } from '@typegpu/color';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const cssProbePosition = d.vec2f(0.5, 0.5);

--- a/apps/typegpu-docs/src/examples/simple/ripple-cube/background.ts
+++ b/apps/typegpu-docs/src/examples/simple/ripple-cube/background.ts
@@ -1,6 +1,6 @@
 import { perlin3d, randf } from '@typegpu/noise';
 import type { TgpuRoot, TgpuTextureView } from 'typegpu';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { CUBEMAP_SIZE } from './constants.ts';
 
 const spaceNebula = (rd: d.v3f): d.v3f => {

--- a/apps/typegpu-docs/src/examples/simple/ripple-cube/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/ripple-cube/index.ts
@@ -1,6 +1,6 @@
 import { perlin3d, randf } from '@typegpu/noise';
 import * as sdf from '@typegpu/sdf';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { Camera, setupOrbitCamera } from '../../common/setup-orbit-camera.ts';
 import { createBackgroundCubemap } from './background.ts';
 import { GRID_SIZE, halton, LIGHT_COUNT, MAX_DIST, MAX_STEPS, SURF_DIST } from './constants.ts';

--- a/apps/typegpu-docs/src/examples/simple/ripple-cube/pbr.ts
+++ b/apps/typegpu-docs/src/examples/simple/ripple-cube/pbr.ts
@@ -1,5 +1,5 @@
 import { perlin3d } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { LIGHT_COUNT, PI } from './constants.ts';
 
 import { Light, Material } from './types.ts';

--- a/apps/typegpu-docs/src/examples/simple/ripple-cube/post-processing.ts
+++ b/apps/typegpu-docs/src/examples/simple/ripple-cube/post-processing.ts
@@ -1,5 +1,5 @@
 import type { ColorAttachment, TgpuRoot } from 'typegpu';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { fullScreenTriangle } from 'typegpu/common';
 import { BLUR_RADIUS, TAA_BLEND } from './constants.ts';
 import { BloomParams } from './types.ts';

--- a/apps/typegpu-docs/src/examples/simple/ripple-cube/sdf-scene.ts
+++ b/apps/typegpu-docs/src/examples/simple/ripple-cube/sdf-scene.ts
@@ -1,5 +1,5 @@
 import * as sdf from '@typegpu/sdf';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 export const timeAccess = tgpu.accessor(d.f32);
 export const blendFactorAccess = tgpu.accessor(d.f32);

--- a/apps/typegpu-docs/src/examples/simple/square/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/square/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/simple/stencil/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/stencil/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 const root = await tgpu.init();
 const canvas = document.querySelector('canvas') as HTMLCanvasElement;

--- a/apps/typegpu-docs/src/examples/simple/triangle/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/triangle/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 // Constants and helper functions
 

--- a/apps/typegpu-docs/src/examples/simple/vaporrave/floor.ts
+++ b/apps/typegpu-docs/src/examples/simple/vaporrave/floor.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 import * as c from './constants.ts';
 

--- a/apps/typegpu-docs/src/examples/simple/vaporrave/helpers.ts
+++ b/apps/typegpu-docs/src/examples/simple/vaporrave/helpers.ts
@@ -1,4 +1,4 @@
-import tgpu, { std } from 'typegpu';
+import { tgpu, std } from 'typegpu';
 
 import { Ray } from './types.ts';
 

--- a/apps/typegpu-docs/src/examples/simple/vaporrave/index.ts
+++ b/apps/typegpu-docs/src/examples/simple/vaporrave/index.ts
@@ -1,6 +1,6 @@
 import { perlin3d } from '@typegpu/noise';
 import { sdPlane } from '@typegpu/sdf';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 import * as c from './constants.ts';
 import { circles, grid } from './floor.ts';

--- a/apps/typegpu-docs/src/examples/simple/vaporrave/sphere.ts
+++ b/apps/typegpu-docs/src/examples/simple/vaporrave/sphere.ts
@@ -1,6 +1,6 @@
 import { perlin3d } from '@typegpu/noise';
 import { sdSphere } from '@typegpu/sdf';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 import * as c from './constants.ts';
 import { Ray } from './types.ts';

--- a/apps/typegpu-docs/src/examples/simulation/boids/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/boids/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const triangleAmount = 1000;

--- a/apps/typegpu-docs/src/examples/simulation/confetti/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/confetti/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 // constants

--- a/apps/typegpu-docs/src/examples/simulation/fluid-double-buffering/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/fluid-double-buffering/index.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { d, std, type TgpuBufferMutable, type TgpuBufferReadonly } from 'typegpu';
+import { tgpu, d, std, type TgpuBufferMutable, type TgpuBufferReadonly } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const MAX_GRID_SIZE = 1024;

--- a/apps/typegpu-docs/src/examples/simulation/fluid-with-atomics/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/fluid-with-atomics/index.ts
@@ -1,5 +1,5 @@
 import { sdLine } from '@typegpu/sdf';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/simulation/game-of-life/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/game-of-life/index.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import type { SampledFlag, StorageFlag, TgpuBindGroup, TgpuComputeFn, TgpuTexture } from 'typegpu';
 import { computeLayout, displayLayout, gameSizeAccessor, TILE_SIZE } from './shaders/common.ts';
 import { tiledCompute } from './shaders/tiled-compute.ts';

--- a/apps/typegpu-docs/src/examples/simulation/game-of-life/shaders/bitpacked-compute.ts
+++ b/apps/typegpu-docs/src/examples/simulation/game-of-life/shaders/bitpacked-compute.ts
@@ -1,6 +1,6 @@
 import * as d from 'typegpu/data';
 import * as std from 'typegpu/std';
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { computeLayout, gameSizeAccessor, TILE_SIZE } from './common.ts';
 
 // oxfmt-ignore

--- a/apps/typegpu-docs/src/examples/simulation/game-of-life/shaders/common.ts
+++ b/apps/typegpu-docs/src/examples/simulation/game-of-life/shaders/common.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import * as d from 'typegpu/data';
 import * as std from 'typegpu/std';
 

--- a/apps/typegpu-docs/src/examples/simulation/game-of-life/shaders/fragment.ts
+++ b/apps/typegpu-docs/src/examples/simulation/game-of-life/shaders/fragment.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import * as d from 'typegpu/data';
 import * as std from 'typegpu/std';
 

--- a/apps/typegpu-docs/src/examples/simulation/game-of-life/shaders/naive-compute.ts
+++ b/apps/typegpu-docs/src/examples/simulation/game-of-life/shaders/naive-compute.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import * as d from 'typegpu/data';
 import * as std from 'typegpu/std';
 import { computeLayout, gameSizeAccessor, loadTexAt, TILE_SIZE } from './common.ts';

--- a/apps/typegpu-docs/src/examples/simulation/game-of-life/shaders/tiled-compute.ts
+++ b/apps/typegpu-docs/src/examples/simulation/game-of-life/shaders/tiled-compute.ts
@@ -1,6 +1,6 @@
 import * as d from 'typegpu/data';
 import * as std from 'typegpu/std';
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { computeLayout, gameSizeAccessor, golNextState, TILE_SIZE } from './common.ts';
 
 const HALO = 1;

--- a/apps/typegpu-docs/src/examples/simulation/game-of-life/shaders/vertex.ts
+++ b/apps/typegpu-docs/src/examples/simulation/game-of-life/shaders/vertex.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import * as d from 'typegpu/data';
 import * as std from 'typegpu/std';
 

--- a/apps/typegpu-docs/src/examples/simulation/gravity/compute.ts
+++ b/apps/typegpu-docs/src/examples/simulation/gravity/compute.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { collisionBehaviors } from './enums.ts';
 import { radiusOf } from './helpers.ts';
 import { CelestialBody, computeLayout, timeAccess } from './schemas.ts';

--- a/apps/typegpu-docs/src/examples/simulation/gravity/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/gravity/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, type StorageFlag, type TgpuBindGroup, type TgpuBuffer } from 'typegpu';
+import { tgpu, d, type StorageFlag, type TgpuBindGroup, type TgpuBuffer } from 'typegpu';
 import { computeCollisionsShader, computeGravityShader } from './compute.ts';
 import {
   collisionBehaviors,

--- a/apps/typegpu-docs/src/examples/simulation/gravity/render.ts
+++ b/apps/typegpu-docs/src/examples/simulation/gravity/render.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { radiusOf } from './helpers.ts';
 import {
   cameraAccess,

--- a/apps/typegpu-docs/src/examples/simulation/gravity/schemas.ts
+++ b/apps/typegpu-docs/src/examples/simulation/gravity/schemas.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, type TgpuSampler } from 'typegpu';
+import { tgpu, d, type TgpuSampler } from 'typegpu';
 import { Camera } from '../../common/setup-orbit-camera.ts';
 
 export type CelestialBody = d.Infer<typeof CelestialBody>;

--- a/apps/typegpu-docs/src/examples/simulation/slime-mold-3d/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/slime-mold-3d/index.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import * as m from 'wgpu-matrix';
 import { defineControls } from '../../common/defineControls.ts';
 

--- a/apps/typegpu-docs/src/examples/simulation/slime-mold/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/slime-mold/index.ts
@@ -1,5 +1,5 @@
 import { randf } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/simulation/stable-fluid/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/stable-fluid/index.ts
@@ -1,4 +1,5 @@
-import tgpu, {
+import {
+  tgpu,
   d,
   type TgpuBindGroup,
   type TgpuComputeFn,

--- a/apps/typegpu-docs/src/examples/simulation/stable-fluid/render.ts
+++ b/apps/typegpu-docs/src/examples/simulation/stable-fluid/render.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { SIM_N } from './params.ts';
 
 export const renderLayout = tgpu.bindGroupLayout({

--- a/apps/typegpu-docs/src/examples/simulation/stable-fluid/simulation.ts
+++ b/apps/typegpu-docs/src/examples/simulation/stable-fluid/simulation.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import * as p from './params.ts';
 
 const getNeighbors = (coords: d.v2i, bounds: d.v2i): d.v2i[] => {

--- a/apps/typegpu-docs/src/examples/simulation/wind-map/index.ts
+++ b/apps/typegpu-docs/src/examples/simulation/wind-map/index.ts
@@ -6,7 +6,7 @@ import {
   polylineVariableWidth,
   startCapSlot,
 } from '@typegpu/geometry';
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { arrayOf, builtin, f32, i32, struct, u16, u32, vec2f, vec4f } from 'typegpu/data';
 import { clamp, mix, normalize, select } from 'typegpu/std';
 import { defineControls } from '../../common/defineControls.ts';

--- a/apps/typegpu-docs/src/examples/tests/buffer-write-benchmark/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/buffer-write-benchmark/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/tests/dispatch/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/dispatch/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const root = await tgpu.init();
 

--- a/apps/typegpu-docs/src/examples/tests/log-test/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/log-test/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std, type TgpuVertexFn } from 'typegpu';
+import { tgpu, d, std, type TgpuVertexFn } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init({

--- a/apps/typegpu-docs/src/examples/tests/prefix-scan/functions.ts
+++ b/apps/typegpu-docs/src/examples/tests/prefix-scan/functions.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import * as d from 'typegpu/data';
 import * as std from 'typegpu/std';
 import type { BinaryOp } from '@typegpu/sort';

--- a/apps/typegpu-docs/src/examples/tests/prefix-scan/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/prefix-scan/index.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import * as d from 'typegpu/data';
 import { type BinaryOp, prefixScan, scan } from '@typegpu/sort';
 import * as std from 'typegpu/std';

--- a/apps/typegpu-docs/src/examples/tests/rc-docs-examples/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/rc-docs-examples/index.ts
@@ -1,6 +1,6 @@
 import * as rc from '@typegpu/radiance-cascades';
 import * as sdf from '@typegpu/sdf';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/tests/sdf-docs-examples/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/sdf-docs-examples/index.ts
@@ -1,5 +1,5 @@
 import * as sdf from '@typegpu/sdf';
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/tests/texture-test/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/texture-test/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d } from 'typegpu';
+import { tgpu, common, d } from 'typegpu';
 import { defineControls } from '../../common/defineControls.ts';
 
 const root = await tgpu.init();

--- a/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/array-and-struct-constructors.ts
+++ b/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/array-and-struct-constructors.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const SimpleStruct = d.struct({ vec: d.vec2f });
 const SimpleArray = d.arrayOf(d.i32, 2);

--- a/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { arrayAndStructConstructorsTest } from './array-and-struct-constructors.ts';
 import { infixOperatorsTests } from './infix-operators.ts';
 import { logicalExpressionTests } from './logical-expressions.ts';

--- a/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/infix-operators.ts
+++ b/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/infix-operators.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const getVec = tgpu.fn([], d.vec3f)(() => d.vec3f(1, 2, 3));
 

--- a/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/logical-expressions.ts
+++ b/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/logical-expressions.ts
@@ -1,5 +1,5 @@
 // oxlint-disable typescript/no-unnecessary-boolean-literal-compare -- this is a test
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const Schema = d.struct({
   vec2b: d.vec2b,

--- a/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/matrix-ops.ts
+++ b/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/matrix-ops.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 // TODO: replace `s = s &&` with `s &&=` when implemented
 export const matrixOpsTests = tgpu.fn(

--- a/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/pointers.ts
+++ b/apps/typegpu-docs/src/examples/tests/tgsl-parsing-test/pointers.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const SimpleStruct = d.struct({ vec: d.vec2f });
 

--- a/apps/typegpu-docs/src/examples/tests/uniformity/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/uniformity/index.ts
@@ -1,5 +1,5 @@
 import { randf, randomGeneratorSlot } from '@typegpu/noise';
-import tgpu, { common, d, std, type TgpuRenderPipeline } from 'typegpu';
+import { tgpu, common, d, std, type TgpuRenderPipeline } from 'typegpu';
 
 import * as c from './constants.ts';
 import { getPRNG, type PRNG } from './prngs.ts';

--- a/apps/typegpu-docs/src/examples/tests/uniformity/lcg.ts
+++ b/apps/typegpu-docs/src/examples/tests/uniformity/lcg.ts
@@ -1,5 +1,5 @@
 import type { StatefulGenerator } from '@typegpu/noise';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 export const LCG: StatefulGenerator = (() => {
   const seed = tgpu.privateVar(d.u32);

--- a/apps/typegpu-docs/src/examples/tests/wgsl-resolution/index.ts
+++ b/apps/typegpu-docs/src/examples/tests/wgsl-resolution/index.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const root = await tgpu.init();
 

--- a/apps/typegpu-docs/src/examples/threejs/compute-cloth/triNoise.ts
+++ b/apps/typegpu-docs/src/examples/threejs/compute-cloth/triNoise.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const tri = (x: number): number => {
   'use gpu';

--- a/apps/typegpu-docs/src/examples/threejs/test-reused-functions/functions.ts
+++ b/apps/typegpu-docs/src/examples/threejs/test-reused-functions/functions.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 export const getColorA = () => {
   'use gpu';

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     'eslint-plugin-import/namespace': 'off',
     'eslint-plugin-import/extensions': ['error', 'always', { ignorePackages: true }],
     'eslint-plugin-internal/no-useless-path-segments': 'error',
-    'eslint-plugin-internal/no-tgpu-namespace-import': 'error',
+    'eslint-plugin-internal/no-tgpu-default-import': 'error',
   },
   ignorePatterns: ['**/*.astro', '**/*.mjs'],
   overrides: [

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     'eslint-plugin-import/no-named-as-default-member': 'off',
     'eslint-plugin-import/extensions': ['error', 'always', { ignorePackages: true }],
     'eslint-plugin-internal/no-useless-path-segments': 'error',
+    'eslint-plugin-internal/no-tgpu-namespace-import': 'error',
   },
   ignorePatterns: ['**/*.astro', '**/*.mjs'],
   overrides: [

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     'eslint-plugin-unicorn/prefer-add-event-listener': 'off',
     'eslint-plugin-import/no-named-as-default': 'off',
     'eslint-plugin-import/no-named-as-default-member': 'off',
+    'eslint-plugin-import/namespace': 'off',
     'eslint-plugin-import/extensions': ['error', 'always', { ignorePackages: true }],
     'eslint-plugin-internal/no-useless-path-segments': 'error',
     'eslint-plugin-internal/no-tgpu-namespace-import': 'error',

--- a/packages/eslint-plugin-internal/src/index.ts
+++ b/packages/eslint-plugin-internal/src/index.ts
@@ -1,7 +1,7 @@
 import pkg from '../package.json' with { type: 'json' };
 import type { TSESLint } from '@typescript-eslint/utils';
 import { noUselessPathSegments } from './rules/noUselessPathSegments.ts';
-import { noTgpuNamespaceImport } from './rules/noTgpuNamespaceImport.ts';
+import { noTgpuDefaultImport } from './rules/noTgpuDefaultImport.ts';
 
 const plugin = {
   meta: {
@@ -10,7 +10,7 @@ const plugin = {
   },
   rules: {
     'no-useless-path-segments': noUselessPathSegments,
-    'no-tgpu-namespace-import': noTgpuNamespaceImport,
+    'no-tgpu-default-import': noTgpuDefaultImport,
   },
 } satisfies TSESLint.FlatConfig.Plugin;
 

--- a/packages/eslint-plugin-internal/src/index.ts
+++ b/packages/eslint-plugin-internal/src/index.ts
@@ -1,6 +1,7 @@
 import pkg from '../package.json' with { type: 'json' };
 import type { TSESLint } from '@typescript-eslint/utils';
 import { noUselessPathSegments } from './rules/noUselessPathSegments.ts';
+import { noTgpuNamespaceImport } from './rules/noTgpuNamespaceImport.ts';
 
 const plugin = {
   meta: {
@@ -9,6 +10,7 @@ const plugin = {
   },
   rules: {
     'no-useless-path-segments': noUselessPathSegments,
+    'no-tgpu-namespace-import': noTgpuNamespaceImport,
   },
 } satisfies TSESLint.FlatConfig.Plugin;
 

--- a/packages/eslint-plugin-internal/src/rules/noTgpuDefaultImport.ts
+++ b/packages/eslint-plugin-internal/src/rules/noTgpuDefaultImport.ts
@@ -1,7 +1,7 @@
 import { createRule } from '../ruleCreator.ts';
 
-export const noTgpuNamespaceImport = createRule({
-  name: 'no-tgpu-namespace-import',
+export const noTgpuDefaultImport = createRule({
+  name: 'no-tgpu-default-import',
   meta: {
     type: 'suggestion',
     docs: {

--- a/packages/eslint-plugin-internal/src/rules/noTgpuNamespaceImport.ts
+++ b/packages/eslint-plugin-internal/src/rules/noTgpuNamespaceImport.ts
@@ -1,0 +1,36 @@
+import { createRule } from '../ruleCreator.ts';
+
+export const noTgpuNamespaceImport = createRule({
+  name: 'no-tgpu-namespace-import',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow `import tgpu`',
+    },
+    messages: {
+      oldImport: '`import tgpu` should be replaced with `import { tgpu }`.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (
+          node.specifiers.some(
+            (specifier) =>
+              (specifier.type === 'ImportDefaultSpecifier' ||
+                specifier.type === 'ImportNamespaceSpecifier') &&
+              specifier.local.name === 'tgpu',
+          )
+        ) {
+          context.report({
+            node,
+            messageId: 'oldImport',
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-internal/src/rules/noTgpuNamespaceImport.ts
+++ b/packages/eslint-plugin-internal/src/rules/noTgpuNamespaceImport.ts
@@ -20,9 +20,7 @@ export const noTgpuNamespaceImport = createRule({
         if (
           node.specifiers.some(
             (specifier) =>
-              (specifier.type === 'ImportDefaultSpecifier' ||
-                specifier.type === 'ImportNamespaceSpecifier') &&
-              specifier.local.name === 'tgpu',
+              specifier.type === 'ImportDefaultSpecifier' && specifier.local.name === 'tgpu',
           )
         ) {
           context.report({

--- a/packages/eslint-plugin-internal/tests/rules/noTgpuDefaultImport.test.ts
+++ b/packages/eslint-plugin-internal/tests/rules/noTgpuDefaultImport.test.ts
@@ -1,9 +1,9 @@
 import { describe } from 'vitest';
 import { ruleTester } from '../utils/ruleTester.ts';
-import { noTgpuNamespaceImport } from '../../src/rules/noTgpuNamespaceImport.ts';
+import { noTgpuDefaultImport } from '../../src/rules/noTgpuDefaultImport.ts';
 
-describe('noTgpuNamespaceImport', () => {
-  ruleTester.run('noTgpuNamespaceImport', noTgpuNamespaceImport, {
+describe('noTgpuDefaultImport', () => {
+  ruleTester.run('noTgpuDefaultImport', noTgpuDefaultImport, {
     valid: [
       { code: "import { tgpu } from 'typegpu';" },
       { code: 'import { tgpu, d } from "typegpu";' },

--- a/packages/eslint-plugin-internal/tests/rules/noTgpuNamespaceImport.test.ts
+++ b/packages/eslint-plugin-internal/tests/rules/noTgpuNamespaceImport.test.ts
@@ -1,0 +1,32 @@
+import { describe } from 'vitest';
+import { ruleTester } from '../utils/ruleTester.ts';
+import { noTgpuNamespaceImport } from '../../src/rules/noTgpuNamespaceImport.ts';
+
+describe('noTgpuNamespaceImport', () => {
+  ruleTester.run('noTgpuNamespaceImport', noTgpuNamespaceImport, {
+    valid: [
+      { code: "import { tgpu } from 'typegpu';" },
+      { code: 'import { tgpu, d } from "typegpu";' },
+      { code: "import { tgpu } from '../../../src/index.js';" },
+      { code: "import { tgpu, d } from '../../../src/index.js';" },
+    ],
+    invalid: [
+      {
+        code: "import tgpu from 'typegpu';",
+        errors: [{ messageId: 'oldImport' }],
+      },
+      {
+        code: "import * as tgpu from 'typegpu';",
+        errors: [{ messageId: 'oldImport' }],
+      },
+      {
+        code: "import tgpu, { d } from 'typegpu';",
+        errors: [{ messageId: 'oldImport' }],
+      },
+      {
+        code: "import tgpu from '../../../src/index.js';",
+        errors: [{ messageId: 'oldImport' }],
+      },
+    ],
+  });
+});

--- a/packages/eslint-plugin-internal/tests/rules/noTgpuNamespaceImport.test.ts
+++ b/packages/eslint-plugin-internal/tests/rules/noTgpuNamespaceImport.test.ts
@@ -16,10 +16,6 @@ describe('noTgpuNamespaceImport', () => {
         errors: [{ messageId: 'oldImport' }],
       },
       {
-        code: "import * as tgpu from 'typegpu';",
-        errors: [{ messageId: 'oldImport' }],
-      },
-      {
         code: "import tgpu, { d } from 'typegpu';",
         errors: [{ messageId: 'oldImport' }],
       },

--- a/packages/tgpu-gen/gen.mjs
+++ b/packages/tgpu-gen/gen.mjs
@@ -493,14 +493,14 @@ function generateImports(options) {
   return [
     options.usedImports?.tgpu
       ? options.moduleSyntax === 'commonjs'
-        ? "const tgpu = require('typegpu').default;"
+        ? "const { tgpu } = require('typegpu').default;"
         : "import tgpu from 'typegpu';"
       : null,
 
     options.usedImports?.data
       ? options.moduleSyntax === 'commonjs'
-        ? "const d = require('typegpu/data');"
-        : "import * as d from 'typegpu/data';"
+        ? "const { d } = require('typegpu');"
+        : "import { d } from 'typegpu';"
       : null,
   ]
     .filter((imp) => !!imp)

--- a/packages/tgpu-gen/gen.mjs
+++ b/packages/tgpu-gen/gen.mjs
@@ -493,8 +493,8 @@ function generateImports(options) {
   return [
     options.usedImports?.tgpu
       ? options.moduleSyntax === 'commonjs'
-        ? "const { tgpu } = require('typegpu').default;"
-        : "import tgpu from 'typegpu';"
+        ? "const { tgpu } = require('typegpu');"
+        : "import { tgpu } from 'typegpu';"
       : null,
 
     options.usedImports?.data

--- a/packages/tgpu-gen/tests/bindGroupLayouts.test.ts
+++ b/packages/tgpu-gen/tests/bindGroupLayouts.test.ts
@@ -212,7 +212,7 @@ export const layout3 = tgpu.bindGroupLayout({
   });
 
   it('adds typegpu import to the generated code', () => {
-    const importStatement = "import tgpu from 'typegpu';";
+    const importStatement = "import { tgpu } from 'typegpu';";
 
     expect(generate('@binding(0) @group(0) var<uniform> a : f32;')).toContain(importStatement);
     expect(generate('')).not.toContain(importStatement);

--- a/packages/tgpu-gen/tests/functions.test.ts
+++ b/packages/tgpu-gen/tests/functions.test.ts
@@ -36,6 +36,6 @@ export const foo = tgpu.fn([])(/* wgsl */ \`() {
 
   it('adds tgpu import', () => {
     const wgsl = 'fn f() {}';
-    expect(generate(wgsl)).toContain("import tgpu from 'typegpu';");
+    expect(generate(wgsl)).toContain("import { tgpu } from 'typegpu';");
   });
 });

--- a/packages/tgpu-gen/tests/structs.test.ts
+++ b/packages/tgpu-gen/tests/structs.test.ts
@@ -212,7 +212,6 @@ export const Triangles = (arrayLength) => d.struct({
         outputPath: '',
         toTs: false,
         moduleSyntax: 'esmodule',
-        experimentalFunctions: false,
       }),
     ).toContain(expected);
   });
@@ -238,7 +237,6 @@ struct Triangles {
       outputPath: '',
       toTs: true,
       moduleSyntax: 'commonjs',
-      experimentalFunctions: false,
     });
 
     expect(generated).not.toContain(`\
@@ -254,8 +252,8 @@ const Triangles = (arrayLength: number) => d.struct({
     expect(generated).not.toContain('export const Vertex = d.struct({');
     expect(generated).toContain('const Vertex = d.struct({');
 
-    expect(generated).toContain("const d = require('typegpu/data');");
-    expect(generated).not.toContain("import * as d from 'typegpu/data';");
+    expect(generated).toContain("const { d } = require('typegpu');");
+    expect(generated).not.toContain("import { d } from 'typegpu';");
 
     expect(generated).toContain('module.exports = {Vertex, Triangle, Triangles};');
   });
@@ -283,7 +281,7 @@ struct D {
   });
 
   it('adds typegpu/data import to the generated code', () => {
-    const importStatement = "import * as d from 'typegpu/data';";
+    const importStatement = "import { d } from 'typegpu';";
 
     expect(generate('struct A { d: u32 };')).toContain(importStatement);
     expect(generate('')).not.toContain(importStatement);

--- a/packages/typegpu-cli/templates/template-vite-bare/src/main.ts
+++ b/packages/typegpu-cli/templates/template-vite-bare/src/main.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d } from 'typegpu';
+import { tgpu, common, d } from 'typegpu';
 
 const root = await tgpu.init();
 

--- a/packages/typegpu-cli/templates/template-vite-complex/src/main.ts
+++ b/packages/typegpu-cli/templates/template-vite-complex/src/main.ts
@@ -1,4 +1,4 @@
-import tgpu, { common, d, std } from 'typegpu';
+import { tgpu, common, d, std } from 'typegpu';
 import { hexToOklab, oklabToRgb } from '@typegpu/color';
 import { perlin2d } from '@typegpu/noise';
 

--- a/packages/typegpu-color/src/hex.ts
+++ b/packages/typegpu-color/src/hex.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { rgbToOklab } from './oklab.ts';
 
 export const hexToRgb = tgpu.comptime((hex: string | number): d.v3f => {

--- a/packages/typegpu-color/src/hsv.ts
+++ b/packages/typegpu-color/src/hsv.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { f32, vec3f } from 'typegpu/data';
 import { floor, max, min } from 'typegpu/std';
 

--- a/packages/typegpu-color/src/oklab.ts
+++ b/packages/typegpu-color/src/oklab.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { f32, struct, vec3f } from 'typegpu/data';
 import { abs, clamp, length, max, min, mix, pow, select, sign, sqrt } from 'typegpu/std';
 import { linearToSrgb, srgbToLinear } from './srgb.ts';

--- a/packages/typegpu-color/src/srgb.ts
+++ b/packages/typegpu-color/src/srgb.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { vec3f } from 'typegpu/data';
 import { gt, pow, select } from 'typegpu/std';
 

--- a/packages/typegpu-color/src/ycbcr.ts
+++ b/packages/typegpu-color/src/ycbcr.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { mat3x3f, vec3f } from 'typegpu/data';
 import { mul } from 'typegpu/std';
 

--- a/packages/typegpu-geometry/src/circle.ts
+++ b/packages/typegpu-geometry/src/circle.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { f32, struct, u32, vec2f } from 'typegpu/data';
 import { cos, select, sin } from 'typegpu/std';
 

--- a/packages/typegpu-geometry/src/lines/caps/arrow.ts
+++ b/packages/typegpu-geometry/src/lines/caps/arrow.ts
@@ -1,6 +1,6 @@
 import { vec2f } from 'typegpu/data';
 import type { JoinInput } from '../types.ts';
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 
 export const arrowCapParamsSlot = tgpu.slot({
   length: 7.5,

--- a/packages/typegpu-geometry/src/lines/externalNormals.ts
+++ b/packages/typegpu-geometry/src/lines/externalNormals.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import type { Infer } from 'typegpu/data';
 import { f32, struct, vec2f } from 'typegpu/data';
 import { dot, max, sqrt } from 'typegpu/std';

--- a/packages/typegpu-geometry/src/lines/joins/miter.ts
+++ b/packages/typegpu-geometry/src/lines/joins/miter.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import type { v2f } from 'typegpu/data';
 import { vec2f } from 'typegpu/data';
 import { dot, normalize, select } from 'typegpu/std';

--- a/packages/typegpu-geometry/src/lines/lineVariableWidth.ts
+++ b/packages/typegpu-geometry/src/lines/lineVariableWidth.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { u32, vec2f } from 'typegpu/data';
 import { dot, neg, normalize, select } from 'typegpu/std';
 import { externalNormals } from './externalNormals.ts';

--- a/packages/typegpu-geometry/src/lines/polylineVariableWidth.ts
+++ b/packages/typegpu-geometry/src/lines/polylineVariableWidth.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { u32, vec2f } from 'typegpu/data';
 import { dot, neg, normalize, select } from 'typegpu/std';
 import { intersectLines, rot90ccw, rot90cw } from '../utils.ts';

--- a/packages/typegpu-geometry/src/lines/slots.ts
+++ b/packages/typegpu-geometry/src/lines/slots.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { round } from './joins/round.ts';
 
 export const joinSlot = tgpu.slot(round);

--- a/packages/typegpu-geometry/src/utils.ts
+++ b/packages/typegpu-geometry/src/utils.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { bool, f32, struct, vec2f } from 'typegpu/data';
 import { dot, mix, normalize, select } from 'typegpu/std';
 

--- a/packages/typegpu-gl/src/initWithGLFallback.ts
+++ b/packages/typegpu-gl/src/initWithGLFallback.ts
@@ -1,4 +1,4 @@
-import tgpu, { type TgpuRoot } from 'typegpu';
+import { tgpu, type TgpuRoot } from 'typegpu';
 
 export async function initWithGLFallback(): Promise<TgpuRoot> {
   // Try WebGPU first

--- a/packages/typegpu-gl/src/tgpuRootWebGL.ts
+++ b/packages/typegpu-gl/src/tgpuRootWebGL.ts
@@ -6,7 +6,7 @@
  * Compute operations, storage buffers, textures, etc. throw WebGLFallbackUnsupportedError.
  */
 
-import tgpu, { d, type TgpuFragmentFn, type TgpuVertexFn } from 'typegpu';
+import { tgpu, d, type TgpuFragmentFn, type TgpuVertexFn } from 'typegpu';
 import type { ShaderGenerator } from 'typegpu/~internal';
 import glslGenerator, { translateWgslTypeToGlsl } from './glslGenerator.ts';
 

--- a/packages/typegpu-gl/tests/glslGenerator.test.ts
+++ b/packages/typegpu-gl/tests/glslGenerator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { glOptions } from '@typegpu/gl';
 import { translateWgslTypeToGlsl } from '../src/glslGenerator.ts';
 

--- a/packages/typegpu-gl/tests/webglFallback.test.ts
+++ b/packages/typegpu-gl/tests/webglFallback.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, vi } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { initWithGL } from '../src/index.ts';
 import { it } from './utils/extendedTest.ts';
 

--- a/packages/typegpu-noise/src/generator.ts
+++ b/packages/typegpu-noise/src/generator.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, type TgpuFnShell, type TgpuSlot } from 'typegpu';
+import { tgpu, d, type TgpuFnShell, type TgpuSlot } from 'typegpu';
 import { cos, dot, fract } from 'typegpu/std';
 
 export interface StatefulGenerator {

--- a/packages/typegpu-noise/src/perlin-2d/algorithm.ts
+++ b/packages/typegpu-noise/src/perlin-2d/algorithm.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { dot, floor, fract } from 'typegpu/std';
 import { randOnUnitCircle, randSeed2 } from '../random.ts';
 import { quinticDerivative, quinticInterpolation } from '../utils.ts';

--- a/packages/typegpu-noise/src/perlin-2d/dynamic-cache.ts
+++ b/packages/typegpu-noise/src/perlin-2d/dynamic-cache.ts
@@ -1,4 +1,5 @@
-import tgpu, {
+import {
+  tgpu,
   type Configurable,
   type StorageFlag,
   type TgpuAccessor,

--- a/packages/typegpu-noise/src/perlin-2d/static-cache.ts
+++ b/packages/typegpu-noise/src/perlin-2d/static-cache.ts
@@ -1,4 +1,4 @@
-import tgpu, { type Configurable, type TgpuFn, type TgpuRoot } from 'typegpu';
+import { tgpu, type Configurable, type TgpuFn, type TgpuRoot } from 'typegpu';
 import * as d from 'typegpu/data';
 import { computeJunctionGradient, getJunctionGradientSlot } from './algorithm.ts';
 

--- a/packages/typegpu-noise/src/perlin-3d/algorithm.ts
+++ b/packages/typegpu-noise/src/perlin-3d/algorithm.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import * as d from 'typegpu/data';
 import { dot, floor, mix } from 'typegpu/std';
 import { randOnUnitSphere, randSeed3 } from '../random.ts';

--- a/packages/typegpu-noise/src/perlin-3d/dynamic-cache.ts
+++ b/packages/typegpu-noise/src/perlin-3d/dynamic-cache.ts
@@ -1,4 +1,5 @@
-import tgpu, {
+import {
+  tgpu,
   type Configurable,
   type StorageFlag,
   type TgpuAccessor,

--- a/packages/typegpu-noise/src/perlin-3d/static-cache.ts
+++ b/packages/typegpu-noise/src/perlin-3d/static-cache.ts
@@ -1,4 +1,4 @@
-import tgpu, { type Configurable, type TgpuFn, type TgpuRoot } from 'typegpu';
+import { tgpu, type Configurable, type TgpuFn, type TgpuRoot } from 'typegpu';
 import * as d from 'typegpu/data';
 import { computeJunctionGradient, getJunctionGradientSlot } from './algorithm.ts';
 

--- a/packages/typegpu-noise/src/random.ts
+++ b/packages/typegpu-noise/src/random.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, type TgpuFn } from 'typegpu';
+import { tgpu, d, type TgpuFn } from 'typegpu';
 import { cos, dot, log, normalize, select, sign, sin, sqrt, step, tan } from 'typegpu/std';
 import { randomGeneratorSlot } from './generator.ts';
 

--- a/packages/typegpu-radiance-cascades/src/cascades.ts
+++ b/packages/typegpu-radiance-cascades/src/cascades.ts
@@ -1,4 +1,4 @@
-import tgpu, { std, d } from 'typegpu';
+import { tgpu, std, d } from 'typegpu';
 
 const ERODE_BIAS = 2;
 

--- a/packages/typegpu-react/src/core/root-context.tsx
+++ b/packages/typegpu-react/src/core/root-context.tsx
@@ -9,7 +9,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import tgpu, { type TgpuRoot } from 'typegpu';
+import { tgpu, type TgpuRoot } from 'typegpu';
 import { useDeferredCleanup } from './helper-hooks.ts';
 import { useBailOnServer } from './use-bail-on-server.ts';
 

--- a/packages/typegpu-react/src/core/use-render.ts
+++ b/packages/typegpu-react/src/core/use-render.ts
@@ -1,5 +1,5 @@
 import * as d from 'typegpu/data';
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { useMemo, useRef } from 'react';
 
 import { useRoot } from './root-context.tsx';

--- a/packages/typegpu-sdf/README.md
+++ b/packages/typegpu-sdf/README.md
@@ -7,7 +7,7 @@
 A set of signed distance functions and utilities for use in WebGPU/TypeGPU apps.
 
 ```ts
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import * as sdf from '@typegpu/sdf';
 
 const mainFragment = tgpu.fragmentFn({

--- a/packages/typegpu-sdf/src/2d.ts
+++ b/packages/typegpu-sdf/src/2d.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { f32, type v2f, vec2f, vec3f } from 'typegpu/data';
 import {
   abs,

--- a/packages/typegpu-sdf/src/3d.ts
+++ b/packages/typegpu-sdf/src/3d.ts
@@ -1,4 +1,4 @@
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { f32, vec3f } from 'typegpu/data';
 import { abs, distance, dot, length, max, min, saturate } from 'typegpu/std';
 

--- a/packages/typegpu-sdf/src/jumpFlood.ts
+++ b/packages/typegpu-sdf/src/jumpFlood.ts
@@ -1,4 +1,5 @@
-import tgpu, {
+import {
+  tgpu,
   type SampledFlag,
   type StorageFlag,
   type TgpuBindGroup,

--- a/packages/typegpu-sdf/src/operators.ts
+++ b/packages/typegpu-sdf/src/operators.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 /**
  * Union operator for combining two SDFs

--- a/packages/typegpu-sort/README.md
+++ b/packages/typegpu-sort/README.md
@@ -11,7 +11,7 @@ GPU sorting and scanning algorithms for TypeGPU.
 Sorts a `u32` storage buffer in-place. Arrays with non-power-of-2 lengths are padded automatically.
 
 ```ts
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { createBitonicSorter } from '@typegpu/sort';
 
 const root = await tgpu.init();

--- a/packages/typegpu-sort/src/bitonic/bitonicSort.ts
+++ b/packages/typegpu-sort/src/bitonic/bitonicSort.ts
@@ -1,4 +1,5 @@
-import tgpu, {
+import {
+  tgpu,
   d,
   std,
   type StorageFlag,

--- a/packages/typegpu-sort/src/bitonic/slots.ts
+++ b/packages/typegpu-sort/src/bitonic/slots.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 /** Default comparison function: ascending order (a < b means a comes before b) */
 export const defaultCompare = tgpu.fn([d.u32, d.u32], d.bool)((a, b) => a < b);

--- a/packages/typegpu-sort/src/scan/compute/applySums.ts
+++ b/packages/typegpu-sort/src/scan/compute/applySums.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { operatorSlot, uniformOpLayout, WORKGROUP_SIZE } from '../schemas.ts';
 
 export const uniformOp = tgpu.computeFn({

--- a/packages/typegpu-sort/src/scan/compute/scan.ts
+++ b/packages/typegpu-sort/src/scan/compute/scan.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import {
   identitySlot,
   onlyGreatestElementSlot,

--- a/packages/typegpu-sort/src/scan/compute/shared.ts
+++ b/packages/typegpu-sort/src/scan/compute/shared.ts
@@ -1,4 +1,4 @@
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { operatorSlot, WORKGROUP_SIZE } from '../schemas.ts';
 
 export const workgroupMemory = tgpu.workgroupVar(d.arrayOf(d.f32, WORKGROUP_SIZE));

--- a/packages/typegpu-sort/src/scan/schemas.ts
+++ b/packages/typegpu-sort/src/scan/schemas.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 export const WORKGROUP_SIZE = 256;
 

--- a/packages/typegpu-testing-utility/src/extendedIt.ts
+++ b/packages/typegpu-testing-utility/src/extendedIt.ts
@@ -1,6 +1,6 @@
 // oxlint-disable no-empty-pattern
 import { test as base, vi } from 'vitest';
-import tgpu, { type TgpuRoot } from 'typegpu';
+import { tgpu, type TgpuRoot } from 'typegpu';
 // oxlint-disable-next-line import/no-unassigned-import -- imported for side effects
 import './webgpuGlobals.ts';
 

--- a/packages/typegpu-three/src/builtin-accessors.ts
+++ b/packages/typegpu-three/src/builtin-accessors.ts
@@ -1,5 +1,5 @@
 import * as TSL from 'three/tsl';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { fromTSL } from './typegpu-node.ts';
 
 export const uv = tgpu.comptime((index?: number) => fromTSL(TSL.uv(index), d.vec2f));

--- a/packages/typegpu-three/src/typegpu-node.ts
+++ b/packages/typegpu-three/src/typegpu-node.ts
@@ -1,7 +1,7 @@
 import type NodeFunction from 'three/src/nodes/core/NodeFunction.js';
 import * as THREE from 'three/webgpu';
 import * as TSL from 'three/tsl';
-import tgpu, { type Namespace, type TgpuVar } from 'typegpu';
+import { tgpu, type Namespace, type TgpuVar } from 'typegpu';
 import * as d from 'typegpu/data';
 import WGSLNodeBuilder from 'three/src/renderers/webgpu/nodes/WGSLNodeBuilder.js';
 

--- a/packages/typegpu/src/index.js
+++ b/packages/typegpu/src/index.js
@@ -4,6 +4,7 @@
 
 // NOTE: This is a barrel file, internal files should not import things from this file
 
+// oxlint-disable-next-line
 import * as tgpu from './tgpu.ts';
 export * as tgpu from './tgpu.ts';
 export default tgpu;

--- a/packages/typegpu/src/index.js
+++ b/packages/typegpu/src/index.js
@@ -4,7 +4,6 @@
 
 // NOTE: This is a barrel file, internal files should not import things from this file
 
-// oxlint-disable-next-line
 import * as tgpu from './tgpu.ts';
 export * as tgpu from './tgpu.ts';
 export default tgpu;

--- a/packages/typegpu/tests/accessor.test.ts
+++ b/packages/typegpu/tests/accessor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf } from 'vitest';
-import tgpu, { d, std, type TgpuAccessor } from 'typegpu';
+import { tgpu, d, std, type TgpuAccessor } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 
 const RED = d.vec3f(1, 0, 0);

--- a/packages/typegpu/tests/builtin.test.ts
+++ b/packages/typegpu/tests/builtin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import * as d from 'typegpu/data';
 
 describe('builtin', () => {

--- a/packages/typegpu/tests/entryFnBuiltinArgs.test.ts
+++ b/packages/typegpu/tests/entryFnBuiltinArgs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import type { TgpuComputeFn, TgpuFragmentFn, TgpuVertexFn } from 'typegpu';
 import { attest } from '@ark/attest';
 

--- a/packages/typegpu/tests/entryFnHeaderGen.test.ts
+++ b/packages/typegpu/tests/entryFnHeaderGen.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('autogenerating wgsl headers for tgpu entry functions with raw string WGSL implementations', () => {
   it('works for fragment entry function with non-decorated non-struct output', () => {

--- a/packages/typegpu/tests/function.test.ts
+++ b/packages/typegpu/tests/function.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import tgpu, { d, type TgpuFn, type TgpuFnShell } from 'typegpu';
+import { tgpu, d, type TgpuFn, type TgpuFnShell } from 'typegpu';
 
 const empty = tgpu.fn([])`() {
   // do nothing

--- a/packages/typegpu/tests/functionTagged.test.ts
+++ b/packages/typegpu/tests/functionTagged.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('tagged syntax', () => {
   describe('function', () => {

--- a/packages/typegpu/tests/indent.test.ts
+++ b/packages/typegpu/tests/indent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 describe('indents', () => {
   it('should indent sanely', () => {

--- a/packages/typegpu/tests/internal/autoname.test.ts
+++ b/packages/typegpu/tests/internal/autoname.test.ts
@@ -205,7 +205,7 @@ describe('autonaming', () => {
         }) && $.f)({}));
 
 
-      			const main = (/*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(__vite_ssr_import_3__.default.fn([])((/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => {
+      			const main = (/*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(__vite_ssr_import_2__.tgpu.fn([])((/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => {
       				myFun();
       			}), {
           v: 1,

--- a/packages/typegpu/tests/internal/autoname.test.ts
+++ b/packages/typegpu/tests/internal/autoname.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect } from 'vitest';
 import { struct } from 'typegpu/data';
 import { getName } from '../../src/shared/meta.ts';
-import tgpu, { d, type TgpuBindGroupLayout } from 'typegpu';
+import { tgpu, d, type TgpuBindGroupLayout } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 
 describe('autonaming', () => {
@@ -205,7 +205,7 @@ describe('autonaming', () => {
         }) && $.f)({}));
 
 
-      			const main = (/*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(__vite_ssr_import_2__.tgpu.fn([])((/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => {
+      			const main = (/*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(__vite_ssr_import_3__.tgpu.fn([])((/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => {
       				myFun();
       			}), {
           v: 1,

--- a/packages/typegpu/tests/internal/connectAttributesToShader.test.ts
+++ b/packages/typegpu/tests/internal/connectAttributesToShader.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { connectAttributesToShader } from '../../src/core/vertexLayout/connectAttributesToShader.ts';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('connectAttributesToShader', () => {
   it('connects a single f32 attribute', () => {

--- a/packages/typegpu/tests/internal/dualImpl.test.ts
+++ b/packages/typegpu/tests/internal/dualImpl.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { dualImpl, MissingCpuImplError } from '../../src/core/function/dualImpl.ts';
 import { getName } from '../../src/shared/meta.ts';
-import tgpu, { d } from '../../src/index.js';
+import { tgpu, d } from '../../src/index.js';
 
 describe('dualImpl', () => {
   it('names functions created by dualImpl', () => {

--- a/packages/typegpu/tests/internal/gpuValueOf.test.ts
+++ b/packages/typegpu/tests/internal/gpuValueOf.test.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import type { GPUValueOf } from '../../src/shared/repr.ts';
 import { it } from 'typegpu-testing-utility';
 

--- a/packages/typegpu/tests/internal/limitsOverflow.test.ts
+++ b/packages/typegpu/tests/internal/limitsOverflow.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, vi } from 'vitest';
 import { it } from 'typegpu-testing-utility';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { warnIfOverflow } from '../../src/core/pipeline/limitsOverflow.ts';
 
 describe('warnIfOverflow', () => {

--- a/packages/typegpu/tests/internal/renderPipeline.test.ts
+++ b/packages/typegpu/tests/internal/renderPipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf, vi } from 'vitest';
 import { matchUpVaryingLocations } from '../../src/core/pipeline/renderPipeline.ts';
 import type { TgpuQuerySet } from '../../src/core/querySet/querySet.ts';
-import tgpu, { d, type TgpuRenderPipeline } from 'typegpu';
+import { tgpu, d, type TgpuRenderPipeline } from 'typegpu';
 import { $internal } from '../../src/shared/symbols.ts';
 import { it } from 'typegpu-testing-utility';
 

--- a/packages/typegpu/tests/internal/resolve.test.ts
+++ b/packages/typegpu/tests/internal/resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, vi } from 'vitest';
-import tgpu, { d } from '../../src/index.js';
+import { tgpu, d } from '../../src/index.js';
 import { getName, setName } from '../../src/shared/meta.ts';
 import { $gpuValueOf, $internal, $ownSnippet, $resolve } from '../../src/shared/symbols.ts';
 import type { ResolutionCtx } from '../../src/types.ts';

--- a/packages/typegpu/tests/internal/tseynit.test.ts
+++ b/packages/typegpu/tests/internal/tseynit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import * as tinyest from 'tinyest';
 import { getFunctionMetadata } from '../../src/shared/meta.ts';
 import { stringifyNode } from '../../src/shared/tseynit.ts';
-import tgpu, { d } from '../../src/index.js';
+import { tgpu, d } from '../../src/index.js';
 
 function getBodyAst(fn: () => void) {
   const meta = getFunctionMetadata(fn);

--- a/packages/typegpu/tests/interpolate.test.ts
+++ b/packages/typegpu/tests/interpolate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('d.interpolate', () => {
   it('adds @interpolate (only interpolation type) attribute for struct members', () => {

--- a/packages/typegpu/tests/invariant.test.ts
+++ b/packages/typegpu/tests/invariant.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('invariant', () => {
   it('adds @invariant attribute to position builtin', () => {

--- a/packages/typegpu/tests/jsMath.test.ts
+++ b/packages/typegpu/tests/jsMath.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('Math', () => {
   it('allows using Math.PI', () => {

--- a/packages/typegpu/tests/lazy.test.ts
+++ b/packages/typegpu/tests/lazy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, vi } from 'vitest';
-import tgpu, { d, type TgpuLazy } from 'typegpu';
+import { tgpu, d, type TgpuLazy } from 'typegpu';
 import { mul } from 'typegpu/std';
 import { it } from 'typegpu-testing-utility';
 

--- a/packages/typegpu/tests/location.test.ts
+++ b/packages/typegpu/tests/location.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('d.location', () => {
   it('adds @location attribute for struct members', () => {

--- a/packages/typegpu/tests/matrix.test.ts
+++ b/packages/typegpu/tests/matrix.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { readFromArrayBuffer, writeToArrayBuffer } from 'typegpu';
 import { isCloseTo } from 'typegpu/std';
 

--- a/packages/typegpu/tests/mutabilityTracking.test.ts
+++ b/packages/typegpu/tests/mutabilityTracking.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const fnShell = tgpu.fn([d.vec4u], d.u32);
 

--- a/packages/typegpu/tests/namespace.test.ts
+++ b/packages/typegpu/tests/namespace.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 
 describe('tgpu.namespace', () => {

--- a/packages/typegpu/tests/numeric.test.ts
+++ b/packages/typegpu/tests/numeric.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('f32', () => {
   it('differs in type from other numeric schemas', () => {

--- a/packages/typegpu/tests/pipeline-resolution.test.ts
+++ b/packages/typegpu/tests/pipeline-resolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 
 describe('resolve', () => {

--- a/packages/typegpu/tests/rawFn.test.ts
+++ b/packages/typegpu/tests/rawFn.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('tgpu.fn with raw string WGSL implementation', () => {
   it('is namable', () => {

--- a/packages/typegpu/tests/ref.test.ts
+++ b/packages/typegpu/tests/ref.test.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { describe, expect } from 'vitest';
 import { it } from 'typegpu-testing-utility';
 

--- a/packages/typegpu/tests/renderPipeline.test.ts
+++ b/packages/typegpu/tests/renderPipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, expectTypeOf, vi } from 'vitest';
-import tgpu, {
+import {
+  tgpu,
   common,
   d,
   MissingBindGroupsError,

--- a/packages/typegpu/tests/resolve.test.ts
+++ b/packages/typegpu/tests/resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, vi } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 
 describe('tgpu resolve', () => {

--- a/packages/typegpu/tests/root.test.ts
+++ b/packages/typegpu/tests/root.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, vi } from 'vitest';
 import { Void } from 'typegpu/data';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 
 describe('TgpuRoot', () => {

--- a/packages/typegpu/tests/simulate.test.ts
+++ b/packages/typegpu/tests/simulate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 
 describe('tgpu.simulate()', () => {

--- a/packages/typegpu/tests/size.test.ts
+++ b/packages/typegpu/tests/size.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('d.size', () => {
   it('adds @size attribute for the custom sized struct members', () => {

--- a/packages/typegpu/tests/slot.test.ts
+++ b/packages/typegpu/tests/slot.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from 'vitest';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 
 const RED = 'vec3f(1., 0., 0.)';

--- a/packages/typegpu/tests/std/bitcast.test.ts
+++ b/packages/typegpu/tests/std/bitcast.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { vec2f, vec2i, vec2u, vec3f, vec3i, vec3u, vec4f, vec4i, vec4u } from 'typegpu/data';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 describe('bitcast', () => {
   it('bitcastU32toF32', () => {

--- a/packages/typegpu/tests/std/boolean/not.test.ts
+++ b/packages/typegpu/tests/std/boolean/not.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from 'vitest';
 import { it } from 'typegpu-testing-utility';
 import { not } from 'typegpu/std';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 describe('not', () => {
   it('negates booleans', () => {

--- a/packages/typegpu/tests/std/boolean/select.test.ts
+++ b/packages/typegpu/tests/std/boolean/select.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import {
   vec2b,
   vec2f,

--- a/packages/typegpu/tests/std/copy.test.ts
+++ b/packages/typegpu/tests/std/copy.test.ts
@@ -1,6 +1,6 @@
 import { it } from 'typegpu-testing-utility';
 import { describe, expect } from 'vitest';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 describe('std.copy', () => {
   describe('on the CPU', () => {

--- a/packages/typegpu/tests/std/environment.test.ts
+++ b/packages/typegpu/tests/std/environment.test.ts
@@ -1,7 +1,7 @@
 import { it } from 'typegpu-testing-utility';
 import { expect, describe } from 'vitest';
 
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 describe('isBeingTranspiled', () => {
   it('returns false top level', () => {

--- a/packages/typegpu/tests/std/matrix/rotate.test.ts
+++ b/packages/typegpu/tests/std/matrix/rotate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { mat4x4f, vec4f } from 'typegpu/data';
 import { isCloseTo, mul, rotateX4, rotateY4, rotateZ4 } from 'typegpu/std';
 

--- a/packages/typegpu/tests/std/matrix/scale.test.ts
+++ b/packages/typegpu/tests/std/matrix/scale.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { mat4x4f, vec3f, vec4f } from 'typegpu/data';
 import { isCloseTo, mul, scale4, translate4 } from 'typegpu/std';
 

--- a/packages/typegpu/tests/std/matrix/translate.test.ts
+++ b/packages/typegpu/tests/std/matrix/translate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 import { mat4x4f, vec3f, vec4f } from 'typegpu/data';
 import { isCloseTo, mul, scale4, translate4 } from 'typegpu/std';
 

--- a/packages/typegpu/tests/std/numeric/bitShift.test.ts
+++ b/packages/typegpu/tests/std/numeric/bitShift.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { u32, i32, vec3f, vec3i, vec3u, f32, vec2u } from 'typegpu/data';
 import { bitShiftLeft, bitShiftRight } from 'typegpu/std';
-import tgpu from 'typegpu';
+import { tgpu } from 'typegpu';
 
 describe('bit shift', () => {
   it('casts rhs to u32', () => {

--- a/packages/typegpu/tests/std/numeric/div.test.ts
+++ b/packages/typegpu/tests/std/numeric/div.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { div, isCloseTo } from 'typegpu/std';
 
 describe('div', () => {

--- a/packages/typegpu/tests/std/numeric/max.test.ts
+++ b/packages/typegpu/tests/std/numeric/max.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 describe('max', () => {
   it('acts as identity when called with one argument', () => {

--- a/packages/typegpu/tests/std/numeric/min.test.ts
+++ b/packages/typegpu/tests/std/numeric/min.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 describe('min', () => {
   it('acts as identity when called with one argument', () => {

--- a/packages/typegpu/tests/std/numeric/mod.test.ts
+++ b/packages/typegpu/tests/std/numeric/mod.test.ts
@@ -15,7 +15,7 @@ import {
 } from 'typegpu/data';
 import type { v2f, v2h, v2i, v2u, v3f, v3h, v3i, v3u, v4f, v4h, v4i, v4u } from 'typegpu/data';
 import { isCloseTo, mod } from 'typegpu/std';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('mod', () => {
   it('computes modulo of a number and a number', () => {

--- a/packages/typegpu/tests/std/numeric/mul.test.ts
+++ b/packages/typegpu/tests/std/numeric/mul.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import {
   mat2x2f,
   mat3x3f,

--- a/packages/typegpu/tests/std/numeric/round.test.ts
+++ b/packages/typegpu/tests/std/numeric/round.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 describe('round', () => {
   it('rounds to even numbers', () => {

--- a/packages/typegpu/tests/std/texture/textureGather.test.ts
+++ b/packages/typegpu/tests/std/texture/textureGather.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf } from 'vitest';
 import { it } from 'typegpu-testing-utility';
 import { textureGather } from 'typegpu/std';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('textureGather', () => {
   it('Has correct signatures', () => {

--- a/packages/typegpu/tests/std/texture/textureLoad.test.ts
+++ b/packages/typegpu/tests/std/texture/textureLoad.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf } from 'vitest';
 import { it } from 'typegpu-testing-utility';
 import { textureLoad } from 'typegpu/std';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 // we need this since all other usages will be removed by plugin
 expectTypeOf(() => {});

--- a/packages/typegpu/tests/std/texture/textureSample.test.ts
+++ b/packages/typegpu/tests/std/texture/textureSample.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from 'vitest';
 import { it } from 'typegpu-testing-utility';
 import { textureSample } from 'typegpu/std';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('textureSample', () => {
   it('does not allow for raw schemas to be passed in', ({ root }) => {

--- a/packages/typegpu/tests/swizzleMixedValidation.test.ts
+++ b/packages/typegpu/tests/swizzleMixedValidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('Mixed swizzle validation', () => {
   describe('JS validation', () => {

--- a/packages/typegpu/tests/texture.test.ts
+++ b/packages/typegpu/tests/texture.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, expectTypeOf, vi } from 'vitest';
 import type { RenderFlag, SampledFlag, TgpuRoot, TgpuTexture, TgpuTextureView } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 import { attest } from '@ark/attest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('TgpuTexture', () => {
   it('makes passing the default, `undefined` or omitting an option prop result in the same type.', ({

--- a/packages/typegpu/tests/tgpuGenericFn.test.ts
+++ b/packages/typegpu/tests/tgpuGenericFn.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from 'vitest';
-import tgpu, { std, d } from 'typegpu';
+import { tgpu, std, d } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 
 describe('TgpuGenericFn - shellless callback wrapper', () => {

--- a/packages/typegpu/tests/tgsl/argumentOrigin.test.ts
+++ b/packages/typegpu/tests/tgsl/argumentOrigin.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from 'vitest';
 import { it } from 'typegpu-testing-utility';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('function argument origin tracking', () => {
   it('should fail on mutation of primitive arguments', () => {

--- a/packages/typegpu/tests/tgsl/assignment.test.ts
+++ b/packages/typegpu/tests/tgsl/assignment.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, expect, type MockInstance, vi } from 'vitest';
 import { it } from 'typegpu-testing-utility';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 let warnSpy: MockInstance<typeof console.warn>;
 

--- a/packages/typegpu/tests/tgsl/codeGen.test.ts
+++ b/packages/typegpu/tests/tgsl/codeGen.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from 'vitest';
 import { it } from 'typegpu-testing-utility';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('codeGen', () => {
   describe('vectors', () => {

--- a/packages/typegpu/tests/tgsl/comptime.test.ts
+++ b/packages/typegpu/tests/tgsl/comptime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from 'vitest';
 import { it } from 'typegpu-testing-utility';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('comptime', () => {
   it('should work in JS', () => {

--- a/packages/typegpu/tests/tgsl/consoleLog.test.ts
+++ b/packages/typegpu/tests/tgsl/consoleLog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, vi } from 'vitest';
 import { it } from 'typegpu-testing-utility';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('wgslGenerator with console.log', () => {
   it('Parses console.log in a stray function to a comment and warns', () => {

--- a/packages/typegpu/tests/tgsl/conversion.test.ts
+++ b/packages/typegpu/tests/tgsl/conversion.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, vi } from 'vitest';
 import { it } from 'typegpu-testing-utility';
 import { expectDataTypeOf } from '../utils/parseResolved.ts';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('convertToCommonType', () => {
   it('converts identical types', () => {

--- a/packages/typegpu/tests/tgsl/entryFnParamPruning.test.ts
+++ b/packages/typegpu/tests/tgsl/entryFnParamPruning.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from 'vitest';
 import { it } from 'typegpu-testing-utility';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const layout = tgpu.bindGroupLayout({
   output: { storage: d.arrayOf(d.f32), access: 'mutable' },

--- a/packages/typegpu/tests/tgsl/extensionEnabled.test.ts
+++ b/packages/typegpu/tests/tgsl/extensionEnabled.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from 'vitest';
 import { it } from 'typegpu-testing-utility';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 describe('extension based pruning', () => {
   it('should include extension code when the feature is used', () => {

--- a/packages/typegpu/tests/tgsl/infixOperators.test.ts
+++ b/packages/typegpu/tests/tgsl/infixOperators.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 
 describe('wgslGenerator', () => {

--- a/packages/typegpu/tests/tgsl/letDeclaration.test.ts
+++ b/packages/typegpu/tests/tgsl/letDeclaration.test.ts
@@ -1,6 +1,6 @@
 import { it } from 'typegpu-testing-utility';
 import { describe, expect } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { expectSnippetOf } from '../utils/parseResolved.ts';
 
 describe('let declarations', () => {

--- a/packages/typegpu/tests/tgsl/memberAccess.test.ts
+++ b/packages/typegpu/tests/tgsl/memberAccess.test.ts
@@ -1,7 +1,7 @@
 import { describe } from 'vitest';
 import { it } from 'typegpu-testing-utility';
 import { expectSnippetOf } from '../utils/parseResolved.ts';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('Member Access', () => {
   const Boid = d.struct({

--- a/packages/typegpu/tests/tgsl/multiplication.test.ts
+++ b/packages/typegpu/tests/tgsl/multiplication.test.ts
@@ -2,7 +2,7 @@ import { test } from 'typegpu-testing-utility';
 import { expect, vi } from 'vitest';
 
 import { expectSnippetOf } from '../utils/parseResolved.ts';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 test('multiplying i32 with a float literal should implicitly convert to an f32', () => {
   using consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/typegpu/tests/tgsl/nameClashes.test.ts
+++ b/packages/typegpu/tests/tgsl/nameClashes.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'vitest';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 import { test } from 'typegpu-testing-utility';
 
 test('should differentiate parameter names from existing declarations', () => {

--- a/packages/typegpu/tests/tgsl/rawCodeSnippet.test.ts
+++ b/packages/typegpu/tests/tgsl/rawCodeSnippet.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf } from 'vitest';
 import { it } from 'typegpu-testing-utility';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('rawCodeSnippet', () => {
   it('should throw a descriptive error when called in JS', () => {

--- a/packages/typegpu/tests/tgsl/shellless.test.ts
+++ b/packages/typegpu/tests/tgsl/shellless.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect } from 'vitest';
-import tgpu, {
+import {
+  tgpu,
   d,
   std,
   type TgpuAccessor,

--- a/packages/typegpu/tests/tgsl/sideEffects.test.ts
+++ b/packages/typegpu/tests/tgsl/sideEffects.test.ts
@@ -1,4 +1,4 @@
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 import { test } from 'typegpu-testing-utility';
 import { expectSideEffects } from '../utils/parseResolved.ts';
 import { describe } from 'vitest';

--- a/packages/typegpu/tests/tgsl/ternaryOperator.test.ts
+++ b/packages/typegpu/tests/tgsl/ternaryOperator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from 'vitest';
 import { it } from 'typegpu-testing-utility';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 describe('ternary operator', () => {
   it('should resolve to one of the branches', () => {

--- a/packages/typegpu/tests/tgsl/typeInference.test.ts
+++ b/packages/typegpu/tests/tgsl/typeInference.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 describe('wgsl generator type inference', () => {
   it('coerces nested structs', () => {

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect } from 'vitest';
 import { it } from 'typegpu-testing-utility';
 import { expectDataTypeOf, extractSnippetFromFn } from '../utils/parseResolved.ts';
-import tgpu, { d, std } from 'typegpu';
+import { tgpu, d, std } from 'typegpu';
 
 const numberSlot = tgpu.slot(44);
 const lazyV4u = tgpu.lazy(() => d.vec4u(1, 2, 3, 4).mul(numberSlot.$));

--- a/packages/typegpu/tests/tgslFn.test.ts
+++ b/packages/typegpu/tests/tgslFn.test.ts
@@ -1,7 +1,7 @@
 import { attest } from '@ark/attest';
 import { describe, expect } from 'vitest';
 import { builtin } from 'typegpu/data';
-import tgpu, { d, type TgpuFn, type TgpuSlot } from 'typegpu';
+import { tgpu, d, type TgpuFn, type TgpuSlot } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 
 describe('TGSL tgpu.fn function', () => {

--- a/packages/typegpu/tests/unroll.test.ts
+++ b/packages/typegpu/tests/unroll.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from 'vitest';
 import { it } from 'typegpu-testing-utility';
-import tgpu, { std, d } from 'typegpu';
+import { tgpu, std, d } from 'typegpu';
 
 describe('tgpu.unroll', () => {
   it('called outside the gpu function returns passed iterable', () => {

--- a/packages/typegpu/tests/utils/parseResolved.ts
+++ b/packages/typegpu/tests/utils/parseResolved.ts
@@ -1,7 +1,7 @@
 import type * as tinyest from 'tinyest';
 import { NodeTypeCatalog as NODE } from 'tinyest';
 import { type Assertion, expect } from 'vitest';
-import tgpu, { d, type TgpuFn } from 'typegpu';
+import { tgpu, d, type TgpuFn } from 'typegpu';
 import {
   type Snippet,
   UnknownData,

--- a/packages/typegpu/tests/variable.test.ts
+++ b/packages/typegpu/tests/variable.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d, std, type TgpuVar, type VariableScope } from 'typegpu';
+import { tgpu, d, std, type TgpuVar, type VariableScope } from 'typegpu';
 
 describe('tgpu.privateVar|tgpu.workgroupVar', () => {
   it('should inject variable declaration when used in functions', () => {

--- a/packages/typegpu/tests/vector.test.ts
+++ b/packages/typegpu/tests/vector.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import { sizeOf } from 'typegpu/data';
-import tgpu, { d, std, readFromArrayBuffer, writeToArrayBuffer } from 'typegpu';
+import { tgpu, d, std, readFromArrayBuffer, writeToArrayBuffer } from 'typegpu';
 
 describe('constructors', () => {
   it('casts floats to signed integers', () => {

--- a/packages/typegpu/tests/vertexLayout.test.ts
+++ b/packages/typegpu/tests/vertexLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import tgpu, { d } from 'typegpu';
+import { tgpu, d } from 'typegpu';
 
 describe('tgpu.vertexLayout', () => {
   it('creates attributes from loose array of vec3f', () => {

--- a/packages/unplugin-typegpu/src/core/common.ts
+++ b/packages/unplugin-typegpu/src/core/common.ts
@@ -176,7 +176,7 @@ export function getBlockScope(
 
 /**
  * Checks if `node` is an alias for the 'tgpu' object, traditionally
- * available via `import tgpu from 'typegpu'`.
+ * available via `import { tgpu } from 'typegpu'`.
  */
 function isTgpu(state: PluginState, node: t.Node): boolean {
   let path = '';

--- a/packages/unplugin-typegpu/test/auto-naming.test.ts
+++ b/packages/unplugin-typegpu/test/auto-naming.test.ts
@@ -4,7 +4,7 @@ import { babelTransform, rollupTransform } from './transform.ts';
 describe('[BABEL] auto naming', () => {
   it('works with tgpu items', () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const bindGroupLayout = tgpu.bindGroupLayout({});
@@ -17,7 +17,7 @@ describe('[BABEL] auto naming', () => {
     `;
 
     expect(babelTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       const bindGroupLayout = /*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu.bindGroupLayout({}), "bindGroupLayout");
       const vertexLayout = /*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu.vertexLayout(d.arrayOf(d.u32)), "vertexLayout");
@@ -41,7 +41,7 @@ describe('[BABEL] auto naming', () => {
 
   it(`works with tgpu['~unstable'] items`, () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       let nothing, accessor = tgpu['~unstable'].accessor(d.u32);
@@ -51,7 +51,7 @@ describe('[BABEL] auto naming', () => {
     `;
 
     expect(babelTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       let nothing,
         accessor = /*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu['~unstable'].accessor(d.u32), "accessor");
@@ -88,7 +88,7 @@ describe('[BABEL] auto naming', () => {
 
   it('works with root items', () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
 
       const root = await tgpu.init();
       const myBuffer = root.createBuffer(d.u32, 2);
@@ -97,7 +97,7 @@ describe('[BABEL] auto naming', () => {
     `;
 
     expect(babelTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       const root = await tgpu.init();
       const myBuffer = /*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(root.createBuffer(d.u32, 2), "myBuffer");
       console.log(myBuffer);"
@@ -106,7 +106,7 @@ describe('[BABEL] auto naming', () => {
 
   it('works with functions', () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const myFunction = tgpu.fn([])(() => 0);
@@ -125,7 +125,7 @@ describe('[BABEL] auto naming', () => {
     `;
 
     expect(babelTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       const myFunction = /*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu.fn([])(/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = () => 0, {
         v: 1,
@@ -229,7 +229,7 @@ describe('[BABEL] auto naming', () => {
 
   it('does not name already named items', () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       import { struct } from 'typegpu/data';
 
@@ -243,7 +243,7 @@ describe('[BABEL] auto naming', () => {
     `;
 
     expect(babelTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       import { struct } from 'typegpu/data';
       const root = await tgpu.init();
@@ -379,7 +379,7 @@ describe('[BABEL] auto naming', () => {
 
   it('works with class properties', () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       const root = await tgpu.init();
 
@@ -389,7 +389,7 @@ describe('[BABEL] auto naming', () => {
     `;
 
     expect(babelTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       const root = await tgpu.init();
       class MyController {
@@ -400,7 +400,7 @@ describe('[BABEL] auto naming', () => {
 
   it('works with object properties', () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       const root = await tgpu.init();
 
@@ -410,7 +410,7 @@ describe('[BABEL] auto naming', () => {
     `;
 
     expect(babelTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       const root = await tgpu.init();
       const items: {
@@ -424,7 +424,7 @@ describe('[BABEL] auto naming', () => {
 
   it('works with assigning to "this" property', () => {
     const code = `\
-      import tgpu, { type TgpuUniform } from 'typegpu';
+      import { tgpu, type TgpuUniform } from 'typegpu';
       import * as d from 'typegpu/data';
       const root = await tgpu.init();
 
@@ -438,7 +438,7 @@ describe('[BABEL] auto naming', () => {
     `;
 
     expect(babelTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu, { type TgpuUniform } from 'typegpu';
+      "import { tgpu, type TgpuUniform } from 'typegpu';
       import * as d from 'typegpu/data';
       const root = await tgpu.init();
       class MyController {
@@ -452,7 +452,7 @@ describe('[BABEL] auto naming', () => {
 
   it('works with assigning to "this" private property', () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const root = await tgpu.init();
@@ -473,7 +473,7 @@ describe('[BABEL] auto naming', () => {
     `;
 
     expect(babelTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       const root = await tgpu.init();
       class MyController {
@@ -491,7 +491,7 @@ describe('[BABEL] auto naming', () => {
 
   it('works with guarded pipelines', () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
 
       const root = await tgpu.init();
 
@@ -508,7 +508,7 @@ describe('[BABEL] auto naming', () => {
     `;
 
     expect(babelTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       const root = await tgpu.init();
       const myGuardedPipeline = /*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(root.createGuardedComputePipeline(/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = () => {
         'use gpu';
@@ -546,7 +546,7 @@ describe('[BABEL] auto naming', () => {
 describe('[ROLLUP] auto naming', () => {
   it('works with tgpu items', async () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const bindGroupLayout = tgpu.bindGroupLayout({});
@@ -560,7 +560,7 @@ describe('[ROLLUP] auto naming', () => {
     `;
 
     expect(await rollupTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const bindGroupLayout = (/*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu.bindGroupLayout({}), "bindGroupLayout"));
@@ -607,7 +607,7 @@ describe('[ROLLUP] auto naming', () => {
 
   it('works with root items', async () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
 
       const root = await tgpu.init();
       const myBuffer = root.createBuffer(d.u32, 2);
@@ -616,7 +616,7 @@ describe('[ROLLUP] auto naming', () => {
     `;
 
     expect(await rollupTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
 
       const root = await tgpu.init();
             const myBuffer = (/*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(root.createBuffer(d.u32, 2), "myBuffer"));
@@ -628,7 +628,7 @@ describe('[ROLLUP] auto naming', () => {
 
   it('works with functions', async () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const myFunction = tgpu.fn([])(() => 0);
@@ -647,7 +647,7 @@ describe('[ROLLUP] auto naming', () => {
     `;
 
     expect(await rollupTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       (/*#__PURE__*/(globalThis.__TYPEGPU_AUTONAME__ ?? (a => a))(tgpu.fn([])((/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => 0), {
@@ -722,7 +722,7 @@ describe('[ROLLUP] auto naming', () => {
 
   it('does not name already named items', async () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       import { struct } from 'typegpu/data';
 
@@ -736,7 +736,7 @@ describe('[ROLLUP] auto naming', () => {
     `;
 
     expect(await rollupTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       import { struct } from 'typegpu/data';
 
@@ -867,7 +867,7 @@ describe('[ROLLUP] auto naming', () => {
 
   it('works with class properties', async () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       const root = await tgpu.init();
 
@@ -879,7 +879,7 @@ describe('[ROLLUP] auto naming', () => {
     `;
 
     expect(await rollupTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const root = await tgpu.init();
@@ -895,7 +895,7 @@ describe('[ROLLUP] auto naming', () => {
 
   it('works with object properties', async () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       const root = await tgpu.init();
 
@@ -907,7 +907,7 @@ describe('[ROLLUP] auto naming', () => {
     `;
 
     expect(await rollupTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const root = await tgpu.init();
@@ -923,7 +923,7 @@ describe('[ROLLUP] auto naming', () => {
 
   it('works with assigning to "this" property', async () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       const root = await tgpu.init();
 
@@ -939,7 +939,7 @@ describe('[ROLLUP] auto naming', () => {
     `;
 
     expect(await rollupTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const root = await tgpu.init();
@@ -959,7 +959,7 @@ describe('[ROLLUP] auto naming', () => {
 
   it('works with assigning to "this" private property', async () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const root = await tgpu.init();
@@ -980,7 +980,7 @@ describe('[ROLLUP] auto naming', () => {
     `;
 
     expect(await rollupTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const root = await tgpu.init();
@@ -1004,7 +1004,7 @@ describe('[ROLLUP] auto naming', () => {
 
   it('works with guarded pipelines', async () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
 
       const root = await tgpu.init();
 
@@ -1022,7 +1022,7 @@ describe('[ROLLUP] auto naming', () => {
     `;
 
     expect(await rollupTransform(code, { autoNamingEnabled: true })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
 
       const root = await tgpu.init();
 

--- a/packages/unplugin-typegpu/test/parser-options.test.ts
+++ b/packages/unplugin-typegpu/test/parser-options.test.ts
@@ -4,7 +4,7 @@ import { babelTransform, rollupTransform } from './transform.ts';
 describe('[BABEL] parser options', () => {
   it('with no include option, import determines whether to run the plugin', () => {
     const codeWithImport = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       
       const increment = tgpu.fn([])(() => {
         const x = 2+2;
@@ -12,7 +12,7 @@ describe('[BABEL] parser options', () => {
     `;
 
     expect(babelTransform(codeWithImport, { include: [/virtual:/] })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       const increment = tgpu.fn([])(/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = () => {
         const x = 2 + 2;
       }, {
@@ -46,7 +46,7 @@ describe('[BABEL] parser options', () => {
 describe('[ROLLUP] tgpu alias gathering', async () => {
   it('with no include option, import determines whether to run the plugin', async () => {
     const codeWithImport = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       
       const increment = tgpu.fn([])(() => {
       });
@@ -55,7 +55,7 @@ describe('[ROLLUP] tgpu alias gathering', async () => {
   `;
 
     expect(await rollupTransform(codeWithImport, { include: [/virtual:/] })).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
 
       const increment = tgpu.fn([])((/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (() => {
             }), {

--- a/packages/unplugin-typegpu/test/tgsl-transpiling.test.ts
+++ b/packages/unplugin-typegpu/test/tgsl-transpiling.test.ts
@@ -4,7 +4,7 @@ import { babelTransform, rollupTransform } from './transform.ts';
 describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
   it('wraps argument passed to function shell with globalThis set call', () => {
     const code = `\
-        import tgpu from 'typegpu';
+        import { tgpu } from 'typegpu';
         import * as d from 'typegpu/data';
 
         const counterBuffer = root
@@ -22,7 +22,7 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
     `;
 
     expect(babelTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       const counterBuffer = root.createBuffer(d.vec3f, d.vec3f(0, 1, 0)).$usage('storage');
       const counter = counterBuffer.as('mutable');
@@ -59,7 +59,7 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
 
   it('works for multiple functions, skips wgsl-implemented', () => {
     const code = `\
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
 
       const a = tgpu.computeFn({ workgroupSize: [1] })((input) => {
         const x = true;
@@ -76,7 +76,7 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
     `;
 
     expect(babelTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       const a = tgpu.computeFn({
         workgroupSize: [1]
       })(/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = input => {
@@ -131,14 +131,14 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
 
   it('transpiles only function shell invocations', () => {
     const code = `\
-        import tgpu from 'typegpu';
+        import { tgpu } from 'typegpu';
         import * as d from 'typegpu/data';
 
         tgpu.x()(d.arrayOf(d.u32));
     `;
 
     expect(babelTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       tgpu.x()(d.arrayOf(d.u32));"
     `);
@@ -146,7 +146,7 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
 
   it('works with some typescript features', () => {
     const code = `\
-        import tgpu from 'typegpu';
+        import { tgpu } from 'typegpu';
 
         const fun = tgpu.computeFn({ workgroupSize: [1] })((input) => {
           const x = true;
@@ -162,7 +162,7 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
     `;
 
     expect(babelTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       const fun = tgpu.computeFn({
         workgroupSize: [1]
       })(/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = input => {
@@ -225,7 +225,7 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
 
   it('correctly lists "this" in externals', () => {
     const code = `
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const root = await tgpu.init();
@@ -242,7 +242,7 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
       console.log(tgpu.resolve([myController.myFn]));`;
 
     expect(babelTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
       const root = await tgpu.init();
       class MyController {
@@ -273,7 +273,7 @@ describe('[BABEL] plugin for transpiling tgsl functions to tinyest', () => {
 describe('[ROLLUP] plugin for transpiling tgsl functions to tinyest', () => {
   it('wraps argument passed to function shell with globalThis set call', async () => {
     const code = `\
-        import tgpu from 'typegpu';
+        import { tgpu } from 'typegpu';
         import * as d from 'typegpu/data';
 
         const counterBuffer = root
@@ -291,7 +291,7 @@ describe('[ROLLUP] plugin for transpiling tgsl functions to tinyest', () => {
     `;
 
     expect(await rollupTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const counterBuffer = root
@@ -317,7 +317,7 @@ describe('[ROLLUP] plugin for transpiling tgsl functions to tinyest', () => {
 
   it('works for multiple functions, skips wgsl-implemented', async () => {
     const code = `\
-        import tgpu from 'typegpu';
+        import { tgpu } from 'typegpu';
 
         const a = tgpu.computeFn({ workgroupSize: [1] })((input) => {
         const x = true;
@@ -334,7 +334,7 @@ describe('[ROLLUP] plugin for transpiling tgsl functions to tinyest', () => {
     `;
 
     expect(await rollupTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
 
       tgpu.computeFn({ workgroupSize: [1] })((/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = ((input) => {
               }), {
@@ -367,14 +367,14 @@ describe('[ROLLUP] plugin for transpiling tgsl functions to tinyest', () => {
 
   it('transpiles only function shell invocations', async () => {
     const code = `\
-        import tgpu from 'typegpu';
+        import { tgpu } from 'typegpu';
         import * as d from 'typegpu/data';
 
         tgpu.x()(d.arrayOf(d.u32));
     `;
 
     expect(await rollupTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       tgpu.x()(d.arrayOf(d.u32));
@@ -384,7 +384,7 @@ describe('[ROLLUP] plugin for transpiling tgsl functions to tinyest', () => {
 
   it('correctly lists "this" in externals', async () => {
     const code = `
-      import tgpu from 'typegpu';
+      import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const root = await tgpu.init();
@@ -401,7 +401,7 @@ describe('[ROLLUP] plugin for transpiling tgsl functions to tinyest', () => {
       console.log(tgpu.resolve([myController.myFn]));`;
 
     expect(await rollupTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       import * as d from 'typegpu/data';
 
       const root = await tgpu.init();

--- a/packages/unplugin-typegpu/test/use-gpu-directive.test.ts
+++ b/packages/unplugin-typegpu/test/use-gpu-directive.test.ts
@@ -76,7 +76,7 @@ describe('"use gpu" marked arrow function, assigned to a const', () => {
 
 describe('marked arrow functions passed to shells', () => {
   const code = `\
-    import tgpu from 'typegpu';
+    import { tgpu } from 'typegpu';
 
     const shell = tgpu.fn([]);
 
@@ -92,7 +92,7 @@ describe('marked arrow functions passed to shells', () => {
 
   test('babel', () => {
     expect(babelTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       const shell = tgpu.fn([]);
       shell(/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = (a, b) => {
         'use gpu';
@@ -124,7 +124,7 @@ describe('marked arrow functions passed to shells', () => {
 
   test('rollup', async () => {
     expect(await rollupTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
 
       const shell = tgpu.fn([]);
 
@@ -148,7 +148,7 @@ describe('marked arrow functions passed to shells', () => {
 
 describe('marked anonymous function expressions passed to shells', () => {
   const code = `\
-    import tgpu from 'typegpu';
+    import { tgpu } from 'typegpu';
 
     const shell = tgpu.fn([]);
 
@@ -164,7 +164,7 @@ describe('marked anonymous function expressions passed to shells', () => {
 
   test('babel', () => {
     expect(babelTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       const shell = tgpu.fn([]);
       shell(/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = function (a, b) {
         'use gpu';
@@ -196,7 +196,7 @@ describe('marked anonymous function expressions passed to shells', () => {
 
   test('rollup', async () => {
     expect(await rollupTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
 
       const shell = tgpu.fn([]);
 
@@ -220,7 +220,7 @@ describe('marked anonymous function expressions passed to shells', () => {
 
 describe('marked named function expressions passed to shells', () => {
   const code = `\
-    import tgpu from 'typegpu';
+    import { tgpu } from 'typegpu';
 
     const shell = tgpu.fn([]);
 
@@ -236,7 +236,7 @@ describe('marked named function expressions passed to shells', () => {
 
   test('babel', () => {
     expect(babelTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
       const shell = tgpu.fn([]);
       shell(/*#__PURE__*/($ => (globalThis.__TYPEGPU_META__ ??= new WeakMap()).set($.f = function addGPU(a, b) {
         'use gpu';
@@ -268,7 +268,7 @@ describe('marked named function expressions passed to shells', () => {
 
   test('rollup', async () => {
     expect(await rollupTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu from 'typegpu';
+      "import { tgpu } from 'typegpu';
 
       const shell = tgpu.fn([]);
 
@@ -500,7 +500,7 @@ describe('marked object methods', () => {
 
 describe('transforms numeric operations', () => {
   const code = `\
-    import tgpu, { d } from 'typegpu';
+    import { tgpu, d } from 'typegpu';
 
     const root = await tgpu.init();
     const countMutable = root.createMutable(d.i32, 0);
@@ -519,7 +519,7 @@ describe('transforms numeric operations', () => {
 
   test('babel', () => {
     expect(babelTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu, { d } from 'typegpu';
+      "import { tgpu, d } from 'typegpu';
       const root = await tgpu.init();
       const countMutable = root.createMutable(d.i32, 0);
 
@@ -557,7 +557,7 @@ describe('transforms numeric operations', () => {
 
   test('rollup', async () => {
     expect(await rollupTransform(code)).toMatchInlineSnapshot(`
-      "import tgpu, { d } from 'typegpu';
+      "import { tgpu, d } from 'typegpu';
 
       const root = await tgpu.init();
           const countMutable = root.createMutable(d.i32, 0);


### PR DESCRIPTION
After just replacing the imports, I had some issues with `tgpu['~unstable']`.

This was fine:
```ts
import type { IndexFlag } from 'typegpu';
import { tgpu } from 'typegpu';
const _ = tgpu['~unstable'];
```

This linted `tgpu['~unstable']` as 'Unable to validate computed reference to imported namespace "tgpu".'
```ts
import { tgpu } from 'typegpu';
const _ = tgpu['~unstable'];
```

So I disabled the rule that reported this.

Also, I added an internal lint rule against `import tgpu` so that we don't use it on autopilot.