### PR TITLE
test: Enforce only argument-less functions as input to expectDataType

### DIFF
--- a/packages/typegpu/tests/tgsl/conversion.test.ts
+++ b/packages/typegpu/tests/tgsl/conversion.test.ts
@@ -51,15 +51,17 @@ describe('convertToCommonType', () => {
   });
 
   it('performs pointer dereferencing', () => {
-    const fn = tgpu.fn(
-      [d.ptrFn(d.f32)],
-      d.f32,
-    )((a) => {
-      const t = [a.$, d.f32(2)];
+    function fn(a: d.ref<number>) {
+      'use gpu';
+      const t = [a.$, d.f32(2)]; // <- should convert all elements to f32
       return t[0] as number;
-    });
+    }
 
-    expectDataTypeOf(fn).toBe(d.f32);
+    expectDataTypeOf(() => {
+      'use gpu';
+      const numRef = d.ref(1);
+      return fn(numRef);
+    }).toBe(d.f32);
   });
 
   it('returns undefined for incompatible types', () => {

--- a/packages/typegpu/tests/utils/parseResolved.ts
+++ b/packages/typegpu/tests/utils/parseResolved.ts
@@ -59,15 +59,13 @@ export function extractSnippetFromFn(cb: TgpuFn | (() => unknown)): Snippet {
 }
 
 export function expectSnippetOf(
-  cb: TgpuFn | (() => unknown),
+  cb: () => unknown,
 ): Assertion<[unknown, d.BaseData | UnknownData, Origin]> {
   const snippet = extractSnippetFromFn(cb);
   return expect([snippet.value, snippet.dataType, snippet.origin]);
 }
 
-export function expectDataTypeOf(
-  cb: TgpuFn | (() => unknown),
-): Assertion<d.BaseData | UnknownData> {
+export function expectDataTypeOf(cb: () => unknown): Assertion<d.BaseData | UnknownData> {
   return expect<d.BaseData | UnknownData>(extractSnippetFromFn(cb).dataType);
 }
 


### PR DESCRIPTION
`'use gpu'` functions passed to are meant to create and return snippets to be inspected