### PR TITLE
chore: Automatically publishing packages that have changed since release as PR packages

### DIFF
--- a/.github/workflows/pkg-pr.yml
+++ b/.github/workflows/pkg-pr.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
 
+      - name: Fetch release ref
+        run: git fetch --no-tags --depth=1 origin release:release
+
       - name: Print commit id, message and tag
         run: |
           git show -s --format='%h %s'
@@ -33,11 +36,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --recursive --frozen-lockfile
 
-      - name: Nightly build
-        run: pnpm nightly-build
-
       - name: Publish (pkg.pr.new)
-        run: pnpm exec pkg-pr-new publish './packages/typegpu' './packages/typegpu-noise' './packages/typegpu-gl' './packages/typegpu-react' './packages/typegpu-cli' './packages/unplugin-typegpu' --json output.json --comment=off --pnpm --no-compact
+        run: pnpm exec bun scripts/publish-pkg-pr.ts
 
       - name: Post or update comment
         uses: actions/github-script@v6
@@ -45,7 +45,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
 
             const sha =
               context.event_name === 'pull_request'
@@ -53,6 +52,95 @@ jobs:
                 : context.payload.after;
 
             const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${sha}`;
+
+            const botCommentIdentifier = '**pkg.pr.new**';
+
+            async function findBotComment(issueNumber) {
+              if (!issueNumber) return null;
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+              return comments.data.find((comment) =>
+                comment.body.includes(botCommentIdentifier)
+              );
+            }
+
+            async function findIssueNumber() {
+              if (context.eventName === 'pull_request') {
+                if (!context.issue.number) {
+                  throw new Error(`Expected issue number in the context`);
+                }
+                return context.issue.number;
+              } else if (context.eventName === 'push') {
+                const pullRequests = await github.rest.pulls.list({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  head: `${context.repo.owner}:${context.ref.replace(
+                    'refs/heads/',
+                    ''
+                  )}`,
+                });
+
+                if (pullRequests.data.length === 0) {
+                  throw new Error('No open pull request found for this push.');
+                }
+                return pullRequests.data[0].number;
+              }
+            }
+
+            async function createOrUpdateComment(issueNumber, body) {
+              if (!issueNumber) {
+                console.log('No issue number provided. Cannot post or update comment.');
+                return;
+              }
+
+              const existingComment = await findBotComment(issueNumber);
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: issueNumber,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body,
+                });
+              }
+            }
+
+            async function logPublishInfo(output) {
+              console.log('\n' + '='.repeat(50));
+              console.log('Publish Information');
+              console.log('='.repeat(50));
+              console.log('\nPublished Packages:');
+              console.log(output.packages
+                .map((p) => `  - '${p.url}'\n`)
+                .join(''));
+              console.log('\nTemplates:');
+              console.log(output.templates);
+              console.log(`\nCommit URL: ${commitUrl}`);
+              console.log('\n' + '='.repeat(50));
+            }
+
+
+            if (!fs.existsSync('output.json')) {
+              console.log('No packages changed since release.');
+              const body = `**pkg.pr.new**
+
+            No packages changed since release`;
+
+              await createOrUpdateComment(await findIssueNumber(), body);
+              return;
+            }
+
+            const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
 
             const body = `**pkg.pr.new**
 
@@ -69,77 +157,8 @@ jobs:
             *commit*
             [view commit](${commitUrl})`;
 
-            const botCommentIdentifier = '**pkg.pr.new**';
-
-            async function findBotComment(issueNumber) {
-              if (!issueNumber) return null;
-              const comments = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-              });
-              return comments.data.find((comment) =>
-                comment.body.includes(botCommentIdentifier)
-              );
-            }
-
-            async function createOrUpdateComment(issueNumber) {
-              if (!issueNumber) {
-                console.log('No issue number provided. Cannot post or update comment.');
-                return;
-              }
-
-              const existingComment = await findBotComment(issueNumber);
-              if (existingComment) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existingComment.id,
-                  body: body,
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  issue_number: issueNumber,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  body: body,
-                });
-              }
-            }
-
-            async function logPublishInfo() {
-              console.log('\n' + '='.repeat(50));
-              console.log('Publish Information');
-              console.log('='.repeat(50));
-              console.log('\nPublished Packages:');
-              console.log(packages);
-              console.log('\nTemplates:');
-              console.log(templates);
-              console.log(`\nCommit URL: ${commitUrl}`);
-              console.log('\n' + '='.repeat(50));
-            }
-
-            if (context.eventName === 'pull_request') {
-              if (context.issue.number) {
-                await createOrUpdateComment(context.issue.number);
-              }
-            } else if (context.eventName === 'push') {
-              const pullRequests = await github.rest.pulls.list({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                head: `${context.repo.owner}:${context.ref.replace(
-                  'refs/heads/',
-                  ''
-                )}`,
-              });
-
-              if (pullRequests.data.length > 0) {
-                await createOrUpdateComment(pullRequests.data[0].number);
-              } else {
-                console.log(
-                  'No open pull request found for this push. Logging publish information to console:'
-                );
-                await logPublishInfo();
-              }
+            try {
+              await createOrUpdateComment(await findIssueNumber(), body);
+            } finally {
+              await logPublishInfo(output);
             }

--- a/.github/workflows/pkg-pr.yml
+++ b/.github/workflows/pkg-pr.yml
@@ -37,7 +37,8 @@ jobs:
         run: pnpm nightly-build
 
       - name: Publish (pkg.pr.new)
-        run: pnpm exec pkg-pr-new publish './packages/typegpu' './packages/typegpu-noise' './packages/typegpu-react' './packages/typegpu-cli' './packages/unplugin-typegpu' --json output.json --comment=off --pnpm --no-compact
+        run: pnpm exec pkg-pr-new publish './packages/typegpu' './packages/typegpu-noise' './packages/typegpu-gl' './packages/typegpu-react' './packages/typegpu-cli' './packages/unplugin-typegpu' --json output.json --comment=off --pnpm --no-compact
+
       - name: Post or update comment
         uses: actions/github-script@v6
         with:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:browser": "vitest run --browser.enabled --project browser",
     "test:browser:watch": "vitest --browser.enabled --project browser",
     "test:coverage": "vitest --coverage run",
-    "nightly-build": "SKIP_TESTS=true pnpm --filter typegpu --filter @typegpu/noise --filter @typegpu/react --filter @typegpu/cli --filter unplugin-typegpu prepublishOnly --skip-publish-tag-check",
+    "nightly-build": "SKIP_TESTS=true pnpm --filter typegpu --filter @typegpu/noise --filter @typegpu/gl --filter @typegpu/react --filter @typegpu/cli --filter unplugin-typegpu prepublishOnly --skip-publish-tag-check",
     "changes": "tgpu-dev-cli changes"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "test:browser": "vitest run --browser.enabled --project browser",
     "test:browser:watch": "vitest --browser.enabled --project browser",
     "test:coverage": "vitest --coverage run",
-    "nightly-build": "SKIP_TESTS=true pnpm --filter typegpu --filter @typegpu/noise --filter @typegpu/gl --filter @typegpu/react --filter @typegpu/cli --filter unplugin-typegpu prepublishOnly --skip-publish-tag-check",
     "changes": "tgpu-dev-cli changes"
   },
   "devDependencies": {

--- a/packages/typegpu-gl/package.json
+++ b/packages/typegpu-gl/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@typegpu/gl",
   "version": "0.11.0-alpha.1",
-  "private": true,
   "description": "WebGL and GLSL utilities for TypeGPU",
   "keywords": [],
   "license": "MIT",

--- a/scripts/_utils.ts
+++ b/scripts/_utils.ts
@@ -1,0 +1,76 @@
+import { $ } from 'bun';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PACKAGES_DIR = join(import.meta.dir, '../packages');
+
+interface PackageJson {
+  name: string;
+  private?: boolean;
+  version: string;
+}
+
+export function getPackages() {
+  const packageDirNames = readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .filter((name) => {
+      return existsSync(join(PACKAGES_DIR, name, 'package.json'));
+    });
+
+  return Promise.all(
+    packageDirNames.map(async (dirname): Promise<PackageInfo> => {
+      const dir = join(PACKAGES_DIR, dirname);
+      const pkg: PackageJson = await Bun.file(join(dir, 'package.json')).json();
+
+      return {
+        dir,
+        dirname,
+        name: pkg.name,
+        version: pkg.version,
+        private: pkg.private ?? false,
+      };
+    }),
+  );
+}
+
+const packageNameRegex = /^packages\/([@\w-]+)\//;
+export async function getPackagesChangedSinceRelease(
+  packages: PackageInfo[],
+): Promise<PackageInfo[]> {
+  const diffMsg = await $`git diff --name-only release.. | sort`.text();
+  const filesChanged = diffMsg.split('\n');
+
+  const dirNamesOfChangedPackages = filesChanged
+    .map((file) => packageNameRegex.exec(file)?.[1])
+    .filter((str): str is string => !!str);
+
+  return packages.filter((pkg) => dirNamesOfChangedPackages.includes(pkg.dirname));
+}
+
+export async function isPublished(name: string, version?: string): Promise<boolean> {
+  const encodedName = encodeURIComponent(name);
+  const response = await fetch(
+    version
+      ? `https://registry.npmjs.org/${encodedName}/${encodeURIComponent(version)}`
+      : `https://registry.npmjs.org/${encodedName}`,
+  );
+  return response.ok;
+}
+
+export function getTag(version: string): string {
+  if (version.includes('-alpha.')) return 'alpha';
+  if (version.includes('-beta.')) return 'beta';
+  if (version.includes('-rc.')) return 'rc';
+  if (version.includes('-nightly.')) return 'nightly';
+  if (!version.includes('-')) return 'latest';
+  throw new Error(`Invalid version: ${version}`);
+}
+
+export interface PackageInfo {
+  dir: string;
+  dirname: string;
+  private: boolean;
+  name: string;
+  version: string;
+}

--- a/scripts/publish-pkg-pr.ts
+++ b/scripts/publish-pkg-pr.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+
+import { $ } from 'bun';
+import { getPackagesChangedSinceRelease, getPackages, getTag } from './_utils.ts';
+
+async function main() {
+  const packages = await getPackages();
+  const changedNames = (await getPackagesChangedSinceRelease(packages)).map((pkg) => pkg.name);
+
+  const toPublish = packages.filter((pkg) => {
+    if (pkg.private) {
+      console.log(`  skip  ${pkg.name} (package is private)`);
+      return false;
+    }
+
+    if (!changedNames.includes(pkg.name)) {
+      console.log(`  skip  ${pkg.name} (no changes since release)`);
+      return false;
+    }
+
+    return true;
+  });
+
+  if (toPublish.length === 0) {
+    console.log('\nNothing to publish.');
+    return;
+  }
+
+  console.log(`\nPackages to publish on pkg.pr.new:\n`);
+
+  const nameWidth = Math.max(...toPublish.map((p) => p.name.length));
+  for (const { name, version } of toPublish) {
+    console.log(`  ${name.padEnd(nameWidth)}  ${version.padEnd(20)}  tag: ${getTag(version)}`);
+  }
+
+  console.log();
+
+  // Building the packages
+
+  const buildArgs = toPublish.map((pkg) => `--filter=${pkg.name}`);
+  await $`pnpm run ${buildArgs} prepublishOnly --skip-publish-tag-check`.env({
+    ...process.env,
+    SKIP_TESTS: 'true',
+  });
+
+  const publishArgs = toPublish.map((pkg) => `./packages/${pkg.dirname}`);
+
+  await $`pnpm exec pkg-pr-new publish ${publishArgs} --json output.json --comment=off --pnpm --no-compact`.env(
+    { ...process.env, SKIP_TESTS: 'true' },
+  );
+}
+
+await main();

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,55 +1,16 @@
 #!/usr/bin/env bun
 
-import { readdirSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
 import { $ } from 'bun';
+import { getPackages, getTag, isPublished, type PackageInfo } from './_utils.ts';
 
-const PACKAGES_DIR = join(import.meta.dir, '../packages');
 const isDryRun = process.env.DISABLE_DRY_RUN !== 'true';
 
-function getTag(version: string): string {
-  if (version.includes('-alpha.')) return 'alpha';
-  if (version.includes('-beta.')) return 'beta';
-  if (version.includes('-rc.')) return 'rc';
-  if (version.includes('-nightly.')) return 'nightly';
-  if (!version.includes('-')) return 'latest';
-  throw new Error(`Invalid version: ${version}`);
-}
-
-async function isPublished(name: string, version: string): Promise<boolean> {
-  const encodedName = encodeURIComponent(name);
-  const response = await fetch(
-    `https://registry.npmjs.org/${encodedName}/${encodeURIComponent(version)}`,
-  );
-  return response.ok;
-}
-
-interface PackageJson {
-  name: string;
-  version: string;
-  private?: boolean;
-}
-
 async function main() {
-  const dirs = readdirSync(PACKAGES_DIR, { withFileTypes: true })
-    .filter((d) => d.isDirectory())
-    .map((d) => join(PACKAGES_DIR, d.name));
-
-  const toPublish: Array<{
-    dir: string;
-    name: string;
-    version: string;
-    tag: string;
-  }> = [];
+  const packages = await getPackages();
+  const toPublish: PackageInfo[] = [];
 
   await Promise.all(
-    dirs.map(async (dir) => {
-      const pkgJsonPath = join(dir, 'package.json');
-      if (!existsSync(pkgJsonPath)) {
-        return;
-      }
-
-      const pkg: PackageJson = await Bun.file(pkgJsonPath).json();
+    packages.map(async (pkg) => {
       if (pkg.private) {
         // Skip private packages
         return;
@@ -62,7 +23,7 @@ async function main() {
         return;
       }
 
-      toPublish.push({ dir, name, version, tag: getTag(version) });
+      toPublish.push(pkg);
     }),
   );
 
@@ -74,13 +35,14 @@ async function main() {
   console.log(`\nPackages to publish${isDryRun ? ' (dry run)' : ''}:\n`);
 
   const nameWidth = Math.max(...toPublish.map((p) => p.name.length));
-  for (const { name, version, tag } of toPublish) {
-    console.log(`  ${name.padEnd(nameWidth)}  ${version.padEnd(20)}  tag: ${tag}`);
+  for (const { name, version } of toPublish) {
+    console.log(`  ${name.padEnd(nameWidth)}  ${version.padEnd(20)}  tag: ${getTag(version)}`);
   }
 
   console.log();
 
-  for (const { dir, name, version, tag } of toPublish) {
+  for (const { dir, name, version } of toPublish) {
+    const tag = getTag(version);
     console.log(`Publishing ${name}@${version} [tag: ${tag}]...`);
 
     const args = [


### PR DESCRIPTION
**Changes**:
- Gathering packages that have changed compared to the `release` branch, builds them, and publishes them through `pkg.pr.new`
- Made `@typegpu/gl` a public package, so that it can be published both on npm and on pkg-pr-new.