### PR TITLE
fix: Fail early when compiling a writer for a runtime-sized array schema

### DIFF
--- a/apps/typegpu-docs/tests/individual-example-tests/utils/commonMocks.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/utils/commonMocks.ts
@@ -192,13 +192,13 @@ export function mock3DModelLoading() {
     load: vi.fn(async () => ({
       attributes: {
         POSITION: {
-          value: new Float32Array(),
+          value: new Float32Array([0, 0, 0, 1, 1, 1, 2, 2, 2]),
         },
         NORMAL: {
-          value: new Float32Array(),
+          value: new Float32Array([0, 1, 0, 0, 1, 0, 0, 1, 0]),
         },
         TEXCOORD_0: {
-          value: new Float32Array(),
+          value: new Float32Array([0, 0, 0, 0, 0, 0]),
         },
       },
     })),

--- a/packages/typegpu/src/data/compiledIO.ts
+++ b/packages/typegpu/src/data/compiledIO.ts
@@ -179,6 +179,10 @@ export function buildWriter(
     }
 
     if (wgsl.isWgslArray(node) || isDisarray(node)) {
+      if (node.elementCount === 0) {
+        throw new Error('Cannot write using a runtime-sized schema.');
+      }
+
       const elementSize = roundUp(sizeOf(node.elementType), alignmentOf(node));
       const totalSize = node.elementCount * elementSize;
 

--- a/packages/typegpu/tests/array.test.ts
+++ b/packages/typegpu/tests/array.test.ts
@@ -1,8 +1,6 @@
 import { attest } from '@ark/attest';
-import { BufferReader, BufferWriter } from 'typed-binary';
 import { describe, expect, expectTypeOf } from 'vitest';
-import { readData, writeData } from '../src/data/dataIO.ts';
-import { d, tgpu } from '../src/index.js';
+import { d, tgpu, readFromArrayBuffer, writeToArrayBuffer } from 'typegpu';
 import { namespace } from '../src/core/resolve/namespace.ts';
 import { resolve } from '../src/resolutionCtx.ts';
 import type { Infer } from '../src/shared/repr.ts';
@@ -23,20 +21,18 @@ describe('array', () => {
   it('aligns array elements when writing', () => {
     const TestArray = d.arrayOf(d.vec3u, 3);
     const buffer = new ArrayBuffer(d.sizeOf(TestArray));
-    const writer = new BufferWriter(buffer);
 
-    writeData(writer, TestArray, [d.vec3u(1, 2, 3), d.vec3u(4, 5, 6), d.vec3u(7, 8, 9)]);
+    writeToArrayBuffer(buffer, TestArray, [d.vec3u(1, 2, 3), d.vec3u(4, 5, 6), d.vec3u(7, 8, 9)]);
     expect([...new Uint32Array(buffer)]).toStrictEqual([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0]);
   });
 
   it('aligns array elements when reading', () => {
     const TestArray = d.arrayOf(d.vec3u, 3);
     const buffer = new ArrayBuffer(d.sizeOf(TestArray));
-    const reader = new BufferReader(buffer);
 
     new Uint32Array(buffer).set([1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0]);
 
-    expect(readData(reader, TestArray)).toStrictEqual([
+    expect(readFromArrayBuffer(buffer, TestArray)).toStrictEqual([
       d.vec3u(1, 2, 3),
       d.vec3u(4, 5, 6),
       d.vec3u(7, 8, 9),
@@ -56,8 +52,8 @@ describe('array', () => {
       d.vec3f(1.5, 2, 15),
     ];
 
-    writeData(new BufferWriter(buffer), TestArray, value);
-    expect(readData(new BufferReader(buffer), TestArray)).toStrictEqual(value);
+    writeToArrayBuffer(buffer, TestArray, value);
+    expect(readFromArrayBuffer(buffer, TestArray)).toStrictEqual(value);
   });
 
   it('throws when trying to read/write a runtime-sized array', () => {
@@ -66,10 +62,10 @@ describe('array', () => {
     expect(d.sizeOf(TestArray)).toBeNaN();
 
     expect(() =>
-      writeData(new BufferWriter(new ArrayBuffer(0)), TestArray, [d.vec3f(), d.vec3f()]),
+      writeToArrayBuffer(new ArrayBuffer(0), TestArray, [d.vec3f(), d.vec3f()]),
     ).toThrow();
 
-    expect(() => readData(new BufferReader(new ArrayBuffer(0)), TestArray)).toThrow();
+    expect(() => readFromArrayBuffer(new ArrayBuffer(0), TestArray)).toThrow();
 
     const opts = { namespace: namespace({ names: 'strict' }) };
 


### PR DESCRIPTION
This check is already happening in the non-compiled writer path