### PR TITLE
feat(🫐): Expose a list of generated declarations in result of tgpu.resolveWithContext()

### DIFF
--- a/packages/typegpu/src/core/function/fnCore.ts
+++ b/packages/typegpu/src/core/function/fnCore.ts
@@ -202,7 +202,7 @@ export function createFnCore(
           body = replacedImpl.slice(providedArgs.range.end);
         }
 
-        ctx.addDeclaration(`${attributes}fn ${id}${header}${body}`);
+        ctx.addDeclaration(`${attributes}fn ${id}${header}${body}`, id);
 
         return snip(id, returnType, /* origin */ 'runtime');
       }
@@ -246,7 +246,7 @@ export function createFnCore(
         externalMap: mergeFunctionExternals(externals),
       });
 
-      ctx.addDeclaration(code);
+      ctx.addDeclaration(code, id);
 
       return snip(id, actualReturnType, /* origin */ 'runtime');
     },

--- a/packages/typegpu/src/core/resolve/resolveData.ts
+++ b/packages/typegpu/src/core/resolve/resolveData.ts
@@ -130,12 +130,15 @@ function resolveStruct(ctx: ResolutionCtx, struct: WgslStruct) {
   }
   const id = ctx.makeUniqueIdentifier(getName(struct), 'global');
 
-  ctx.addDeclaration(`\
+  ctx.addDeclaration(
+    `\
 struct ${id} {
 ${Object.entries(struct.propTypes)
   .map((prop) => resolveStructProperty(ctx, prop))
   .join('')}\
-}`);
+}`,
+    id,
+  );
 
   return id;
 }
@@ -158,7 +161,8 @@ ${Object.entries(struct.propTypes)
 function resolveUnstruct(ctx: ResolutionCtx, unstruct: Unstruct) {
   const id = ctx.makeUniqueIdentifier(getName(unstruct), 'global');
 
-  ctx.addDeclaration(`\
+  ctx.addDeclaration(
+    `\
 struct ${id} {
 ${Object.entries(unstruct.propTypes)
   .map((prop) =>
@@ -167,7 +171,9 @@ ${Object.entries(unstruct.propTypes)
       : resolveStructProperty(ctx, prop),
   )
   .join('')}
-}`);
+}`,
+    id,
+  );
 
   return id;
 }

--- a/packages/typegpu/src/core/sampler/sampler.ts
+++ b/packages/typegpu/src/core/sampler/sampler.ts
@@ -108,6 +108,7 @@ export class TgpuLaidOutSamplerImpl<
       `@group(${group}) @binding(${this.#membership.idx}) var ${id}: ${
         ctx.resolve(this.schema).value
       };`,
+      id,
     );
 
     return snip(id, this.schema, /* origin */ 'handle');
@@ -195,6 +196,7 @@ class TgpuFixedSamplerImpl<T extends WgslSampler | WgslComparisonSampler>
 
     ctx.addDeclaration(
       `@group(${group}) @binding(${binding}) var ${id}: ${ctx.resolve(this.schema).value};`,
+      id,
     );
 
     return snip(id, this.schema, /* origin */ 'handle');

--- a/packages/typegpu/src/core/texture/externalTexture.ts
+++ b/packages/typegpu/src/core/texture/externalTexture.ts
@@ -44,6 +44,7 @@ export class TgpuExternalTextureImpl implements TgpuExternalTexture, SelfResolva
       `@group(${group}) @binding(${this.#membership.idx}) var ${id}: ${
         ctx.resolve(this.schema).value
       };`,
+      id,
     );
 
     return snip(id, textureExternal(), 'handle');

--- a/packages/typegpu/src/core/texture/texture.ts
+++ b/packages/typegpu/src/core/texture/texture.ts
@@ -689,6 +689,7 @@ export class TgpuLaidOutTextureViewImpl<T extends WgslTexture | WgslStorageTextu
       `@group(${group}) @binding(${this.#membership.idx}) var ${id}: ${
         ctx.resolve(this.schema).value
       };`,
+      id,
     );
 
     return snip(id, this.schema, /* origin */ 'handle');

--- a/packages/typegpu/src/resolutionCtx.ts
+++ b/packages/typegpu/src/resolutionCtx.ts
@@ -1085,10 +1085,10 @@ export class ResolutionCtxImpl implements ResolutionCtx {
 /**
  * A single module-scope declaration emitted during resolution.
  *
- * @param name - The resolved identifier the declaration declares (a fn,
- *   struct, var, const or alias name), or `undefined` for declarations that
- *   don't declare a single identifier (e.g. `tgpu['~unstable'].declare`).
- * @param code - The WGSL code of the declaration.
+ * @property name - The resolved identifier the declaration declares (a fn, struct, var, const or
+ *   alias name), or `undefined` for declarations that don't declare a single identifier (e.g.
+ *   `tgpu['~unstable'].declare`).
+ * @property code - The WGSL code of the declaration.
  */
 export interface ResolvedDeclaration {
   name: string | undefined;
@@ -1099,9 +1099,12 @@ export interface ResolvedDeclaration {
  * The results of a WGSL resolution.
  *
  * @param code - The resolved code.
- * @param declarations - The module-scope declarations `code` is made of, in
- *   emission order. When resolving with a shared namespace, only declarations
- *   emitted by *this* resolution are included (memoized ones are not re-emitted).
+ * @param declarations - The module-scope declarations emitted by TypeGPU
+ *  during this resolution, in emission order. When resolving an array without a
+ *  template, `code` equals `declarations.map((d) => d.code).join('\n\n')`.
+ *  When resolving a template, the template itself is not included in `declarations`.
+ *  With a shared namespace, only declarations emitted by *this* resolution are
+ *  included (memoized ones are not re-emitted).
  * @param usedBindGroupLayouts - List of used `tgpu.bindGroupLayout`s.
  * @param catchall - Automatically constructed bind group for buffer usages and buffer bindings, preceded by its index.
  * @param logResources - Buffers and information about used console.logs needed to decode the raw data.

--- a/packages/typegpu/src/resolutionCtx.ts
+++ b/packages/typegpu/src/resolutionCtx.ts
@@ -376,7 +376,7 @@ export class ResolutionCtxImpl implements ResolutionCtx {
   private readonly _indentController = new IndentController();
   private readonly _itemStateStack = new ItemStateStackImpl();
   readonly #modeStack: ExecState[] = [];
-  private readonly _declarations: string[] = [];
+  private readonly _declarations: ResolvedDeclaration[] = [];
   private _varyingLocations: Record<string, number> | undefined;
   /**
    * Holds a set of base (slot-less) functions that have started their resolution process.
@@ -733,8 +733,12 @@ export class ResolutionCtxImpl implements ResolutionCtx {
     }
   }
 
-  addDeclaration(declaration: string): void {
-    this._declarations.push(declaration);
+  addDeclaration(declaration: string, name?: string | undefined): void {
+    this._declarations.push({ name, code: declaration });
+  }
+
+  get declarations(): readonly ResolvedDeclaration[] {
+    return this._declarations;
   }
 
   allocateLayoutEntry(layout: TgpuBindGroupLayout): string {
@@ -997,7 +1001,7 @@ export class ResolutionCtxImpl implements ResolutionCtx {
           this.pushMode(new CodegenState());
           const result = provideCtx(this, () => this._getOrInstantiate(item));
           return snip(
-            `${[...this._declarations].join('\n\n')}${result.value}`,
+            `${this._declarations.map((decl) => decl.code).join('\n\n')}${result.value}`,
             Void,
             /* origin */ 'runtime', // arbitrary
           );
@@ -1079,15 +1083,32 @@ export class ResolutionCtxImpl implements ResolutionCtx {
 }
 
 /**
+ * A single module-scope declaration emitted during resolution.
+ *
+ * @param name - The resolved identifier the declaration declares (a fn,
+ *   struct, var, const or alias name), or `undefined` for declarations that
+ *   don't declare a single identifier (e.g. `tgpu['~unstable'].declare`).
+ * @param code - The WGSL code of the declaration.
+ */
+export interface ResolvedDeclaration {
+  name: string | undefined;
+  code: string;
+}
+
+/**
  * The results of a WGSL resolution.
  *
  * @param code - The resolved code.
+ * @param declarations - The module-scope declarations `code` is made of, in
+ *   emission order. When resolving with a shared namespace, only declarations
+ *   emitted by *this* resolution are included (memoized ones are not re-emitted).
  * @param usedBindGroupLayouts - List of used `tgpu.bindGroupLayout`s.
  * @param catchall - Automatically constructed bind group for buffer usages and buffer bindings, preceded by its index.
  * @param logResources - Buffers and information about used console.logs needed to decode the raw data.
  */
 export interface ResolutionResult {
   code: string;
+  declarations: ResolvedDeclaration[];
   usedBindGroupLayouts: TgpuBindGroupLayout[];
   catchall: [number, TgpuBindGroup] | undefined;
   logResources: LogResources | undefined;
@@ -1112,11 +1133,17 @@ export function resolve(item: Wgsl, options: ResolutionCtxImplOptions): Resoluti
     (binding, idx) => [String(idx), binding.layoutEntry] as [string, TgpuLayoutEntry],
   );
 
+  // Bind group indices are only known now, so the same placeholder
+  // replacements applied to `code` are recorded and re-applied to each
+  // declaration's code.
+  const bindingReplacements: [placeholder: string, index: string][] = [];
+
   const createCatchallGroup = () => {
     const catchallIdx = automaticIds.next().value;
     const catchallLayout = bindGroupLayout(Object.fromEntries(layoutEntries));
     usedBindGroupLayouts[catchallIdx] = catchallLayout;
     code = code.replaceAll(CATCHALL_BIND_GROUP_IDX_MARKER, String(catchallIdx));
+    bindingReplacements.push([CATCHALL_BIND_GROUP_IDX_MARKER, String(catchallIdx)]);
 
     return [
       catchallIdx,
@@ -1141,6 +1168,7 @@ export function resolve(item: Wgsl, options: ResolutionCtxImplOptions): Resoluti
     const idx = layout.index ?? automaticIds.next().value;
     usedBindGroupLayouts[idx] = layout;
     code = code.replaceAll(placeholder, String(idx));
+    bindingReplacements.push([placeholder, String(idx)]);
   }
 
   if (options.enableExtensions && options.enableExtensions.length > 0) {
@@ -1148,8 +1176,17 @@ export function resolve(item: Wgsl, options: ResolutionCtxImplOptions): Resoluti
     code = `${extensions.join('\n')}\n\n${code}`;
   }
 
+  const declarations = ctx.declarations.map(({ name, code: declarationCode }) => ({
+    name,
+    code: bindingReplacements.reduce(
+      (acc, [placeholder, idx]) => acc.replaceAll(placeholder, idx),
+      declarationCode,
+    ),
+  }));
+
   return {
     code,
+    declarations,
     usedBindGroupLayouts,
     catchall,
     logResources: ctx.logResources,

--- a/packages/typegpu/src/resolutionCtx.ts
+++ b/packages/typegpu/src/resolutionCtx.ts
@@ -739,7 +739,7 @@ export class ResolutionCtxImpl implements ResolutionCtx {
     }
   }
 
-  addDeclaration(declaration: string, name?: string | undefined): void {
+  addDeclaration(declaration: string, name?: string): void {
     this._declarations.push({ name, code: declaration });
   }
 

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -897,7 +897,10 @@ ${this.ctx.pre}}`;
     const resolvedDataType = this.ctx.resolve(options.dataType).value;
     const resolvedValue = this.ctx.resolveSnippet(options.init).value;
 
-    this.ctx.addDeclaration(`const ${options.id}: ${resolvedDataType} = ${resolvedValue};`);
+    this.ctx.addDeclaration(
+      `const ${options.id}: ${resolvedDataType} = ${resolvedValue};`,
+      options.id,
+    );
 
     return snip(options.id, options.dataType, 'constant-immutable-def');
   }
@@ -923,6 +926,7 @@ ${this.ctx.pre}}`;
 
     this.ctx.addDeclaration(
       options.init ? `${pre} = ${this.ctx.resolveSnippet(options.init).value};` : `${pre};`,
+      options.id,
     );
 
     return snip(options.id, options.dataType, options.scope);

--- a/packages/typegpu/src/types.ts
+++ b/packages/typegpu/src/types.ts
@@ -281,7 +281,7 @@ export interface ResolutionCtx {
    *   const or alias name), if it declares one. Reported back to the caller
    *   through `ResolutionResult.declarations`.
    */
-  addDeclaration(declaration: string, name?: string | undefined): void;
+  addDeclaration(declaration: string, name?: string): void;
   withResetIndentLevel<T>(callback: () => T): T;
 
   /**

--- a/packages/typegpu/src/types.ts
+++ b/packages/typegpu/src/types.ts
@@ -274,7 +274,14 @@ export interface ResolutionCtx {
   readonly enableExtensions: WgslEnableExtension[] | undefined;
   readonly gen: ShaderGenerator;
 
-  addDeclaration(declaration: string): void;
+  /**
+   * Adds a module-scope declaration to the resolution output.
+   * @param declaration - The WGSL code of the declaration.
+   * @param name - The identifier the declaration declares (a fn, struct, var,
+   *   const or alias name), if it declares one. Reported back to the caller
+   *   through `ResolutionResult.declarations`.
+   */
+  addDeclaration(declaration: string, name?: string | undefined): void;
   withResetIndentLevel<T>(callback: () => T): T;
 
   /**

--- a/packages/typegpu/tests/resolve.test.ts
+++ b/packages/typegpu/tests/resolve.test.ts
@@ -608,3 +608,73 @@ describe('resolve without template', () => {
       `);
   });
 });
+
+describe('tgpu resolveWithContext declarations', () => {
+  it('reports each module-scope declaration with its resolved name', () => {
+    const Boid = d.struct({
+      pos: d.vec3f,
+      vel: d.vec3f,
+    });
+
+    const getSpeed = tgpu.fn([Boid], d.f32)((boid) => boid.vel.x);
+
+    const isFast = tgpu.fn([Boid], d.bool)((boid) => getSpeed(boid) > 1);
+
+    const { code, declarations } = tgpu.resolveWithContext([isFast], {
+      names: 'strict',
+    });
+
+    expect(declarations.map((decl) => decl.name)).toEqual(['Boid', 'getSpeed', 'isFast']);
+    // The code is exactly the declarations, joined.
+    expect(declarations.map((decl) => decl.code).join('\n\n')).toBe(code);
+  });
+
+  it('does not include the template itself in declarations', () => {
+    const Gradient = d.struct({
+      start: d.vec3f,
+      end: d.vec3f,
+    });
+
+    const { declarations } = tgpu.resolveWithContext({
+      template: 'fn foo() { var g: Gradient; }',
+      externals: { Gradient },
+      names: 'strict',
+    });
+
+    expect(declarations.map((decl) => decl.name)).toEqual(['Gradient']);
+  });
+
+  it('reports only newly emitted declarations when sharing a namespace', () => {
+    const Boid = d.struct({
+      pos: d.vec3f,
+    });
+
+    const getX = tgpu.fn([Boid], d.f32)((boid) => boid.pos.x);
+    const getY = tgpu.fn([Boid], d.f32)((boid) => boid.pos.y);
+
+    const names = tgpu['~unstable'].namespace();
+
+    const first = tgpu.resolveWithContext([getX], { names });
+    const second = tgpu.resolveWithContext([getY], { names });
+
+    expect(first.declarations.map((decl) => decl.name)).toEqual(['Boid', 'getX']);
+    // Boid is memoized in the namespace, so it is neither re-emitted nor re-reported.
+    expect(second.declarations.map((decl) => decl.name)).toEqual(['getY']);
+  });
+
+  it('applies bind group indices to declaration code', () => {
+    const layout = tgpu.bindGroupLayout({
+      ambient: { uniform: d.vec3f },
+    });
+
+    const readAmbient = tgpu.fn([], d.vec3f)(() => layout.$.ambient);
+
+    const { declarations } = tgpu.resolveWithContext([readAmbient], {
+      names: 'strict',
+    });
+
+    const ambient = declarations.find((decl) => decl.name === 'ambient');
+    expect(ambient?.code).toContain('@group(0)');
+    expect(ambient?.code).not.toContain('#BIND_GROUP_LAYOUT');
+  });
+});

--- a/packages/typegpu/tests/resolve.test.ts
+++ b/packages/typegpu/tests/resolve.test.ts
@@ -629,6 +629,20 @@ describe('tgpu resolveWithContext declarations', () => {
     expect(declarations.map((decl) => decl.code).join('\n\n')).toBe(code);
   });
 
+  it('reports declarations that have no name', () => {
+    const declaration = '/* my declaration */';
+    const myDecl = tgpu['~unstable'].declare(declaration);
+
+    const main = () => {
+      'use gpu';
+      myDecl;
+    };
+
+    const { declarations } = tgpu.resolveWithContext([main], { names: 'strict' });
+
+    expect(declarations[0]).toStrictEqual({ name: undefined, code: declaration });
+  });
+
   it('does not include the template itself in declarations', () => {
     const Gradient = d.struct({
       start: d.vec3f,


### PR DESCRIPTION
```
const { code, declarations } = tgpu.resolveWithContext([isFast], { names: 'strict' });
// declarations: [
//   { name: 'Boid',     code: 'struct Boid {...}' },
//   { name: 'getSpeed', code: 'fn getSpeed(boid: Boid) -> f32 {...}' },
//   { name: 'isFast',   code: 'fn isFast(boid: Boid) -> bool {...}' },
// ]
```