### PR TITLE
feat: accept buffer shorthands directly in createBindGroup

### DIFF
--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -1,5 +1,12 @@
 import { isBuffer, type TgpuBuffer, type UniformFlag } from './core/buffer/buffer.ts';
 import {
+  isBufferShorthand,
+  type TgpuBufferShorthand,
+  type TgpuMutable,
+  type TgpuReadonly,
+  type TgpuUniform,
+} from './core/buffer/bufferShorthand.ts';
+import {
   isUsableAsUniform,
   type TgpuBufferMutable,
   type TgpuBufferReadonly,
@@ -341,6 +348,7 @@ export type LayoutEntryToInput<T extends TgpuLayoutEntry | null> =
   TgpuLayoutEntry | null extends T
     ?
         | TgpuBuffer<AnyWgslData>
+        | TgpuBufferShorthand<AnyWgslData>
         | GPUBuffer
         | TgpuSampler
         | GPUSampler
@@ -350,10 +358,15 @@ export type LayoutEntryToInput<T extends TgpuLayoutEntry | null> =
         | GPUExternalTexture
     : // Strict type-checking
       T extends TgpuLayoutUniform
-      ? (TgpuBuffer<MemIdentity<UnwrapRuntimeConstructor<T['uniform']>>> & UniformFlag) | GPUBuffer
+      ?
+          | (TgpuBuffer<MemIdentity<UnwrapRuntimeConstructor<T['uniform']>>> & UniformFlag)
+          | TgpuUniform<MemIdentity<UnwrapRuntimeConstructor<T['uniform']>>>
+          | GPUBuffer
       : T extends TgpuLayoutStorage
         ?
             | (TgpuBuffer<MemIdentity<UnwrapRuntimeConstructor<T['storage']>>> & StorageFlag)
+            | TgpuMutable<MemIdentity<UnwrapRuntimeConstructor<T['storage']>>>
+            | TgpuReadonly<MemIdentity<UnwrapRuntimeConstructor<T['storage']>>>
             | GPUBuffer
         : T extends TgpuLayoutSampler
           ? TgpuSampler | GPUSampler
@@ -682,7 +695,14 @@ export class TgpuBindGroupImpl<
             return null;
           }
 
-          const value = this.entries[key as keyof typeof this.entries];
+          // Buffer shorthands (uniform/mutable/readonly) are accepted directly
+          // for buffer-typed entries; unwrap them to their underlying buffer so
+          // the rest of the bind-group machinery is unchanged.
+          const entryValue = this.entries[key as keyof typeof this.entries];
+          const value = (isBufferShorthand(entryValue) ? entryValue.buffer : entryValue) as Exclude<
+            (typeof this.entries)[keyof typeof this.entries],
+            TgpuBufferShorthand<AnyWgslData>
+          >;
 
           if (value === undefined) {
             throw new Error(

--- a/packages/typegpu/tests/bindGroupLayout.test.ts
+++ b/packages/typegpu/tests/bindGroupLayout.test.ts
@@ -266,6 +266,80 @@ describe('TgpuBindGroup', () => {
         ],
       });
     });
+
+    it('populates a uniform layout with a buffer shorthand', ({ root }) => {
+      const uniform = root.createUniform(d.vec3f);
+      const bindGroup = root.createBindGroup(layout, { foo: uniform });
+
+      root.unwrap(bindGroup);
+
+      expect(root.device.createBindGroup).toBeCalledWith({
+        label: 'example',
+        layout: root.unwrap(layout),
+        entries: [
+          {
+            binding: 0,
+            resource: {
+              buffer: root.unwrap(uniform.buffer),
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  describe('simple storage layout', () => {
+    let layout: TgpuBindGroupLayout<{
+      foo: { storage: d.Vec3f; access: 'mutable' };
+    }>;
+
+    beforeEach(() => {
+      layout = tgpu
+        .bindGroupLayout({
+          foo: { storage: d.vec3f, access: 'mutable' },
+        })
+        .$name('example');
+    });
+
+    it('populates a storage layout with a mutable shorthand', ({ root }) => {
+      const mutable = root.createMutable(d.vec3f);
+      const bindGroup = root.createBindGroup(layout, { foo: mutable });
+
+      root.unwrap(bindGroup);
+
+      expect(root.device.createBindGroup).toBeCalledWith({
+        label: 'example',
+        layout: root.unwrap(layout),
+        entries: [
+          {
+            binding: 0,
+            resource: {
+              buffer: root.unwrap(mutable.buffer),
+            },
+          },
+        ],
+      });
+    });
+
+    it('populates a storage layout with a readonly shorthand', ({ root }) => {
+      const readonly = root.createReadonly(d.vec3f);
+      const bindGroup = root.createBindGroup(layout, { foo: readonly });
+
+      root.unwrap(bindGroup);
+
+      expect(root.device.createBindGroup).toBeCalledWith({
+        label: 'example',
+        layout: root.unwrap(layout),
+        entries: [
+          {
+            binding: 0,
+            resource: {
+              buffer: root.unwrap(readonly.buffer),
+            },
+          },
+        ],
+      });
+    });
   });
 
   describe('simple layout with atomics', () => {


### PR DESCRIPTION
## Summary

Lets buffer shorthands (`root.createUniform` / `root.createMutable` / `root.createReadonly`) be passed directly as entries to `root.createBindGroup(...)`, without first unwrapping them back to the underlying buffer usage.

```ts
const uniform = root.createUniform(d.vec3f);

// before: had to unwrap to the buffer/usage
root.createBindGroup(layout, { foo: uniform.buffer });

// now: the shorthand is accepted directly
root.createBindGroup(layout, { foo: uniform });
```

Changes are purely additive on the input side:

- `LayoutEntryToInput` now accepts `TgpuUniform` for uniform entries and `TgpuMutable`/`TgpuReadonly` for storage entries (and `TgpuBufferShorthand` in the widest-type branch), reusing the existing `MemIdentity`/`UnwrapRuntimeConstructor` machinery so the same type guarantees apply.
- `TgpuBindGroupImpl.unwrap` detects shorthands via the existing `isBufferShorthand` guard and resolves them to their underlying `buffer`, so the rest of the bind-group machinery is unchanged.

All previously accepted entry types (raw buffer usages, `GPUBuffer`, textures, samplers) continue to work unchanged. This covers the direct bind-group acceptance path only and does not depend on #2454.

## Why this matters

Closes #2477. The shorthands were introduced to make buffers easier to use, but bind groups still required unwrapping them by hand, which was an inconsistency the issue (and the maintainer discussion) flagged. Accepting them directly removes that friction and matches the ergonomics shorthands were meant to provide.

## Testing

Added unit tests in `bindGroupLayout.test.ts` covering:

- a `createUniform` shorthand passed directly for a uniform entry, producing the same resolved bind group as the unwrapped buffer
- `createMutable` and `createReadonly` shorthands accepted for storage entries

Verified locally (in `packages/typegpu`):

- `pnpm run test:types` — passes
- `pnpm exec vitest run --project=!browser bindGroupLayout` — 36/36 pass
- `oxlint --type-aware` + `oxfmt --check` on the touched files — clean

Fixes #2477
