### PR TITLE
fix(@typegpu/react): Better SSR handling

### DIFF
--- a/apps/react-prerendering-test/app/page.tsx
+++ b/apps/react-prerendering-test/app/page.tsx
@@ -1,12 +1,16 @@
-'use client';
-
-import dynamic from 'next/dynamic';
+import { Root, ClientOnly } from '@typegpu/react';
 import Shader from '../components/Shader.tsx';
 
-const ShaderNoSSR = dynamic(() => import('../components/Shader.tsx'), {
-  ssr: false,
-});
-
 export default function Page() {
-  return process.env.NEXT_PUBLIC_DISABLE_SSR ? <ShaderNoSSR /> : <Shader />;
+  return (
+    <Root>
+      <ClientOnly
+        fallback={
+          <p style={{ backgroundColor: 'red', color: 'white', padding: '1rem' }}>Loading...</p>
+        }
+      >
+        <Shader />
+      </ClientOnly>
+    </Root>
+  );
 }

--- a/packages/typegpu-react/src/core/client-only.tsx
+++ b/packages/typegpu-react/src/core/client-only.tsx
@@ -22,7 +22,7 @@ export function ClientOnly(props: ClientOnly.Props) {
   }, []);
 
   if (!hydrated) {
-    return props.fallback || null;
+    return props.fallback ?? null;
   }
 
   return <Suspense fallback={props.fallback}>{props.children}</Suspense>;

--- a/packages/typegpu-react/src/core/client-only.tsx
+++ b/packages/typegpu-react/src/core/client-only.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Suspense, useEffect, useState, type ReactNode } from 'react';
+
+export namespace ClientOnly {
+  export interface Props {
+    children?: ReactNode | undefined;
+    fallback?: ReactNode | undefined;
+  }
+}
+
+/**
+ * Only mounts children when the component is being rendered on the client.
+ * Returns `fallback` on the server, as well as wraps the content in <Suspense>
+ * with the same fallback.
+ */
+export function ClientOnly(props: ClientOnly.Props) {
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  if (!hydrated) {
+    return props.fallback || null;
+  }
+
+  return <Suspense fallback={props.fallback}>{props.children}</Suspense>;
+}

--- a/packages/typegpu-react/src/core/root-context.tsx
+++ b/packages/typegpu-react/src/core/root-context.tsx
@@ -1,13 +1,17 @@
+'use client'; // will cause the <Root /> component to be hydrated on the client
 import React, {
   createContext,
   type ReactNode,
+  Suspense,
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import tgpu, { type TgpuRoot } from 'typegpu';
 import { useDeferredCleanup } from './helper-hooks.ts';
+import { useBailOnServer } from './use-bail-on-server.ts';
 
 function attachPromiseStatus<T>(
   promise: PromiseLike<T> & {
@@ -53,10 +57,23 @@ const use =
     }
   };
 
+type RootContextPendingResult = {
+  status: 'pending';
+  promise: Promise<TgpuRoot>;
+  settledPromise: Promise<PromiseSettledResult<TgpuRoot>>;
+};
+type RootContextFulfilledResult = {
+  status: 'fulfilled';
+  promise?: Promise<TgpuRoot> | undefined;
+  settledPromise?: Promise<PromiseSettledResult<TgpuRoot>> | undefined;
+  value: TgpuRoot;
+};
+type RootContextRejectedResult = { status: 'rejected'; reason: unknown };
+
 type RootContextResult =
-  | { status: 'pending'; promise: Promise<TgpuRoot> }
-  | { status: 'resolved'; value: TgpuRoot }
-  | { status: 'rejected'; error: unknown };
+  | RootContextPendingResult
+  | RootContextFulfilledResult
+  | RootContextRejectedResult;
 
 interface RootContext {
   initOrGetRoot(): RootContextResult;
@@ -70,28 +87,36 @@ class OwnRootContext implements RootContext {
   initOrGetRoot(): RootContextResult {
     if (this.#destroyed) {
       console.warn(`[@typegpu/react]: Tried to init an already destroyed root.`);
-      return { status: 'rejected', error: new Error('Already destroyed') };
+      return { status: 'rejected', reason: new Error('Already destroyed') };
     }
 
     if (!this.#result) {
+      const promise = tgpu.init().then(
+        (root) => {
+          if (this.#destroyed) {
+            root.destroy();
+            this.#result = undefined;
+          } else {
+            this.#result = { status: 'fulfilled', promise, settledPromise, value: root };
+          }
+
+          return root;
+        },
+        (reason) => {
+          this.#result = { status: 'rejected', reason };
+          throw reason;
+        },
+      );
+
+      const settledPromise = promise.then(
+        (value) => ({ status: 'fulfilled' as const, value }),
+        (reason) => ({ status: 'rejected' as const, reason }),
+      );
+
       this.#result = {
         status: 'pending',
-        promise: tgpu.init().then(
-          (root) => {
-            if (this.#destroyed) {
-              root.destroy();
-              this.#result = undefined;
-            } else {
-              this.#result = { status: 'resolved', value: root };
-            }
-
-            return root;
-          },
-          (error) => {
-            this.#result = { status: 'rejected', error };
-            throw error;
-          },
-        ),
+        promise,
+        settledPromise,
       };
     }
 
@@ -101,7 +126,7 @@ class OwnRootContext implements RootContext {
   unmount(): void {
     this.#destroyed = true;
 
-    if (this.#result?.status === 'resolved') {
+    if (this.#result?.status === 'fulfilled') {
       this.#result.value.destroy();
     }
     this.#result = undefined;
@@ -109,10 +134,10 @@ class OwnRootContext implements RootContext {
 }
 
 class ExistingRootContext implements RootContext {
-  result: { status: 'resolved'; value: TgpuRoot };
+  result: { status: 'fulfilled'; value: TgpuRoot };
 
   constructor(root: TgpuRoot) {
-    this.result = { status: 'resolved', value: root };
+    this.result = { status: 'fulfilled', value: root };
   }
 
   initOrGetRoot(): RootContextResult {
@@ -142,6 +167,22 @@ export interface RootProps {
   children?: ReactNode | undefined;
 }
 
+function WarnSuspense() {
+  const warnedRef = useRef(false);
+  useEffect(() => {
+    if (warnedRef.current) {
+      return;
+    }
+
+    warnedRef.current = true;
+    console.warn(
+      `[@typegpu/react] There's no Suspense boundary between <Root /> and components using @typegpu/react hooks. Either move the <Root /> component above a boundary, or provide one below it to customize the loading fallback. Note that the <ClientOnly /> component also acts as a Suspense boundary.`,
+    );
+  }, []);
+
+  return null;
+}
+
 export const Root = ({ children, root }: RootProps) => {
   const [ownCtx] = useState(() => new OwnRootContext());
   const existingRootCtx = useMemo(() => {
@@ -155,7 +196,11 @@ export const Root = ({ children, root }: RootProps) => {
     ownCtx.unmount();
   });
 
-  return <rootContext.Provider value={existingRootCtx ?? ownCtx}>{children}</rootContext.Provider>;
+  return (
+    <rootContext.Provider value={existingRootCtx ?? ownCtx}>
+      <Suspense fallback={<WarnSuspense />}>{children}</Suspense>
+    </rootContext.Provider>
+  );
 };
 
 /**
@@ -169,42 +214,50 @@ export const Root = ({ children, root }: RootProps) => {
  * {@link useRootWithStatus} instead.
  */
 export function useRoot(): TgpuRoot {
+  useBailOnServer();
+
   const context = useContext(rootContext) ?? globalRootContextValue;
 
   const result = context.initOrGetRoot();
   if (result.status === 'rejected') {
-    throw result.error as Error;
+    throw result.reason as Error;
   }
-  return result.status === 'pending' ? use(result.promise) : result.value;
+  // Making sure to `use` the promise again after the component unsuspends and it's already
+  // been resolved, and to return the value outright if there was no promise to suspend on
+  // before. This allows React to verify that hooks have been ran in the same order across renders.
+  return result.promise ? use(result.promise) : (result as RootContextFulfilledResult).value;
 }
 
 /**
  * Same as {@link useRoot}, but returns `null` if the root failed to initialize.
  */
 export function useRootOrError():
-  | { status: 'resolved'; value: TgpuRoot }
-  | { status: 'rejected'; error: unknown } {
+  | { status: 'fulfilled'; value: TgpuRoot }
+  | { status: 'rejected'; reason: unknown } {
+  useBailOnServer();
+
   const context = useContext(rootContext) ?? globalRootContextValue;
 
   const result = context.initOrGetRoot();
 
   if (result.status === 'rejected') {
-    return { status: 'rejected', error: result.error };
+    return { status: 'rejected', reason: result.reason };
   }
 
-  return result.status === 'pending'
-    ? use(
-        result.promise
-          .then((value) => ({ status: 'resolved' as const, value }))
-          .catch((error) => ({ status: 'rejected' as const, error })),
-      )
-    : { status: 'resolved', value: result.value };
+  // Making sure to `use` the promise again after the component unsuspends and it's already
+  // been resolved, and to return the value outright if there was no promise to suspend on
+  // before. This allows React to verify that hooks have been ran in the same order across renders.
+  return result.settledPromise
+    ? use(result.settledPromise)
+    : { status: 'fulfilled', value: (result as RootContextFulfilledResult).value };
 }
 
 /**
  * Same as {@link useRoot}, but does not suspend or throw.
  */
 export function useRootWithStatus(): RootContextResult {
+  useBailOnServer();
+
   const context = useContext(rootContext) ?? globalRootContextValue;
   const result = context.initOrGetRoot();
 

--- a/packages/typegpu-react/src/core/root-context.tsx
+++ b/packages/typegpu-react/src/core/root-context.tsx
@@ -223,13 +223,14 @@ export function useRoot(): TgpuRoot {
     throw result.reason as Error;
   }
   // Making sure to `use` the promise again after the component unsuspends and it's already
-  // been resolved, and to return the value outright if there was no promise to suspend on
-  // before. This allows React to verify that hooks have been ran in the same order across renders.
+  // been fulfilled, and to return the value outright if there was no promise to suspend on
+  // before. This allows React to verify that hooks have run in the same order across renders.
   return result.promise ? use(result.promise) : (result as RootContextFulfilledResult).value;
 }
 
 /**
- * Same as {@link useRoot}, but returns `null` if the root failed to initialize.
+ * Same as {@link useRoot}, but returns a PromiseSettledResult-style object instead of throwing.
+ * If initialization is still in progress, this hook will suspend until it settles.
  */
 export function useRootOrError():
   | { status: 'fulfilled'; value: TgpuRoot }
@@ -245,8 +246,8 @@ export function useRootOrError():
   }
 
   // Making sure to `use` the promise again after the component unsuspends and it's already
-  // been resolved, and to return the value outright if there was no promise to suspend on
-  // before. This allows React to verify that hooks have been ran in the same order across renders.
+  // been fulfilled, and to return the value outright if there was no promise to suspend on
+  // before. This allows React to verify that hooks have run in the same order across renders.
   return result.settledPromise
     ? use(result.settledPromise)
     : { status: 'fulfilled', value: (result as RootContextFulfilledResult).value };

--- a/packages/typegpu-react/src/core/use-bail-on-server.ts
+++ b/packages/typegpu-react/src/core/use-bail-on-server.ts
@@ -1,0 +1,16 @@
+/**
+ * Throwing an error only on the server to opt-out of server rendering, show the nearest
+ * suspense boundary and resume on the client as recommended by:
+ *
+ * https://react.dev/reference/react/Suspense#providing-a-fallback-for-server-errors-and-client-only-content
+ *
+ * It unfortunatelly still causes an error log to be surfaced to the developer, tracked here:
+ * https://github.com/reactjs/react.dev/issues/8497
+ */
+export function useBailOnServer() {
+  if (typeof window === 'undefined') {
+    throw new Error(`\
+WebGPU cannot be used on the server. Make sure that this component runs only on the client.
+You can use the <ClientOnly /> component from '@typegpu/react' to help with this.`);
+  }
+}

--- a/packages/typegpu-react/src/core/use-bail-on-server.ts
+++ b/packages/typegpu-react/src/core/use-bail-on-server.ts
@@ -4,13 +4,14 @@
  *
  * https://react.dev/reference/react/Suspense#providing-a-fallback-for-server-errors-and-client-only-content
  *
- * It unfortunatelly still causes an error log to be surfaced to the developer, tracked here:
+ * It unfortunately still causes an error log to be surfaced to the developer, tracked here:
  * https://github.com/reactjs/react.dev/issues/8497
  */
 export function useBailOnServer() {
   if (typeof window === 'undefined') {
-    throw new Error(`\
-WebGPU cannot be used on the server. Make sure that this component runs only on the client.
-You can use the <ClientOnly /> component from '@typegpu/react' to help with this.`);
+    throw new Error(
+      `WebGPU cannot be used on the server. Make sure that this component runs only on the client.\n` +
+        `You can use the <ClientOnly /> component from '@typegpu/react' to help with this.`,
+    );
   }
 }

--- a/packages/typegpu-react/src/shared-exports.ts
+++ b/packages/typegpu-react/src/shared-exports.ts
@@ -6,6 +6,7 @@ export { useUniform } from './core/use-uniform.ts';
 export { useMirroredUniform } from './core/use-mirrored-uniform.ts';
 export { useBuffer } from './core/use-buffer.ts';
 export { useBindGroup } from './core/use-bind-group.ts';
+export { ClientOnly } from './core/client-only.tsx';
 
 export type {
   UseConfigureContextOptions,

--- a/packages/typegpu-react/tests/root-context.test.tsx
+++ b/packages/typegpu-react/tests/root-context.test.tsx
@@ -22,7 +22,7 @@ describe('Root unmount cleanup', () => {
       const result = useRootWithStatus();
 
       useEffect(() => {
-        if (result.status === 'resolved') {
+        if (result.status === 'fulfilled') {
           capturedRoot = result.value;
         }
       });
@@ -100,7 +100,7 @@ describe('Root unmount cleanup', () => {
         const result = useRootWithStatus();
 
         useEffect(() => {
-          if (result.status === 'resolved') {
+          if (result.status === 'fulfilled') {
             capturedRoot = result.value;
           }
         });


### PR DESCRIPTION
Changes:
- [x] Fix React getting confused about the hook order across renders
- [x] Add `ClientOnly` helper component
- [x] Warn if there's no Suspense boundary between a `<Root />` component and our hooks

**Breaking changes**:
- The type returned by `useRootOrError` and `useRootWithStatus` has changed to reflect the type of `PromiseSettledResult`