### PR TITLE
fix(unplugin-typegpu): expose built artifacts via $built$ exports

### DIFF
--- a/packages/unplugin-typegpu/package.json
+++ b/packages/unplugin-typegpu/package.json
@@ -29,16 +29,60 @@
   "exports": {
     "./package.json": "./package.json",
     ".": "./src/index.ts",
+    "./$built$": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./rollup": "./src/rollup.ts",
+    "./rollup/$built$": {
+      "types": "./dist/rollup.d.ts",
+      "default": "./dist/rollup.js"
+    },
     "./babel": "./src/babel.ts",
+    "./babel/$built$": {
+      "types": "./dist/babel.d.ts",
+      "default": "./dist/babel.js"
+    },
     "./bun": "./src/bun.ts",
+    "./bun/$built$": {
+      "types": "./dist/bun.d.ts",
+      "default": "./dist/bun.js"
+    },
     "./esbuild": "./src/esbuild.ts",
+    "./esbuild/$built$": {
+      "types": "./dist/esbuild.d.ts",
+      "default": "./dist/esbuild.js"
+    },
     "./farm": "./src/farm.ts",
+    "./farm/$built$": {
+      "types": "./dist/farm.d.ts",
+      "default": "./dist/farm.js"
+    },
     "./rolldown": "./src/rolldown.ts",
+    "./rolldown/$built$": {
+      "types": "./dist/rolldown.d.ts",
+      "default": "./dist/rolldown.js"
+    },
     "./rolldown-browser": "./src/rolldown-browser.ts",
+    "./rolldown-browser/$built$": {
+      "types": "./dist/rolldown-browser.d.ts",
+      "default": "./dist/rolldown-browser.js"
+    },
     "./rspack": "./src/rspack.ts",
+    "./rspack/$built$": {
+      "types": "./dist/rspack.d.ts",
+      "default": "./dist/rspack.js"
+    },
     "./vite": "./src/vite.ts",
-    "./webpack": "./src/webpack.ts"
+    "./vite/$built$": {
+      "types": "./dist/vite.d.ts",
+      "default": "./dist/vite.js"
+    },
+    "./webpack": "./src/webpack.ts",
+    "./webpack/$built$": {
+      "types": "./dist/webpack.d.ts",
+      "default": "./dist/webpack.js"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/unplugin-typegpu/package.json
+++ b/packages/unplugin-typegpu/package.json
@@ -30,58 +30,124 @@
     "./package.json": "./package.json",
     ".": "./src/index.ts",
     "./$built$": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./rollup": "./src/rollup.ts",
     "./rollup/$built$": {
-      "types": "./dist/rollup.d.ts",
-      "default": "./dist/rollup.js"
+      "import": {
+        "types": "./dist/rollup.d.ts",
+        "default": "./dist/rollup.js"
+      },
+      "require": {
+        "types": "./dist/rollup.d.cts",
+        "default": "./dist/rollup.cjs"
+      }
     },
     "./babel": "./src/babel.ts",
     "./babel/$built$": {
-      "types": "./dist/babel.d.ts",
-      "default": "./dist/babel.js"
+      "import": {
+        "types": "./dist/babel.d.ts",
+        "default": "./dist/babel.js"
+      },
+      "require": {
+        "types": "./dist/babel.d.cts",
+        "default": "./dist/babel.cjs"
+      }
     },
     "./bun": "./src/bun.ts",
     "./bun/$built$": {
-      "types": "./dist/bun.d.ts",
-      "default": "./dist/bun.js"
+      "import": {
+        "types": "./dist/bun.d.ts",
+        "default": "./dist/bun.js"
+      },
+      "require": {
+        "types": "./dist/bun.d.cts",
+        "default": "./dist/bun.cjs"
+      }
     },
     "./esbuild": "./src/esbuild.ts",
     "./esbuild/$built$": {
-      "types": "./dist/esbuild.d.ts",
-      "default": "./dist/esbuild.js"
+      "import": {
+        "types": "./dist/esbuild.d.ts",
+        "default": "./dist/esbuild.js"
+      },
+      "require": {
+        "types": "./dist/esbuild.d.cts",
+        "default": "./dist/esbuild.cjs"
+      }
     },
     "./farm": "./src/farm.ts",
     "./farm/$built$": {
-      "types": "./dist/farm.d.ts",
-      "default": "./dist/farm.js"
+      "import": {
+        "types": "./dist/farm.d.ts",
+        "default": "./dist/farm.js"
+      },
+      "require": {
+        "types": "./dist/farm.d.cts",
+        "default": "./dist/farm.cjs"
+      }
     },
     "./rolldown": "./src/rolldown.ts",
     "./rolldown/$built$": {
-      "types": "./dist/rolldown.d.ts",
-      "default": "./dist/rolldown.js"
+      "import": {
+        "types": "./dist/rolldown.d.ts",
+        "default": "./dist/rolldown.js"
+      },
+      "require": {
+        "types": "./dist/rolldown.d.cts",
+        "default": "./dist/rolldown.cjs"
+      }
     },
     "./rolldown-browser": "./src/rolldown-browser.ts",
     "./rolldown-browser/$built$": {
-      "types": "./dist/rolldown-browser.d.ts",
-      "default": "./dist/rolldown-browser.js"
+      "import": {
+        "types": "./dist/rolldown-browser.d.ts",
+        "default": "./dist/rolldown-browser.js"
+      },
+      "require": {
+        "types": "./dist/rolldown-browser.d.cts",
+        "default": "./dist/rolldown-browser.cjs"
+      }
     },
     "./rspack": "./src/rspack.ts",
     "./rspack/$built$": {
-      "types": "./dist/rspack.d.ts",
-      "default": "./dist/rspack.js"
+      "import": {
+        "types": "./dist/rspack.d.ts",
+        "default": "./dist/rspack.js"
+      },
+      "require": {
+        "types": "./dist/rspack.d.cts",
+        "default": "./dist/rspack.cjs"
+      }
     },
     "./vite": "./src/vite.ts",
     "./vite/$built$": {
-      "types": "./dist/vite.d.ts",
-      "default": "./dist/vite.js"
+      "import": {
+        "types": "./dist/vite.d.ts",
+        "default": "./dist/vite.js"
+      },
+      "require": {
+        "types": "./dist/vite.d.cts",
+        "default": "./dist/vite.cjs"
+      }
     },
     "./webpack": "./src/webpack.ts",
     "./webpack/$built$": {
-      "types": "./dist/webpack.d.ts",
-      "default": "./dist/webpack.js"
+      "import": {
+        "types": "./dist/webpack.d.ts",
+        "default": "./dist/webpack.js"
+      },
+      "require": {
+        "types": "./dist/webpack.d.cts",
+        "default": "./dist/webpack.cjs"
+      }
     }
   },
   "publishConfig": {

--- a/packages/unplugin-typegpu/package.json
+++ b/packages/unplugin-typegpu/package.json
@@ -37,7 +37,8 @@
       "require": {
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
-      }
+      },
+      "default": "./dist/index.js"
     },
     "./rollup": "./src/rollup.ts",
     "./rollup/$built$": {
@@ -48,7 +49,8 @@
       "require": {
         "types": "./dist/rollup.d.cts",
         "default": "./dist/rollup.cjs"
-      }
+      },
+      "default": "./dist/rollup.js"
     },
     "./babel": "./src/babel.ts",
     "./babel/$built$": {
@@ -59,7 +61,8 @@
       "require": {
         "types": "./dist/babel.d.cts",
         "default": "./dist/babel.cjs"
-      }
+      },
+      "default": "./dist/babel.js"
     },
     "./bun": "./src/bun.ts",
     "./bun/$built$": {
@@ -70,7 +73,8 @@
       "require": {
         "types": "./dist/bun.d.cts",
         "default": "./dist/bun.cjs"
-      }
+      },
+      "default": "./dist/bun.js"
     },
     "./esbuild": "./src/esbuild.ts",
     "./esbuild/$built$": {
@@ -81,7 +85,8 @@
       "require": {
         "types": "./dist/esbuild.d.cts",
         "default": "./dist/esbuild.cjs"
-      }
+      },
+      "default": "./dist/esbuild.js"
     },
     "./farm": "./src/farm.ts",
     "./farm/$built$": {
@@ -92,7 +97,8 @@
       "require": {
         "types": "./dist/farm.d.cts",
         "default": "./dist/farm.cjs"
-      }
+      },
+      "default": "./dist/farm.js"
     },
     "./rolldown": "./src/rolldown.ts",
     "./rolldown/$built$": {
@@ -103,7 +109,8 @@
       "require": {
         "types": "./dist/rolldown.d.cts",
         "default": "./dist/rolldown.cjs"
-      }
+      },
+      "default": "./dist/rolldown.js"
     },
     "./rolldown-browser": "./src/rolldown-browser.ts",
     "./rolldown-browser/$built$": {
@@ -114,7 +121,8 @@
       "require": {
         "types": "./dist/rolldown-browser.d.cts",
         "default": "./dist/rolldown-browser.cjs"
-      }
+      },
+      "default": "./dist/rolldown-browser.js"
     },
     "./rspack": "./src/rspack.ts",
     "./rspack/$built$": {
@@ -125,7 +133,8 @@
       "require": {
         "types": "./dist/rspack.d.cts",
         "default": "./dist/rspack.cjs"
-      }
+      },
+      "default": "./dist/rspack.js"
     },
     "./vite": "./src/vite.ts",
     "./vite/$built$": {
@@ -136,7 +145,8 @@
       "require": {
         "types": "./dist/vite.d.cts",
         "default": "./dist/vite.cjs"
-      }
+      },
+      "default": "./dist/vite.js"
     },
     "./webpack": "./src/webpack.ts",
     "./webpack/$built$": {
@@ -147,7 +157,8 @@
       "require": {
         "types": "./dist/webpack.d.cts",
         "default": "./dist/webpack.cjs"
-      }
+      },
+      "default": "./dist/webpack.js"
     }
   },
   "publishConfig": {

--- a/packages/unplugin-typegpu/tsdown.config.ts
+++ b/packages/unplugin-typegpu/tsdown.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'tsdown';
 
+// `$built$` is a workspace-only marker; prepack replaces it with the public export map.
 export default defineConfig({
   entry: [
     'src/index.ts',


### PR DESCRIPTION
## Summary

Adds `$built$` sibling entries to the dev `exports` map in `packages/unplugin-typegpu/package.json` so consumers can opt into the compiled `dist/*.js` artifacts instead of the raw TypeScript source. Every existing subpath (`.`, `rollup`, `babel`, `bun`, `esbuild`, `farm`, `rolldown`, `rolldown-browser`, `rspack`, `vite`, `webpack`) gains a matching `<subpath>/$built$` entry resolving to `./dist/<name>.js` (and `./dist/<name>.d.ts` for types). The original `./src/*.ts` entries are left untouched, and `publishConfig.exports` is unchanged.

This mirrors the exact mechanism already used by the sibling `typegpu` package, which exposes `$built$` variants of each export pointing at its compiled `dist` output.

## Why this matters

Today the dev `exports` map points every subpath directly at `./src/*.ts`. When the package is consumed outside the dev/monorepo resolution (or when a consumer simply wants the compiled output), there is no way to opt into the built artifacts, so the raw `.ts` source is imported. Issue #2605 requests exactly this, and the maintainer confirmed the direction:

> "We could use the same mechanism we use for the `typegpu` package, and expose the built package artifacts under `unplugin-typegpu/babel/$built$`."

## Testing

- `package.json` remains valid JSON.
- `pnpm --filter unplugin-typegpu build` (tsdown) produces every referenced `dist` file; no `$built$` entry points at a non-existent artifact (all 11 subpaths cross-checked against the tsdown entry list).
- Runtime resolution verified: `require('unplugin-typegpu/babel/$built$')` resolves to the compiled `./dist/babel.js`.
- `pnpm --filter unplugin-typegpu test:types` passes; `oxlint` and `oxfmt --check` report no issues on the changed file.

Fixes #2605
