### PR TITLE
impr: More flexible bitcast

### DIFF
--- a/apps/typegpu-docs/src/content/docs/ecosystem/typegpu-noise.mdx
+++ b/apps/typegpu-docs/src/content/docs/ecosystem/typegpu-noise.mdx
@@ -287,7 +287,7 @@ const LCG: StatefulGenerator = (() => {
   const u32To01Float = tgpu.fn([d.u32], d.f32)((value) => {
     const mantissa = value >> 9;
     const bits = 0x3F800000 | mantissa;
-    const f = std.bitcastU32toF32(bits);
+    const f = std.bitcast(d.u32, d.f32)(bits);
     return f - 1;
   });
 

--- a/apps/typegpu-docs/src/examples/tests/uniformity/lcg.ts
+++ b/apps/typegpu-docs/src/examples/tests/uniformity/lcg.ts
@@ -10,7 +10,7 @@ export const LCG: StatefulGenerator = (() => {
   )((value) => {
     const mantissa = value >> 9;
     const bits = 0x3f800000 | mantissa;
-    const f = std.bitcastU32toF32(bits);
+    const f = std.bitcast(d.u32, d.f32)(bits);
     return f - 1;
   });
 

--- a/packages/typegpu/src/std/bitcast.ts
+++ b/packages/typegpu/src/std/bitcast.ts
@@ -247,10 +247,10 @@ const getCpuBitcast = <In extends BitcastAllowedTypes, Out extends BitcastAllowe
   };
 };
 
-const bitcastFor = <In extends BitcastAllowedTypes, Out extends BitcastAllowedTypes>(
+function bitcastFor<In extends BitcastAllowedTypes, Out extends BitcastAllowedTypes>(
   inType: In,
   outType: Out,
-) => {
+): (value: Infer<In>) => Infer<Out> {
   return dualImpl({
     name: 'bitcast',
     normalImpl: getCpuBitcast<In, Out>(inType, outType),
@@ -267,7 +267,7 @@ const bitcastFor = <In extends BitcastAllowedTypes, Out extends BitcastAllowedTy
     },
     sideEffects: false,
   });
-};
+}
 
 const casts = {
   /* 2 bytes */

--- a/packages/typegpu/src/std/bitcast.ts
+++ b/packages/typegpu/src/std/bitcast.ts
@@ -5,13 +5,47 @@ import {
   bitcastU32toF32Impl,
   bitcastU32toI32Impl,
 } from '../data/numberOps.ts';
-import { f32, i32, u32 } from '../data/numeric.ts';
+import { bool, f16, f32, i32, u32 } from '../data/numeric.ts';
 import { isVec } from '../data/wgslTypes.ts';
-import { vec2f, vec2i, vec2u, vec3f, vec3i, vec3u, vec4f, vec4i, vec4u } from '../data/vector.ts';
+import {
+  vec2b,
+  vec2f,
+  vec2h,
+  vec2i,
+  vec2u,
+  vec3b,
+  vec3f,
+  vec3h,
+  vec3i,
+  vec3u,
+  vec4b,
+  vec4f,
+  vec4h,
+  vec4i,
+  vec4u,
+} from '../data/vector.ts';
 import { VectorOps } from '../data/vectorOps.ts';
-import type { v2f, v2i, v2u, v3f, v3i, v3u, v4f, v4i, v4u } from '../data/wgslTypes.ts';
+import type {
+  AnyNumericVecInstance,
+  AnyVecInstance,
+  AnyWgslData,
+  BaseData,
+  v2f,
+  v2i,
+  v2u,
+  v3f,
+  v3i,
+  v3u,
+  v4f,
+  v4i,
+  v4u,
+} from '../data/wgslTypes.ts';
 import { unifyStrict } from '../tgsl/conversion.ts';
 import { SignatureNotSupportedError } from '../errors.ts';
+import { comptime } from '../tgpu.ts';
+import { getName } from '../internal.ts';
+import type { Infer } from '../shared/repr.ts';
+import { sizeOf } from '../data/sizeOf.ts';
 
 type BitcastU32toF32Overload = <T extends number | v2u | v3u | v4u>(
   value: T,
@@ -124,3 +158,209 @@ export const bitcastF32toU32 = dualImpl({
   },
   sideEffects: false,
 });
+
+const validBitcastNTypes = [f32, f16, i32, u32] as const;
+
+const validBitcastVTypes = [
+  vec2f,
+  vec3f,
+  vec4f,
+  vec2h,
+  vec3h,
+  vec4h,
+  vec2i,
+  vec3i,
+  vec4i,
+  vec2u,
+  vec3u,
+  vec4u,
+] as const;
+
+const validBitcastTypes = [...validBitcastNTypes, ...validBitcastVTypes] as const;
+
+type BitcastIOType = (typeof validBitcastTypes)[number];
+
+const buf = new ArrayBuffer(16);
+const bufViews = {
+  f32: new Float32Array(buf),
+  u32: new Uint32Array(buf),
+  i32: new Int32Array(buf),
+  f16: new Float16Array(buf),
+};
+
+function writeToBuf(
+  item: AnyNumericVecInstance | number,
+  target: Float32Array | Uint32Array | Int32Array | Float16Array,
+): void {
+  if (typeof item === 'number') {
+    target[0] = item;
+  } else {
+    for (let i = 0; i < item.length; i++) {
+      target[i] = item[i] as number;
+    }
+  }
+}
+
+function readFromBuf<Schema extends BitcastIOType>(
+  buf: Float32Array | Uint32Array | Int32Array | Float16Array,
+  schema: Schema,
+): Infer<Schema> {
+  const length = 'componentCount' in schema ? schema.componentCount : 1;
+  const items = [];
+  for (let i = 0; i < length; i++) {
+    items.push(buf[i]);
+  }
+  return schema(...items) as Infer<Schema>;
+}
+
+const cpuBitcast = (
+  inType: WgslTypeFor<keyof typeof bufViews>,
+  outType: (typeof validBitcastNTypes)[number],
+) => {
+  const writeToPrimitive = 'primitive' in inType ? inType.primitive : inType;
+  const readFromPrimitive = 'primitive' in outType ? outType.primitive : outType;
+
+  return (n: number | AnyNumericVecInstance) => {
+    writeToBuf(n, bufViews[writeToPrimitive.type]);
+    return readFromBuf(bufViews[readFromPrimitive.type], outType);
+  };
+};
+
+const bitcastFor = <In extends BitcastIOType, Out extends BitcastIOType>(
+  inType: In,
+  outType: Out,
+) => {
+  return dualImpl({
+    name: 'bitcast',
+    normalImpl: cpuBitcast(inType, outType) as unknown as (value: Infer<In>) => Infer<Out>, // TODO: type the function properly
+    codegenImpl: (_ctx, [n]) => stitch`bitcast<${outType.type}>(${n})`,
+    signature: (arg) => {
+      const uarg = unifyStrict([arg], [inType]);
+      if (!uarg) {
+        throw new SignatureNotSupportedError([arg], [inType]);
+      }
+      return {
+        argTypes: uarg,
+        returnType: outType,
+      };
+    },
+    sideEffects: false,
+  });
+};
+
+// TODO: lepiej podzielić to na klasy abstrakcji
+// i typować na chama
+// ... i cacheować dual imple??
+const casts = {
+  f32: {
+    f32: bitcastFor(f32, f32),
+    i32: bitcastFor(f32, i32),
+    u32: bitcastFor(f32, u32),
+    vec2h: bitcastFor(f32, vec2h),
+  },
+  i32: {
+    f32: bitcastFor(i32, f32),
+    i32: bitcastFor(i32, i32),
+    u32: bitcastFor(i32, u32),
+    vec2h: bitcastFor(i32, vec2h),
+  },
+  u32: {
+    f32: bitcastFor(u32, f32),
+    i32: bitcastFor(u32, i32),
+    u32: bitcastFor(u32, u32),
+    vec2h: bitcastFor(u32, vec2h),
+  },
+
+  vec2f: {
+    vec2f: bitcastFor(vec2f, vec2f),
+    vec2i: bitcastFor(vec2f, vec2i),
+    vec2u: bitcastFor(vec2f, vec2u),
+    vec4h: bitcastFor(vec2f, vec2h),
+  },
+  vec2i: {
+    vec2f: bitcastFor(vec2i, vec2f),
+    vec2i: bitcastFor(vec2i, vec2i),
+    vec2u: bitcastFor(vec2i, vec2u),
+    vec4h: bitcastFor(vec2i, vec4h),
+  },
+  vec2u: {
+    vec2f: bitcastFor(vec2u, vec2f),
+    vec2i: bitcastFor(vec2u, vec2i),
+    vec2u: bitcastFor(vec2u, vec2u),
+    vec4h: bitcastFor(vec2u, vec4h),
+  },
+
+  vec3f: {
+    vec3f: bitcastFor(vec3f, vec3f),
+    vec3i: bitcastFor(vec3f, vec3i),
+    vec3u: bitcastFor(vec3f, vec3u),
+  },
+  vec3i: {
+    vec3f: bitcastFor(vec3i, vec3f),
+    vec3i: bitcastFor(vec3i, vec3i),
+    vec3u: bitcastFor(vec3i, vec3u),
+  },
+  vec3u: {
+    vec3f: bitcastFor(vec3u, vec3f),
+    vec3i: bitcastFor(vec3u, vec3i),
+    vec3u: bitcastFor(vec3u, vec3u),
+  },
+
+  vec4f: {
+    vec4f: bitcastFor(vec4f, vec4f),
+    vec4i: bitcastFor(vec4f, vec4i),
+    vec4u: bitcastFor(vec4f, vec4u),
+  },
+  vec4i: {
+    vec4f: bitcastFor(vec4i, vec4f),
+    vec4i: bitcastFor(vec4i, vec4i),
+    vec4u: bitcastFor(vec4i, vec4u),
+  },
+  vec4u: {
+    vec4f: bitcastFor(vec4u, vec4f),
+    vec4i: bitcastFor(vec4u, vec4i),
+    vec4u: bitcastFor(vec4u, vec4u),
+  },
+
+  f16: {
+    f16: bitcastFor(f16, f16),
+  },
+  vec2h: {
+    vec2h: bitcastFor(vec2h, vec2h),
+    f32: bitcastFor(vec2h, f32),
+    i32: bitcastFor(vec2h, i32),
+    u32: bitcastFor(vec2h, u32),
+  },
+  vec3h: {
+    vec3h: bitcastFor(vec3h, vec3h),
+  },
+  vec4h: {
+    vec4h: bitcastFor(vec4h, vec4h),
+    vec2f: bitcastFor(vec4h, vec2f),
+    vec2i: bitcastFor(vec4h, vec2i),
+    vec2u: bitcastFor(vec4h, vec2u),
+  },
+} as const;
+
+type WgslTypeFor<Type extends string> = Extract<AnyWgslData, { type: Type }>;
+
+function getBitcast<
+  FromType extends keyof typeof casts,
+  ToType extends keyof (typeof casts)[FromType] & string,
+>(from: WgslTypeFor<FromType>, to: WgslTypeFor<ToType>) {
+  if ('type' in from && from.type in casts) {
+    const intermediate = casts[from.type];
+    if ('type' in to && to.type in intermediate) {
+      return intermediate[to.type];
+    }
+  }
+  throw new Error(`Incorrect bitcast from ${getName(from)} to ${getName(to)}.`);
+}
+
+export const bitcast = comptime(getBitcast);
+
+// T <=> T (liczby, wektory)
+// T <=> S (f32, i32, u32)
+// T <=> S (vecf ...)
+// vec2h <=> u32/i32/f32
+// vec4h <=> v2f/v2u/v2h

--- a/packages/typegpu/src/std/bitcast.ts
+++ b/packages/typegpu/src/std/bitcast.ts
@@ -57,6 +57,11 @@ type BitcastU32toF32Overload = <T extends number | v2u | v3u | v4u>(
 
 const u32AllowedSchemas = [u32, vec2u, vec3u, vec4u];
 
+// TODO(#???): Remove deprecated bitcasts. Remember about cpu implementations.
+
+/**
+ * @deprecated Use 'std.bitcast' instead.
+ */
 export const bitcastU32toF32 = dualImpl({
   name: 'bitcastU32toF32',
   normalImpl: ((value) => {
@@ -93,6 +98,9 @@ type BitcastU32toI32Overload = <T extends number | v2u | v3u | v4u>(
   value: T,
 ) => T extends v2u ? v2i : T extends v3u ? v3i : T extends v4u ? v4i : number;
 
+/**
+ * @deprecated Use 'std.bitcast' instead.
+ */
 export const bitcastU32toI32 = dualImpl({
   name: 'bitcastU32toI32',
   normalImpl: ((value) => {
@@ -131,6 +139,9 @@ type BitcastF32toU32Overload = <T extends number | v2f | v3f | v4f>(
 
 const f32AllowedSchemas = [f32, vec2f, vec3f, vec4f];
 
+/**
+ * @deprecated Use 'std.bitcast' instead.
+ */
 export const bitcastF32toU32 = dualImpl({
   name: 'bitcastF32toU32',
   normalImpl: ((value) => {
@@ -163,7 +174,7 @@ export const bitcastF32toU32 = dualImpl({
   sideEffects: false,
 });
 
-const validBitcastTypes = [
+const bitcastAllowedSchemas = [
   /* 2 bytes */
   f16,
 
@@ -193,17 +204,17 @@ const validBitcastTypes = [
   vec4u,
 ] as const;
 
-type BitcastIOType = (typeof validBitcastTypes)[number];
+type BitcastAllowedTypes = (typeof bitcastAllowedSchemas)[number];
 
-const buf = new ArrayBuffer(16);
+const buffer = new ArrayBuffer(16);
 const bufViews = {
-  f32: new Float32Array(buf),
-  u32: new Uint32Array(buf),
-  i32: new Int32Array(buf),
-  f16: new Float16Array(buf),
+  f32: new Float32Array(buffer),
+  u32: new Uint32Array(buffer),
+  i32: new Int32Array(buffer),
+  f16: new Float16Array(buffer),
 };
 
-function writeToBuf(
+function writeToBuffer(
   item: AnyNumericVecInstance | number,
   target: Float32Array | Uint32Array | Int32Array | Float16Array,
 ): void {
@@ -216,7 +227,7 @@ function writeToBuf(
   }
 }
 
-function readFromBuf<Schema extends BitcastIOType>(
+function readFromBuffer<Schema extends BitcastAllowedTypes>(
   buf: Float32Array | Uint32Array | Int32Array | Float16Array,
   schema: Schema,
 ): Infer<Schema> {
@@ -228,7 +239,7 @@ function readFromBuf<Schema extends BitcastIOType>(
   return schema(...items) as Infer<Schema>;
 }
 
-const cpuBitcast = <In extends BitcastIOType, Out extends BitcastIOType>(
+const getCpuBitcast = <In extends BitcastAllowedTypes, Out extends BitcastAllowedTypes>(
   inType: In,
   outType: Out,
 ) => {
@@ -237,18 +248,18 @@ const cpuBitcast = <In extends BitcastIOType, Out extends BitcastIOType>(
     'primitive' in outType ? outType.primitive : outType;
 
   return (value: Infer<In>): Infer<Out> => {
-    writeToBuf(value, bufViews[writeToPrimitive.type]);
-    return readFromBuf(bufViews[readFromPrimitive.type], outType);
+    writeToBuffer(value, bufViews[writeToPrimitive.type]);
+    return readFromBuffer(bufViews[readFromPrimitive.type], outType);
   };
 };
 
-const bitcastFor = <In extends BitcastIOType, Out extends BitcastIOType>(
+const bitcastFor = <In extends BitcastAllowedTypes, Out extends BitcastAllowedTypes>(
   inType: In,
   outType: Out,
 ) => {
   return dualImpl({
     name: 'bitcast',
-    normalImpl: cpuBitcast<In, Out>(inType, outType),
+    normalImpl: getCpuBitcast<In, Out>(inType, outType),
     codegenImpl: (_ctx, [n]) => stitch`bitcast<${outType.type}>(${n})`,
     signature: (arg) => {
       const uarg = unifyStrict([arg], [inType]);
@@ -362,12 +373,12 @@ const casts = {
   },
 } as const;
 
-type WgslTypeFor<Type extends string> = Extract<AnyWgslData, { type: Type }>;
+type SchemaFor<Type extends string> = Extract<AnyWgslData, { type: Type }>;
 
 function getBitcast<
   FromType extends keyof typeof casts,
   ToType extends keyof (typeof casts)[FromType] & string,
->(from: WgslTypeFor<FromType>, to: WgslTypeFor<ToType>) {
+>(from: SchemaFor<FromType>, to: SchemaFor<ToType>) {
   if ('type' in from && from.type in casts) {
     const intermediate = casts[from.type];
     if ('type' in to && to.type in intermediate) {

--- a/packages/typegpu/src/std/bitcast.ts
+++ b/packages/typegpu/src/std/bitcast.ts
@@ -41,9 +41,9 @@ import type {
 } from '../data/wgslTypes.ts';
 import { unifyStrict } from '../tgsl/conversion.ts';
 import { SignatureNotSupportedError } from '../errors.ts';
-import { comptime } from '../tgpu.ts';
 import { getName } from '../internal.ts';
 import type { Infer } from '../shared/repr.ts';
+import { comptime } from '../core/function/comptime.ts';
 
 type BitcastU32toF32Overload = <T extends number | v2u | v3u | v4u>(
   value: T,

--- a/packages/typegpu/src/std/bitcast.ts
+++ b/packages/typegpu/src/std/bitcast.ts
@@ -57,7 +57,7 @@ type BitcastU32toF32Overload = <T extends number | v2u | v3u | v4u>(
 
 const u32AllowedSchemas = [u32, vec2u, vec3u, vec4u];
 
-// TODO(#???): Remove deprecated bitcasts. Remember about cpu implementations.
+// TODO(#2731): Remove deprecated bitcasts. Remember about cpu implementations.
 
 /**
  * @deprecated Use 'std.bitcast' instead.

--- a/packages/typegpu/src/std/bitcast.ts
+++ b/packages/typegpu/src/std/bitcast.ts
@@ -295,10 +295,10 @@ const casts = {
     vec2h: bitcastFor(u32, vec2h),
   },
   vec2h: {
-    vec2h: bitcastFor(vec2h, vec2h),
     f32: bitcastFor(vec2h, f32),
     i32: bitcastFor(vec2h, i32),
     u32: bitcastFor(vec2h, u32),
+    vec2h: bitcastFor(vec2h, vec2h),
   },
 
   /* 6 bytes */
@@ -311,7 +311,7 @@ const casts = {
     vec2f: bitcastFor(vec2f, vec2f),
     vec2i: bitcastFor(vec2f, vec2i),
     vec2u: bitcastFor(vec2f, vec2u),
-    vec4h: bitcastFor(vec2f, vec2h),
+    vec4h: bitcastFor(vec2f, vec4h),
   },
   vec2i: {
     vec2f: bitcastFor(vec2i, vec2f),

--- a/packages/typegpu/src/std/bitcast.ts
+++ b/packages/typegpu/src/std/bitcast.ts
@@ -30,6 +30,10 @@ import type {
   AnyVecInstance,
   AnyWgslData,
   BaseData,
+  F16,
+  F32,
+  I32,
+  U32,
   v2f,
   v2i,
   v2u,
@@ -159,24 +163,35 @@ export const bitcastF32toU32 = dualImpl({
   sideEffects: false,
 });
 
-const validBitcastNTypes = [f32, f16, i32, u32] as const;
+const validBitcastTypes = [
+  /* 2 bytes */
+  f16,
 
-const validBitcastVTypes = [
-  vec2f,
-  vec3f,
-  vec4f,
+  /* 4 bytes */
+  f32,
+  i32,
+  u32,
   vec2h,
+
+  /* 6 bytes */
   vec3h,
-  vec4h,
+
+  /* 8 bytes */
+  vec2f,
   vec2i,
-  vec3i,
-  vec4i,
   vec2u,
+  vec4h,
+
+  /* 12 bytes */
+  vec3f,
+  vec3i,
   vec3u,
+
+  /* 16 bytes */
+  vec4f,
+  vec4i,
   vec4u,
 ] as const;
-
-const validBitcastTypes = [...validBitcastNTypes, ...validBitcastVTypes] as const;
 
 type BitcastIOType = (typeof validBitcastTypes)[number];
 
@@ -213,15 +228,16 @@ function readFromBuf<Schema extends BitcastIOType>(
   return schema(...items) as Infer<Schema>;
 }
 
-const cpuBitcast = (
-  inType: WgslTypeFor<keyof typeof bufViews>,
-  outType: (typeof validBitcastNTypes)[number],
+const cpuBitcast = <In extends BitcastIOType, Out extends BitcastIOType>(
+  inType: In,
+  outType: Out,
 ) => {
-  const writeToPrimitive = 'primitive' in inType ? inType.primitive : inType;
-  const readFromPrimitive = 'primitive' in outType ? outType.primitive : outType;
+  const writeToPrimitive: F32 | U32 | I32 | F16 = 'primitive' in inType ? inType.primitive : inType;
+  const readFromPrimitive: F32 | U32 | I32 | F16 =
+    'primitive' in outType ? outType.primitive : outType;
 
-  return (n: number | AnyNumericVecInstance) => {
-    writeToBuf(n, bufViews[writeToPrimitive.type]);
+  return (value: Infer<In>): Infer<Out> => {
+    writeToBuf(value, bufViews[writeToPrimitive.type]);
     return readFromBuf(bufViews[readFromPrimitive.type], outType);
   };
 };
@@ -232,7 +248,7 @@ const bitcastFor = <In extends BitcastIOType, Out extends BitcastIOType>(
 ) => {
   return dualImpl({
     name: 'bitcast',
-    normalImpl: cpuBitcast(inType, outType) as unknown as (value: Infer<In>) => Infer<Out>, // TODO: type the function properly
+    normalImpl: cpuBitcast<In, Out>(inType, outType),
     codegenImpl: (_ctx, [n]) => stitch`bitcast<${outType.type}>(${n})`,
     signature: (arg) => {
       const uarg = unifyStrict([arg], [inType]);
@@ -248,10 +264,13 @@ const bitcastFor = <In extends BitcastIOType, Out extends BitcastIOType>(
   });
 };
 
-// TODO: lepiej podzielić to na klasy abstrakcji
-// i typować na chama
-// ... i cacheować dual imple??
 const casts = {
+  /* 2 bytes */
+  f16: {
+    f16: bitcastFor(f16, f16),
+  },
+
+  /* 4 bytes */
   f32: {
     f32: bitcastFor(f32, f32),
     i32: bitcastFor(f32, i32),
@@ -270,7 +289,19 @@ const casts = {
     u32: bitcastFor(u32, u32),
     vec2h: bitcastFor(u32, vec2h),
   },
+  vec2h: {
+    vec2h: bitcastFor(vec2h, vec2h),
+    f32: bitcastFor(vec2h, f32),
+    i32: bitcastFor(vec2h, i32),
+    u32: bitcastFor(vec2h, u32),
+  },
 
+  /* 6 bytes */
+  vec3h: {
+    vec3h: bitcastFor(vec3h, vec3h),
+  },
+
+  /* 8 bytes */
   vec2f: {
     vec2f: bitcastFor(vec2f, vec2f),
     vec2i: bitcastFor(vec2f, vec2i),
@@ -289,7 +320,14 @@ const casts = {
     vec2u: bitcastFor(vec2u, vec2u),
     vec4h: bitcastFor(vec2u, vec4h),
   },
+  vec4h: {
+    vec2f: bitcastFor(vec4h, vec2f),
+    vec2i: bitcastFor(vec4h, vec2i),
+    vec2u: bitcastFor(vec4h, vec2u),
+    vec4h: bitcastFor(vec4h, vec4h),
+  },
 
+  /* 12 bytes */
   vec3f: {
     vec3f: bitcastFor(vec3f, vec3f),
     vec3i: bitcastFor(vec3f, vec3i),
@@ -306,6 +344,7 @@ const casts = {
     vec3u: bitcastFor(vec3u, vec3u),
   },
 
+  /* 16 bytes */
   vec4f: {
     vec4f: bitcastFor(vec4f, vec4f),
     vec4i: bitcastFor(vec4f, vec4i),
@@ -320,25 +359,6 @@ const casts = {
     vec4f: bitcastFor(vec4u, vec4f),
     vec4i: bitcastFor(vec4u, vec4i),
     vec4u: bitcastFor(vec4u, vec4u),
-  },
-
-  f16: {
-    f16: bitcastFor(f16, f16),
-  },
-  vec2h: {
-    vec2h: bitcastFor(vec2h, vec2h),
-    f32: bitcastFor(vec2h, f32),
-    i32: bitcastFor(vec2h, i32),
-    u32: bitcastFor(vec2h, u32),
-  },
-  vec3h: {
-    vec3h: bitcastFor(vec3h, vec3h),
-  },
-  vec4h: {
-    vec4h: bitcastFor(vec4h, vec4h),
-    vec2f: bitcastFor(vec4h, vec2f),
-    vec2i: bitcastFor(vec4h, vec2i),
-    vec2u: bitcastFor(vec4h, vec2u),
   },
 } as const;
 
@@ -358,9 +378,3 @@ function getBitcast<
 }
 
 export const bitcast = comptime(getBitcast);
-
-// T <=> T (liczby, wektory)
-// T <=> S (f32, i32, u32)
-// T <=> S (vecf ...)
-// vec2h <=> u32/i32/f32
-// vec4h <=> v2f/v2u/v2h

--- a/packages/typegpu/src/std/bitcast.ts
+++ b/packages/typegpu/src/std/bitcast.ts
@@ -5,20 +5,17 @@ import {
   bitcastU32toF32Impl,
   bitcastU32toI32Impl,
 } from '../data/numberOps.ts';
-import { bool, f16, f32, i32, u32 } from '../data/numeric.ts';
+import { f16, f32, i32, u32 } from '../data/numeric.ts';
 import { isVec } from '../data/wgslTypes.ts';
 import {
-  vec2b,
   vec2f,
   vec2h,
   vec2i,
   vec2u,
-  vec3b,
   vec3f,
   vec3h,
   vec3i,
   vec3u,
-  vec4b,
   vec4f,
   vec4h,
   vec4i,
@@ -27,9 +24,7 @@ import {
 import { VectorOps } from '../data/vectorOps.ts';
 import type {
   AnyNumericVecInstance,
-  AnyVecInstance,
   AnyWgslData,
-  BaseData,
   F16,
   F32,
   I32,
@@ -49,7 +44,6 @@ import { SignatureNotSupportedError } from '../errors.ts';
 import { comptime } from '../tgpu.ts';
 import { getName } from '../internal.ts';
 import type { Infer } from '../shared/repr.ts';
-import { sizeOf } from '../data/sizeOf.ts';
 
 type BitcastU32toF32Overload = <T extends number | v2u | v3u | v4u>(
   value: T,

--- a/packages/typegpu/src/std/index.ts
+++ b/packages/typegpu/src/std/index.ts
@@ -186,7 +186,7 @@ export {
 
 export { extensionEnabled } from './extensions.ts';
 
-export { bitcastU32toF32, bitcastU32toI32, bitcastF32toU32 } from './bitcast.ts';
+export { bitcastU32toF32, bitcastU32toI32, bitcastF32toU32, bitcast } from './bitcast.ts';
 
 export { range } from './range.ts';
 

--- a/packages/typegpu/src/tgsl/consoleLog/deserializers.ts
+++ b/packages/typegpu/src/tgsl/consoleLog/deserializers.ts
@@ -1,4 +1,5 @@
 import { mat2x2f, mat3x3f, mat4x4f } from '../../data/matrix.ts';
+import { f32, i32, u32 } from '../../data/numeric.ts';
 import { sizeOf } from '../../data/sizeOf.ts';
 import {
   vec2b,
@@ -26,12 +27,12 @@ import {
 } from '../../data/wgslTypes.ts';
 import type { Infer } from '../../shared/repr.ts';
 import { niceStringify } from '../../shared/stringify.ts';
-import { bitcastU32toF32, bitcastU32toI32 } from '../../std/bitcast.ts';
+import { bitcast } from '../../std/bitcast.ts';
 import { unpack2x16float } from '../../std/packing.ts';
 import type { LogMeta, LogResources } from './types.ts';
 
-const toF = (n: number | undefined) => bitcastU32toF32(n ?? 0);
-const toI = (n: number | undefined) => bitcastU32toI32(n ?? 0);
+const toF = (n: number | undefined) => bitcast(u32, f32)(n ?? 0);
+const toI = (n: number | undefined) => bitcast(u32, i32)(n ?? 0);
 const unpack = (n: number | undefined) => unpack2x16float(n ?? 0);
 
 // ----------------

--- a/packages/typegpu/tests/std/bitcast.test.ts
+++ b/packages/typegpu/tests/std/bitcast.test.ts
@@ -10,70 +10,70 @@ describe('bitcast', () => {
   it('bitcastU32toF32', () => {
     // 1.0 in f32
     //0 01111111 00000000000000000000000
-    const f = bitcast(d.u32, d.f32)(1065353216);
+    const f = std.bitcast(d.u32, d.f32)(1065353216);
     expect(f).toBeCloseTo(1.0);
 
     // -1 in f32
     //1 01111111 00000000000000000000000
-    const f2 = bitcast(d.u32, d.f32)(3212836864);
+    const f2 = std.bitcast(d.u32, d.f32)(3212836864);
     expect(f2).toBeCloseTo(-1.0);
   });
 
   it('bitcastU32toI32', () => {
     // -1 in i32
     // 1111111111111111111111111111111
-    const i = bitcast(d.u32, d.i32)(4294967295);
+    const i = std.bitcast(d.u32, d.i32)(4294967295);
     expect(i).toBe(-1);
 
     // -2147483648 in i32
     // 10000000000000000000000000000000
-    const i2 = bitcast(d.u32, d.i32)(2147483648);
+    const i2 = std.bitcast(d.u32, d.i32)(2147483648);
     expect(i2).toBe(-2147483648);
   });
 
   it('bitcastF32toU32', () => {
-    const i1 = bitcast(d.f32, d.u32)(floatFromHex('00000001'));
+    const i1 = std.bitcast(d.f32, d.u32)(floatFromHex('00000001'));
     expect(i1).toBe(1);
 
-    const i2 = bitcast(d.f32, d.u32)(floatFromHex('7f800000'));
+    const i2 = std.bitcast(d.f32, d.u32)(floatFromHex('7f800000'));
     expect(i2).toBe(2139095040);
   });
 
   it('bitcastU32toF32 vectors', () => {
     const v2 = vec2u(1065353216, 3212836864); // 1.0f, -1.0f
-    const cast2 = bitcast(d.vec2u, d.vec2f)(v2);
+    const cast2 = std.bitcast(d.vec2u, d.vec2f)(v2);
     expect(std.isCloseTo(cast2, vec2f(1.0, -1.0))).toBe(true);
 
     const v3 = vec3u(0, 1065353216, 3212836864); // 0.0f, 1.0f, -1.0f
-    const cast3 = bitcast(d.vec3u, d.vec3f)(v3);
+    const cast3 = std.bitcast(d.vec3u, d.vec3f)(v3);
     expect(std.isCloseTo(cast3, vec3f(0.0, 1.0, -1.0))).toBe(true);
 
     const v4 = vec4u(0, 1065353216, 3212836864, 0); // 0,1,-1,0
-    const cast4 = bitcast(d.vec4u, d.vec4f)(v4);
+    const cast4 = std.bitcast(d.vec4u, d.vec4f)(v4);
     expect(std.isCloseTo(cast4, vec4f(0.0, 1.0, -1.0, 0.0))).toBe(true);
   });
 
   it('bitcastU32toI32 vectors', () => {
     const v2 = vec2u(4294967295, 2147483648); // -1, -2147483648
-    const cast2 = bitcast(d.vec2u, d.vec2i)(v2); // int vector
+    const cast2 = std.bitcast(d.vec2u, d.vec2i)(v2); // int vector
     expect(cast2).toEqual(vec2i(-1, -2147483648));
 
     const v3 = vec3u(0, 4294967295, 2147483648);
-    const cast3 = bitcast(d.vec3u, d.vec3i)(v3);
+    const cast3 = std.bitcast(d.vec3u, d.vec3i)(v3);
     expect(cast3).toEqual(vec3i(0, -1, -2147483648));
 
     const v4 = vec4u(0, 1, 4294967295, 2147483648);
-    const cast4 = bitcast(d.vec4u, d.vec4i)(v4);
+    const cast4 = std.bitcast(d.vec4u, d.vec4i)(v4);
     expect(cast4).toEqual(vec4i(0, 1, -1, -2147483648));
   });
 
   it('bitcastF32toU32 vectors', () => {
     const v2 = vec2f(floatFromHex('7c800001'), floatFromHex('100008c7'));
-    const cast2 = bitcast(d.vec2f, d.vec2u)(v2);
+    const cast2 = std.bitcast(d.vec2f, d.vec2u)(v2);
     expect(cast2).toStrictEqual(vec2u(2088763393, 268437703));
 
     const v3 = vec3f(floatFromHex('ff000000'), floatFromHex('00000001'), floatFromHex('80000001'));
-    const cast3 = bitcast(d.vec3f, d.vec3u)(v3);
+    const cast3 = std.bitcast(d.vec3f, d.vec3u)(v3);
     expect(cast3).toStrictEqual(vec3u(4278190080, 1, 2147483649));
 
     const v4 = vec4f(
@@ -82,28 +82,28 @@ describe('bitcast', () => {
       floatFromHex('48980780'),
       floatFromHex('0000075a'),
     );
-    const cast4 = bitcast(d.vec4f, d.vec4u)(v4);
+    const cast4 = std.bitcast(d.vec4f, d.vec4u)(v4);
     expect(cast4).toStrictEqual(vec4u(2216823077, 1753219072, 1217922944, 1882));
   });
 
   it('bitcastU32toF32 specials', () => {
     // +0
-    const pz = bitcast(d.u32, d.f32)(0x00000000);
+    const pz = std.bitcast(d.u32, d.f32)(0x00000000);
     expect(Object.is(pz, 0)).toBe(true);
     expect(1 / pz).toBe(Number.POSITIVE_INFINITY);
 
     // -0
-    const nz = bitcast(d.u32, d.f32)(0x80000000);
+    const nz = std.bitcast(d.u32, d.f32)(0x80000000);
     expect(Object.is(nz, -0)).toBe(true);
     expect(1 / nz).toBe(Number.NEGATIVE_INFINITY);
 
     // Smallest positive subnormal
-    const sub = bitcast(d.u32, d.f32)(0x00000001);
+    const sub = std.bitcast(d.u32, d.f32)(0x00000001);
     expect(sub).toBeGreaterThan(0);
     expect(sub).toBeLessThan(1e-44);
 
     // Smallest negative subnormal
-    const nsub = bitcast(d.u32, d.f32)(0x80000001);
+    const nsub = std.bitcast(d.u32, d.f32)(0x80000001);
     expect(nsub).toBeLessThan(0);
     expect(nsub).toBeGreaterThan(-1e-44);
   });
@@ -117,11 +117,11 @@ describe('bitcast', () => {
 
     // Vectors
     const v3 = vec3u(0x00000000, 0x80000000, 0xffffffff);
-    const c3 = bitcast(d.vec3u, d.vec3i)(v3);
+    const c3 = std.bitcast(d.vec3u, d.vec3i)(v3);
     expect(c3).toEqual(vec3i(0, -2147483648, -1));
 
     const v4 = vec4u(0x80000000, 0x00000001, 0x00000000, 0x7fffffff);
-    const c4 = bitcast(d.vec4u, d.vec4i)(v4);
+    const c4 = std.bitcast(d.vec4u, d.vec4i)(v4);
     expect(c4).toEqual(vec4i(-2147483648, 1, 0, 2147483647));
   });
 
@@ -149,9 +149,9 @@ describe('bitcast', () => {
 
 describe('bitcast in shaders', () => {
   it('works for primitives', () => {
-    const fnf32 = tgpu.fn([], d.f32)(() => bitcast(d.u32, d.f32)(1234));
-    const fni32 = tgpu.fn([], d.i32)(() => bitcast(d.u32, d.i32)(d.u32(2 ** 31)));
-    const fnu32 = tgpu.fn([d.f32], d.u32)((v) => bitcast(d.f32, d.u32)(v));
+    const fnf32 = tgpu.fn([], d.f32)(() => std.bitcast(d.u32, d.f32)(1234));
+    const fni32 = tgpu.fn([], d.i32)(() => std.bitcast(d.u32, d.i32)(d.u32(2 ** 31)));
+    const fnu32 = tgpu.fn([d.f32], d.u32)((v) => std.bitcast(d.f32, d.u32)(v));
 
     expect(tgpu.resolve([fnf32])).toMatchInlineSnapshot(`
       "fn fnf32() -> f32 {
@@ -171,9 +171,9 @@ describe('bitcast in shaders', () => {
   });
 
   it('works for vectors', () => {
-    const fnvec4i = tgpu.fn([], d.vec4i)(() => bitcast(d.vec4u, d.vec4i)(vec4u(1, 2, 3, 4)));
-    const fnvec4f = tgpu.fn([], d.vec4f)(() => bitcast(d.vec4u, d.vec4f)(vec4u(1, 2, 3, 4)));
-    const fnvec4u = tgpu.fn([d.vec4f], d.vec4u)((v) => bitcast(d.vec4f, d.vec4u)(v));
+    const fnvec4i = tgpu.fn([], d.vec4i)(() => std.bitcast(d.vec4u, d.vec4i)(vec4u(1, 2, 3, 4)));
+    const fnvec4f = tgpu.fn([], d.vec4f)(() => std.bitcast(d.vec4u, d.vec4f)(vec4u(1, 2, 3, 4)));
+    const fnvec4u = tgpu.fn([d.vec4f], d.vec4u)((v) => std.bitcast(d.vec4f, d.vec4u)(v));
 
     expect(tgpu.resolve([fnvec4i])).toMatchInlineSnapshot(`
       "fn fnvec4i() -> vec4i {
@@ -196,7 +196,7 @@ describe('bitcast in shaders', () => {
     const f1 = () => {
       'use gpu';
       // @ts-expect-error
-      return bitcast(d.vec2u, d.vec2i)(d.vec2i());
+      return std.bitcast(d.vec2u, d.vec2i)(d.vec2i());
     };
     expect(() => tgpu.resolve([f1])).toThrowErrorMatchingInlineSnapshot(`
       [Error: Resolution of the following tree failed:
@@ -209,7 +209,7 @@ describe('bitcast in shaders', () => {
     const f2 = () => {
       'use gpu';
       // @ts-expect-error
-      return bitcast(d.vec2u, d.vec2i)(d.vec3f());
+      return std.bitcast(d.vec2u, d.vec2i)(d.vec3f());
     };
     expect(() => tgpu.resolve([f2])).toThrowErrorMatchingInlineSnapshot(`
       [Error: Resolution of the following tree failed:
@@ -222,7 +222,7 @@ describe('bitcast in shaders', () => {
     const f3 = () => {
       'use gpu';
       // @ts-expect-error
-      return bitcast(d.vec2u, d.vec4h)(d.vec2h());
+      return std.bitcast(d.vec2u, d.vec4h)(d.vec2h());
     };
     expect(() => tgpu.resolve([f3])).toThrowErrorMatchingInlineSnapshot(`
       [Error: Resolution of the following tree failed:
@@ -235,7 +235,7 @@ describe('bitcast in shaders', () => {
     const f4 = () => {
       'use gpu';
       const u = d.u32(1);
-      return bitcast(d.f32, d.u32)(u);
+      return std.bitcast(d.f32, d.u32)(u);
     };
     expect(() => tgpu.resolve([f4])).toThrowErrorMatchingInlineSnapshot(`
       [Error: Resolution of the following tree failed:

--- a/packages/typegpu/tests/std/bitcast.test.ts
+++ b/packages/typegpu/tests/std/bitcast.test.ts
@@ -149,9 +149,9 @@ describe('bitcast', () => {
 
 describe('bitcast in shaders', () => {
   it('works for primitives', () => {
-    const fnf32 = tgpu.fn([], d.f32)(() => std.bitcastU32toF32(1234));
-    const fni32 = tgpu.fn([], d.i32)(() => std.bitcastU32toI32(d.u32(2 ** 31)));
-    const fnu32 = tgpu.fn([d.f32], d.u32)((v) => std.bitcastF32toU32(v));
+    const fnf32 = tgpu.fn([], d.f32)(() => bitcast(d.u32, d.f32)(1234));
+    const fni32 = tgpu.fn([], d.i32)(() => bitcast(d.u32, d.i32)(d.u32(2 ** 31)));
+    const fnu32 = tgpu.fn([d.f32], d.u32)((v) => bitcast(d.f32, d.u32)(v));
 
     expect(tgpu.resolve([fnf32])).toMatchInlineSnapshot(`
       "fn fnf32() -> f32 {
@@ -171,9 +171,9 @@ describe('bitcast in shaders', () => {
   });
 
   it('works for vectors', () => {
-    const fnvec4i = tgpu.fn([], d.vec4i)(() => std.bitcastU32toI32(vec4u(1, 2, 3, 4)));
-    const fnvec4f = tgpu.fn([], d.vec4f)(() => std.bitcastU32toF32(vec4u(1, 2, 3, 4)));
-    const fnvec4u = tgpu.fn([d.vec4f], d.vec4u)((v) => std.bitcastF32toU32(v));
+    const fnvec4i = tgpu.fn([], d.vec4i)(() => bitcast(d.vec4u, d.vec4i)(vec4u(1, 2, 3, 4)));
+    const fnvec4f = tgpu.fn([], d.vec4f)(() => bitcast(d.vec4u, d.vec4f)(vec4u(1, 2, 3, 4)));
+    const fnvec4u = tgpu.fn([d.vec4f], d.vec4u)((v) => bitcast(d.vec4f, d.vec4u)(v));
 
     expect(tgpu.resolve([fnvec4i])).toMatchInlineSnapshot(`
       "fn fnvec4i() -> vec4i {
@@ -196,53 +196,53 @@ describe('bitcast in shaders', () => {
     const f1 = () => {
       'use gpu';
       // @ts-expect-error
-      return std.bitcastU32toF32(d.vec2i());
+      return bitcast(d.vec2u, d.vec2i)(d.vec2i());
     };
     expect(() => tgpu.resolve([f1])).toThrowErrorMatchingInlineSnapshot(`
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:f1
       - fn*:f1()
-      - fn:bitcastU32toF32: Unsupported data types: vec2i. Supported types are: u32, vec2u, vec3u, vec4u.]
+      - fn:bitcast: Unsupported data types: vec2i. Supported types are: vec2u.]
     `);
 
     const f2 = () => {
       'use gpu';
       // @ts-expect-error
-      return std.bitcastU32toI32(d.vec3f());
+      return bitcast(d.vec2u, d.vec2i)(d.vec3f());
     };
     expect(() => tgpu.resolve([f2])).toThrowErrorMatchingInlineSnapshot(`
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:f2
       - fn*:f2()
-      - fn:bitcastU32toI32: Unsupported data types: vec3f. Supported types are: u32, vec2u, vec3u, vec4u.]
+      - fn:bitcast: Unsupported data types: vec3f. Supported types are: vec2u.]
     `);
 
     const f3 = () => {
       'use gpu';
       // @ts-expect-error
-      return std.bitcastF32toU32(d.vec2h());
+      return bitcast(d.vec2u, d.vec4h)(d.vec2h());
     };
     expect(() => tgpu.resolve([f3])).toThrowErrorMatchingInlineSnapshot(`
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:f3
       - fn*:f3()
-      - fn:bitcastF32toU32: Unsupported data types: vec2h. Supported types are: f32, vec2f, vec3f, vec4f.]
+      - fn:bitcast: Unsupported data types: vec2h. Supported types are: vec2u.]
     `);
 
     const f4 = () => {
       'use gpu';
       const u = d.u32(1);
-      return std.bitcastF32toU32(u);
+      return bitcast(d.f32, d.u32)(u);
     };
     expect(() => tgpu.resolve([f4])).toThrowErrorMatchingInlineSnapshot(`
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:f4
       - fn*:f4()
-      - fn:bitcastF32toU32: Unsupported data types: u32. Supported types are: f32, vec2f, vec3f, vec4f.]
+      - fn:bitcast: Unsupported data types: u32. Supported types are: f32.]
     `);
   });
 });

--- a/packages/typegpu/tests/std/bitcast.test.ts
+++ b/packages/typegpu/tests/std/bitcast.test.ts
@@ -7,7 +7,7 @@ import { bitcast } from '../../src/std/bitcast.ts';
 const floatFromHex = (hex: string) => Buffer.from(hex, 'hex').readFloatBE(0);
 
 describe('bitcast', () => {
-  it('bitcastU32toF32', () => {
+  it('bitcast U32 to F32', () => {
     // 1.0 in f32
     //0 01111111 00000000000000000000000
     const f = std.bitcast(d.u32, d.f32)(1065353216);
@@ -19,7 +19,7 @@ describe('bitcast', () => {
     expect(f2).toBeCloseTo(-1.0);
   });
 
-  it('bitcastU32toI32', () => {
+  it('bitcast U32 to I32', () => {
     // -1 in i32
     // 1111111111111111111111111111111
     const i = std.bitcast(d.u32, d.i32)(4294967295);
@@ -31,7 +31,7 @@ describe('bitcast', () => {
     expect(i2).toBe(-2147483648);
   });
 
-  it('bitcastF32toU32', () => {
+  it('bitcast F32 to U32', () => {
     const i1 = std.bitcast(d.f32, d.u32)(floatFromHex('00000001'));
     expect(i1).toBe(1);
 
@@ -39,7 +39,7 @@ describe('bitcast', () => {
     expect(i2).toBe(2139095040);
   });
 
-  it('bitcastU32toF32 vectors', () => {
+  it('bitcast U32 to F32 vectors', () => {
     const v2 = vec2u(1065353216, 3212836864); // 1.0f, -1.0f
     const cast2 = std.bitcast(d.vec2u, d.vec2f)(v2);
     expect(std.isCloseTo(cast2, vec2f(1.0, -1.0))).toBe(true);
@@ -53,7 +53,7 @@ describe('bitcast', () => {
     expect(std.isCloseTo(cast4, vec4f(0.0, 1.0, -1.0, 0.0))).toBe(true);
   });
 
-  it('bitcastU32toI32 vectors', () => {
+  it('bitcast U32 to I32 vectors', () => {
     const v2 = vec2u(4294967295, 2147483648); // -1, -2147483648
     const cast2 = std.bitcast(d.vec2u, d.vec2i)(v2); // int vector
     expect(cast2).toEqual(vec2i(-1, -2147483648));
@@ -67,7 +67,7 @@ describe('bitcast', () => {
     expect(cast4).toEqual(vec4i(0, 1, -1, -2147483648));
   });
 
-  it('bitcastF32toU32 vectors', () => {
+  it('bitcast F32 to U32 vectors', () => {
     const v2 = vec2f(floatFromHex('7c800001'), floatFromHex('100008c7'));
     const cast2 = std.bitcast(d.vec2f, d.vec2u)(v2);
     expect(cast2).toStrictEqual(vec2u(2088763393, 268437703));
@@ -86,7 +86,7 @@ describe('bitcast', () => {
     expect(cast4).toStrictEqual(vec4u(2216823077, 1753219072, 1217922944, 1882));
   });
 
-  it('bitcastU32toF32 specials', () => {
+  it('bitcast U32 to F32 specials', () => {
     // +0
     const pz = std.bitcast(d.u32, d.f32)(0x00000000);
     expect(Object.is(pz, 0)).toBe(true);
@@ -108,7 +108,7 @@ describe('bitcast', () => {
     expect(nsub).toBeGreaterThan(-1e-44);
   });
 
-  it('bitcastU32toI32 more edges', () => {
+  it('bitcast U32 to I32 more edges', () => {
     // Scalars
     expect(bitcast(d.u32, d.i32)(0x00000000)).toBe(0);
     expect(bitcast(d.u32, d.i32)(0x00000001)).toBe(1);
@@ -125,7 +125,7 @@ describe('bitcast', () => {
     expect(c4).toEqual(vec4i(-2147483648, 1, 0, 2147483647));
   });
 
-  it('bitcastF32toU32 specials (NaN, infinities etc)', () => {
+  it('bitcast F32 to U32 specials (NaN, infinities etc)', () => {
     // +0
     expect(bitcast(d.f32, d.u32)(+0)).toBe(0x00000000);
 

--- a/packages/typegpu/tests/std/bitcast.test.ts
+++ b/packages/typegpu/tests/std/bitcast.test.ts
@@ -105,6 +105,14 @@ describe('bitcast', () => {
     const nsub = std.bitcast(d.u32, d.f32)(0x80000001);
     expect(nsub).toBeLessThan(0);
     expect(nsub).toBeGreaterThan(-1e-44);
+
+    // +Inf / -Inf
+    expect(() => std.bitcast(d.u32, d.f32)(0x7f800000)).toThrow('Finite Math Assumption');
+    expect(() => std.bitcast(d.u32, d.f32)(0xff800000)).toThrow('Finite Math Assumption');
+
+    // NaNs
+    expect(() => std.bitcast(d.u32, d.f32)(0x7fc00000)).toThrow('Finite Math Assumption');
+    expect(() => std.bitcast(d.u32, d.f32)(0x7f800001)).toThrow('Finite Math Assumption');
   });
 
   it('bitcast U32 to I32 more edges', () => {

--- a/packages/typegpu/tests/std/bitcast.test.ts
+++ b/packages/typegpu/tests/std/bitcast.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import { vec2f, vec2i, vec2u, vec3f, vec3i, vec3u, vec4f, vec4i, vec4u } from 'typegpu/data';
 import { tgpu, d, std } from 'typegpu';
-import { bitcast } from '../../src/std/bitcast.ts';
 
 // remember to pad with zeros to 8 hex symbols
 const floatFromHex = (hex: string) => Buffer.from(hex, 'hex').readFloatBE(0);
@@ -110,10 +109,10 @@ describe('bitcast', () => {
 
   it('bitcast U32 to I32 more edges', () => {
     // Scalars
-    expect(bitcast(d.u32, d.i32)(0x00000000)).toBe(0);
-    expect(bitcast(d.u32, d.i32)(0x00000001)).toBe(1);
-    expect(bitcast(d.u32, d.i32)(0x7fffffff)).toBe(2147483647);
-    expect(bitcast(d.u32, d.i32)(0xffffffff)).toBe(-1);
+    expect(std.bitcast(d.u32, d.i32)(0x00000000)).toBe(0);
+    expect(std.bitcast(d.u32, d.i32)(0x00000001)).toBe(1);
+    expect(std.bitcast(d.u32, d.i32)(0x7fffffff)).toBe(2147483647);
+    expect(std.bitcast(d.u32, d.i32)(0xffffffff)).toBe(-1);
 
     // Vectors
     const v3 = vec3u(0x00000000, 0x80000000, 0xffffffff);
@@ -127,23 +126,23 @@ describe('bitcast', () => {
 
   it('bitcast F32 to U32 specials (NaN, infinities etc)', () => {
     // +0
-    expect(bitcast(d.f32, d.u32)(+0)).toBe(0x00000000);
+    expect(std.bitcast(d.f32, d.u32)(+0)).toBe(0x00000000);
 
     // -0
-    expect(bitcast(d.f32, d.u32)(-0)).toBe(0x80000000);
+    expect(std.bitcast(d.f32, d.u32)(-0)).toBe(0x80000000);
 
     // +Inf / -Inf
-    expect(bitcast(d.f32, d.u32)(Number.POSITIVE_INFINITY)).toBe(0x7f800000);
-    expect(bitcast(d.f32, d.u32)(Number.NEGATIVE_INFINITY)).toBe(0xff800000);
+    expect(std.bitcast(d.f32, d.u32)(Number.POSITIVE_INFINITY)).toBe(0x7f800000);
+    expect(std.bitcast(d.f32, d.u32)(Number.NEGATIVE_INFINITY)).toBe(0xff800000);
 
     // NaN
-    expect(bitcast(d.f32, d.u32)(Number.NaN)).toBe(0x7fc00000);
+    expect(std.bitcast(d.f32, d.u32)(Number.NaN)).toBe(0x7fc00000);
 
     // Smallest positive subnormal
-    expect(bitcast(d.f32, d.u32)(floatFromHex('00000001'))).toBe(0x00000001);
+    expect(std.bitcast(d.f32, d.u32)(floatFromHex('00000001'))).toBe(0x00000001);
 
     // Smallest negative subnormal
-    expect(bitcast(d.f32, d.u32)(floatFromHex('80000001'))).toBe(0x80000001);
+    expect(std.bitcast(d.f32, d.u32)(floatFromHex('80000001'))).toBe(0x80000001);
   });
 });
 

--- a/packages/typegpu/tests/std/bitcast.test.ts
+++ b/packages/typegpu/tests/std/bitcast.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import { vec2f, vec2i, vec2u, vec3f, vec3i, vec3u, vec4f, vec4i, vec4u } from 'typegpu/data';
 import { tgpu, d, std } from 'typegpu';
+import { bitcast } from '../../src/std/bitcast.ts';
 
 // remember to pad with zeros to 8 hex symbols
 const floatFromHex = (hex: string) => Buffer.from(hex, 'hex').readFloatBE(0);
@@ -9,70 +10,70 @@ describe('bitcast', () => {
   it('bitcastU32toF32', () => {
     // 1.0 in f32
     //0 01111111 00000000000000000000000
-    const f = std.bitcastU32toF32(1065353216);
+    const f = bitcast(d.u32, d.f32)(1065353216);
     expect(f).toBeCloseTo(1.0);
 
     // -1 in f32
     //1 01111111 00000000000000000000000
-    const f2 = std.bitcastU32toF32(3212836864);
+    const f2 = bitcast(d.u32, d.f32)(3212836864);
     expect(f2).toBeCloseTo(-1.0);
   });
 
   it('bitcastU32toI32', () => {
     // -1 in i32
     // 1111111111111111111111111111111
-    const i = std.bitcastU32toI32(4294967295);
+    const i = bitcast(d.u32, d.i32)(4294967295);
     expect(i).toBe(-1);
 
     // -2147483648 in i32
     // 10000000000000000000000000000000
-    const i2 = std.bitcastU32toI32(2147483648);
+    const i2 = bitcast(d.u32, d.i32)(2147483648);
     expect(i2).toBe(-2147483648);
   });
 
   it('bitcastF32toU32', () => {
-    const i1 = std.bitcastF32toU32(floatFromHex('00000001'));
+    const i1 = bitcast(d.f32, d.u32)(floatFromHex('00000001'));
     expect(i1).toBe(1);
 
-    const i2 = std.bitcastF32toU32(floatFromHex('7f800000'));
+    const i2 = bitcast(d.f32, d.u32)(floatFromHex('7f800000'));
     expect(i2).toBe(2139095040);
   });
 
   it('bitcastU32toF32 vectors', () => {
     const v2 = vec2u(1065353216, 3212836864); // 1.0f, -1.0f
-    const cast2 = std.bitcastU32toF32(v2);
+    const cast2 = bitcast(d.vec2u, d.vec2f)(v2);
     expect(std.isCloseTo(cast2, vec2f(1.0, -1.0))).toBe(true);
 
     const v3 = vec3u(0, 1065353216, 3212836864); // 0.0f, 1.0f, -1.0f
-    const cast3 = std.bitcastU32toF32(v3);
+    const cast3 = bitcast(d.vec3u, d.vec3f)(v3);
     expect(std.isCloseTo(cast3, vec3f(0.0, 1.0, -1.0))).toBe(true);
 
     const v4 = vec4u(0, 1065353216, 3212836864, 0); // 0,1,-1,0
-    const cast4 = std.bitcastU32toF32(v4);
+    const cast4 = bitcast(d.vec4u, d.vec4f)(v4);
     expect(std.isCloseTo(cast4, vec4f(0.0, 1.0, -1.0, 0.0))).toBe(true);
   });
 
   it('bitcastU32toI32 vectors', () => {
     const v2 = vec2u(4294967295, 2147483648); // -1, -2147483648
-    const cast2 = std.bitcastU32toI32(v2); // int vector
+    const cast2 = bitcast(d.vec2u, d.vec2i)(v2); // int vector
     expect(cast2).toEqual(vec2i(-1, -2147483648));
 
     const v3 = vec3u(0, 4294967295, 2147483648);
-    const cast3 = std.bitcastU32toI32(v3);
+    const cast3 = bitcast(d.vec3u, d.vec3i)(v3);
     expect(cast3).toEqual(vec3i(0, -1, -2147483648));
 
     const v4 = vec4u(0, 1, 4294967295, 2147483648);
-    const cast4 = std.bitcastU32toI32(v4);
+    const cast4 = bitcast(d.vec4u, d.vec4i)(v4);
     expect(cast4).toEqual(vec4i(0, 1, -1, -2147483648));
   });
 
   it('bitcastF32toU32 vectors', () => {
     const v2 = vec2f(floatFromHex('7c800001'), floatFromHex('100008c7'));
-    const cast2 = std.bitcastF32toU32(v2);
+    const cast2 = bitcast(d.vec2f, d.vec2u)(v2);
     expect(cast2).toStrictEqual(vec2u(2088763393, 268437703));
 
     const v3 = vec3f(floatFromHex('ff000000'), floatFromHex('00000001'), floatFromHex('80000001'));
-    const cast3 = std.bitcastF32toU32(v3);
+    const cast3 = bitcast(d.vec3f, d.vec3u)(v3);
     expect(cast3).toStrictEqual(vec3u(4278190080, 1, 2147483649));
 
     const v4 = vec4f(
@@ -81,106 +82,68 @@ describe('bitcast', () => {
       floatFromHex('48980780'),
       floatFromHex('0000075a'),
     );
-    const cast4 = std.bitcastF32toU32(v4);
+    const cast4 = bitcast(d.vec4f, d.vec4u)(v4);
     expect(cast4).toStrictEqual(vec4u(2216823077, 1753219072, 1217922944, 1882));
   });
 
-  it('bitcastU32toF32 specials (NaN, infinities etc)', () => {
+  it('bitcastU32toF32 specials', () => {
     // +0
-    const pz = std.bitcastU32toF32(0x00000000);
+    const pz = bitcast(d.u32, d.f32)(0x00000000);
     expect(Object.is(pz, 0)).toBe(true);
     expect(1 / pz).toBe(Number.POSITIVE_INFINITY);
 
     // -0
-    const nz = std.bitcastU32toF32(0x80000000);
+    const nz = bitcast(d.u32, d.f32)(0x80000000);
     expect(Object.is(nz, -0)).toBe(true);
     expect(1 / nz).toBe(Number.NEGATIVE_INFINITY);
 
-    // +Inf / -Inf
-    expect(std.bitcastU32toF32(0x7f800000)).toBe(Number.POSITIVE_INFINITY);
-    expect(std.bitcastU32toF32(0xff800000)).toBe(Number.NEGATIVE_INFINITY);
-
-    // NaNs
-    const qnan = std.bitcastU32toF32(0x7fc00000);
-    const snan = std.bitcastU32toF32(0x7f800001);
-    expect(Number.isNaN(qnan)).toBe(true);
-    expect(Number.isNaN(snan)).toBe(true);
-
     // Smallest positive subnormal
-    const sub = std.bitcastU32toF32(0x00000001);
+    const sub = bitcast(d.u32, d.f32)(0x00000001);
     expect(sub).toBeGreaterThan(0);
     expect(sub).toBeLessThan(1e-44);
 
     // Smallest negative subnormal
-    const nsub = std.bitcastU32toF32(0x80000001);
+    const nsub = bitcast(d.u32, d.f32)(0x80000001);
     expect(nsub).toBeLessThan(0);
     expect(nsub).toBeGreaterThan(-1e-44);
   });
 
   it('bitcastU32toI32 more edges', () => {
     // Scalars
-    expect(std.bitcastU32toI32(0x00000000)).toBe(0);
-    expect(std.bitcastU32toI32(0x00000001)).toBe(1);
-    expect(std.bitcastU32toI32(0x7fffffff)).toBe(2147483647);
-    expect(std.bitcastU32toI32(0xffffffff)).toBe(-1);
+    expect(bitcast(d.u32, d.i32)(0x00000000)).toBe(0);
+    expect(bitcast(d.u32, d.i32)(0x00000001)).toBe(1);
+    expect(bitcast(d.u32, d.i32)(0x7fffffff)).toBe(2147483647);
+    expect(bitcast(d.u32, d.i32)(0xffffffff)).toBe(-1);
 
     // Vectors
     const v3 = vec3u(0x00000000, 0x80000000, 0xffffffff);
-    const c3 = std.bitcastU32toI32(v3);
+    const c3 = bitcast(d.vec3u, d.vec3i)(v3);
     expect(c3).toEqual(vec3i(0, -2147483648, -1));
 
     const v4 = vec4u(0x80000000, 0x00000001, 0x00000000, 0x7fffffff);
-    const c4 = std.bitcastU32toI32(v4);
+    const c4 = bitcast(d.vec4u, d.vec4i)(v4);
     expect(c4).toEqual(vec4i(-2147483648, 1, 0, 2147483647));
   });
 
   it('bitcastF32toU32 specials (NaN, infinities etc)', () => {
     // +0
-    expect(std.bitcastF32toU32(+0)).toBe(0x00000000);
+    expect(bitcast(d.f32, d.u32)(+0)).toBe(0x00000000);
 
     // -0
-    expect(std.bitcastF32toU32(-0)).toBe(0x80000000);
+    expect(bitcast(d.f32, d.u32)(-0)).toBe(0x80000000);
 
     // +Inf / -Inf
-    expect(std.bitcastF32toU32(Number.POSITIVE_INFINITY)).toBe(0x7f800000);
-    expect(std.bitcastF32toU32(Number.NEGATIVE_INFINITY)).toBe(0xff800000);
+    expect(bitcast(d.f32, d.u32)(Number.POSITIVE_INFINITY)).toBe(0x7f800000);
+    expect(bitcast(d.f32, d.u32)(Number.NEGATIVE_INFINITY)).toBe(0xff800000);
 
     // NaN
-    expect(std.bitcastF32toU32(Number.NaN)).toBe(0x7fc00000);
+    expect(bitcast(d.f32, d.u32)(Number.NaN)).toBe(0x7fc00000);
 
     // Smallest positive subnormal
-    expect(std.bitcastF32toU32(floatFromHex('00000001'))).toBe(0x00000001);
+    expect(bitcast(d.f32, d.u32)(floatFromHex('00000001'))).toBe(0x00000001);
 
     // Smallest negative subnormal
-    expect(std.bitcastF32toU32(floatFromHex('80000001'))).toBe(0x80000001);
-  });
-
-  it('handles union of types', () => {
-    const f1 = (x: number | d.v2u) => {
-      'use gpu';
-      return std.bitcastU32toF32(x);
-    };
-    expectTypeOf(f1).returns.toEqualTypeOf<number | d.v2f>();
-
-    const f2 = (x: number | d.v2u) => {
-      'use gpu';
-      return std.bitcastU32toI32(x);
-    };
-    expectTypeOf(f2).returns.toEqualTypeOf<number | d.v2i>();
-
-    const f3 = (x: number | d.v2f) => {
-      'use gpu';
-      return std.bitcastF32toU32(x);
-    };
-    expectTypeOf(f3).returns.toEqualTypeOf<number | d.v2u>();
-  });
-
-  it('type error on invalid argument', () => {
-    const _f = (x: number | d.v2f) => {
-      'use gpu';
-      // @ts-expect-error
-      return std.bitcastU32toI32(x);
-    };
+    expect(bitcast(d.f32, d.u32)(floatFromHex('80000001'))).toBe(0x80000001);
   });
 });
 


### PR DESCRIPTION
I tried to generate the overloads in runtime from the following:
```ts
const bitcastTypes = [
  /* 2 bytes */
  [f16],
  /* 4 bytes */
  [f32, i32, u32, vec2h],
  /* 6 bytes */
  [vec3h],
  /* 8 bytes */
  [vec2f, vec2i, vec2u, vec4h],
  /* 12 bytes */
  [vec3f, vec3i, vec3u],
  /* 16 bytes */
  [vec4f, vec4i, vec4u],
] as const;
```
however I couldn't get the types to work without lying and using `as unknown as`.

Regarding union casts, everything works naturally (though this does not necessarily mean it's practical):
```ts
const outSchema = d.u32 as d.Vec2h | d.U32;
const outCast = std.bitcast(d.f32, outSchema); // either (number) => number or (number) => v2h
outCast(0); // number | v2h
```
```ts
const inSchema = d.u32 as d.Vec2h | d.U32;
const inCast = std.bitcast(inSchema, d.f32); // either (v2h) => number or (number) => number
inCast(0); // error, expects argument to be v2h & number
```