### PR TITLE
fix: Use a more compatible API path for Genetic Racing example

### DIFF
--- a/apps/typegpu-docs/src/examples/algorithms/genetic-racing/index.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/genetic-racing/index.ts
@@ -477,9 +477,7 @@ function frame() {
 }
 
 function applyTrack(result: TrackResult) {
-  trackTexture.write(
-    new ImageData(new Uint8ClampedArray(result.data), result.width, result.height),
-  );
+  trackTexture.write(result.data.buffer);
   params.patch({
     spawnX: result.spawn.position[0],
     spawnY: result.spawn.position[1],

--- a/apps/typegpu-docs/src/examples/algorithms/genetic-racing/track.ts
+++ b/apps/typegpu-docs/src/examples/algorithms/genetic-racing/track.ts
@@ -3,7 +3,7 @@ import { std } from 'typegpu';
 export type TrackResult = {
   width: number;
   height: number;
-  data: Uint8ClampedArray;
+  data: Uint8ClampedArray<ArrayBuffer>;
   spawn: { position: [number, number]; angle: number };
   trackLength: number;
 };


### PR DESCRIPTION
The `.copyExternalImageToTexture` API (which is used internally by `texture.write()`) does not work on Firefox and Safari. In this case it was also totally redundant.