### PR TITLE
chore: Skip dist/ typecheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,6 @@
     "emitDeclarationOnly": false,
     "noEmit": true,
     "jsx": "react-jsx"
-  }
+  },
+  "exclude": ["**/dist"]
 }


### PR DESCRIPTION
This was causing TypeScript to overflow the stack when running `pnpm run test:unit-and-attest`