### PR TITLE
feat: CPU implementation of std.transpose

### DIFF
--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -529,6 +529,7 @@ export interface mat2x2<TColumn> extends NumberArrayView {
   readonly kind: string;
   /* override */ readonly columns: readonly [TColumn, TColumn];
   [n: number]: number;
+  toString(): string;
 }
 
 /**
@@ -549,6 +550,7 @@ export interface mat3x3<TColumn> extends NumberArrayView {
   readonly kind: string;
   /* override */ readonly columns: readonly [TColumn, TColumn, TColumn];
   [n: number]: number;
+  toString(): string;
 }
 
 /**
@@ -569,6 +571,7 @@ export interface mat4x4<TColumn> extends NumberArrayView {
   readonly kind: string;
   /* override */ readonly columns: readonly [TColumn, TColumn, TColumn, TColumn];
   [n: number]: number;
+  toString(): string;
 }
 
 /**

--- a/packages/typegpu/src/shared/stringify.ts
+++ b/packages/typegpu/src/shared/stringify.ts
@@ -21,7 +21,6 @@ export function safeStringify(item: unknown): string {
 
 export function niceStringify(item: unknown): string {
   if (isVecInstance(item) || isMatInstance(item)) {
-    // oxlint-disable-next-line typescript/no-base-to-string -- it's fine
     return item.toString();
   }
 

--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -41,6 +41,7 @@ import {
   type v4i,
   type Vec2f,
   type VecData,
+  WORKAROUND_getSchema,
 } from '../data/wgslTypes.ts';
 import { SignatureNotSupportedError } from '../errors.ts';
 import type { Infer } from '../shared/repr.ts';
@@ -1227,11 +1228,23 @@ export const tanh = dualImpl({
   sideEffects: false,
 });
 
-export const transpose = dualImpl<<T extends AnyMatInstance>(e: T) => T>({
+function cpuTranspose<T extends AnyMatInstance>(value: T): T {
+  const schema = WORKAROUND_getSchema(value);
+  // NOTE: This assumes all matrices are square
+  const transposed = schema() as T;
+  for (let c = 0; c < value.columns.length; c++) {
+    for (let r = 0; r < value.columns[0].length; r++) {
+      // oxlint-disable-next-line typescript/no-non-null-assertion
+      transposed.columns[r]![c] = value.columns[c]![r]!;
+    }
+  }
+  return transposed;
+}
+
+export const transpose = dualImpl({
   name: 'transpose',
   signature: unaryIdentitySignature,
-  normalImpl:
-    'CPU implementation for transpose not implemented yet. Please submit an issue at https://github.com/software-mansion/TypeGPU/issues',
+  normalImpl: cpuTranspose,
   codegenImpl: (_ctx, [e]) => stitch`transpose(${e})`,
   sideEffects: false,
 });

--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -45,6 +45,7 @@ import {
 } from '../data/wgslTypes.ts';
 import { SignatureNotSupportedError } from '../errors.ts';
 import type { Infer } from '../shared/repr.ts';
+import { assertExhaustive } from '../shared/utilityTypes.ts';
 import { unify } from '../tgsl/conversion.ts';
 import type { ResolutionCtx } from '../types.ts';
 import { mul, sub } from './operators.ts';
@@ -1232,12 +1233,51 @@ function cpuTranspose<T extends AnyMatInstance>(value: T): T {
   const schema = WORKAROUND_getSchema(value);
   // NOTE: This assumes all matrices are square
   const transposed = schema() as T;
-  for (let c = 0; c < value.columns.length; c++) {
-    for (let r = 0; r < value.columns[0].length; r++) {
-      // oxlint-disable-next-line typescript/no-non-null-assertion
-      transposed.columns[r]![c] = value.columns[c]![r]!;
-    }
+  const src = value.columns;
+  const dst = transposed.columns;
+
+  if (src.length === 2) {
+    dst[0]![0] = src[0]![0]!;
+    dst[0]![1] = src[1]![0]!;
+
+    dst[1]![0] = src[0]![1]!;
+    dst[1]![1] = src[1]![1]!;
+  } else if (src.length === 3) {
+    dst[0]![0] = src[0]![0]!;
+    dst[0]![1] = src[1]![0]!;
+    dst[0]![2] = src[2]![0]!;
+
+    dst[1]![0] = src[0]![1]!;
+    dst[1]![1] = src[1]![1]!;
+    dst[1]![2] = src[2]![1]!;
+
+    dst[2]![0] = src[0]![2]!;
+    dst[2]![1] = src[1]![2]!;
+    dst[2]![2] = src[2]![2]!;
+  } else if (src.length === 4) {
+    dst[0]![0] = src[0]![0]!;
+    dst[0]![1] = src[1]![0]!;
+    dst[0]![2] = src[2]![0]!;
+    dst[0]![3] = src[3]![0]!;
+
+    dst[1]![0] = src[0]![1]!;
+    dst[1]![1] = src[1]![1]!;
+    dst[1]![2] = src[2]![1]!;
+    dst[1]![3] = src[3]![1]!;
+
+    dst[2]![0] = src[0]![2]!;
+    dst[2]![1] = src[1]![2]!;
+    dst[2]![2] = src[2]![2]!;
+    dst[2]![3] = src[3]![2]!;
+
+    dst[3]![0] = src[0]![3]!;
+    dst[3]![1] = src[1]![3]!;
+    dst[3]![2] = src[2]![3]!;
+    dst[3]![3] = src[3]![3]!;
+  } else {
+    assertExhaustive(src, 'std/numeric.ts#cpuTranspose');
   }
+
   return transposed;
 }
 

--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -1237,43 +1237,49 @@ function cpuTranspose<T extends AnyMatInstance>(value: T): T {
   const dst = transposed.columns;
 
   if (src.length === 2) {
-    dst[0]![0] = src[0]![0]!;
-    dst[0]![1] = src[1]![0]!;
+    dst[0][0] = src[0][0];
+    dst[0][1] = src[1][0];
 
-    dst[1]![0] = src[0]![1]!;
-    dst[1]![1] = src[1]![1]!;
+    dst[1][0] = src[0][1];
+    dst[1][1] = src[1][1];
   } else if (src.length === 3) {
-    dst[0]![0] = src[0]![0]!;
-    dst[0]![1] = src[1]![0]!;
-    dst[0]![2] = src[2]![0]!;
+    dst[0][0] = src[0][0];
+    dst[0][1] = src[1][0];
+    dst[0][2] = src[2][0];
 
-    dst[1]![0] = src[0]![1]!;
-    dst[1]![1] = src[1]![1]!;
-    dst[1]![2] = src[2]![1]!;
+    dst[1][0] = src[0][1];
+    dst[1][1] = src[1][1];
+    dst[1][2] = src[2][1];
 
-    dst[2]![0] = src[0]![2]!;
-    dst[2]![1] = src[1]![2]!;
-    dst[2]![2] = src[2]![2]!;
+    // oxlint-disable-next-line typescript/no-non-null-assertion
+    const dst2 = dst[2]!;
+    dst2[0] = src[0][2];
+    dst2[1] = src[1][2];
+    dst2[2] = src[2][2];
   } else if (src.length === 4) {
-    dst[0]![0] = src[0]![0]!;
-    dst[0]![1] = src[1]![0]!;
-    dst[0]![2] = src[2]![0]!;
-    dst[0]![3] = src[3]![0]!;
+    dst[0][0] = src[0][0];
+    dst[0][1] = src[1][0];
+    dst[0][2] = src[2][0];
+    dst[0][3] = src[3][0];
 
-    dst[1]![0] = src[0]![1]!;
-    dst[1]![1] = src[1]![1]!;
-    dst[1]![2] = src[2]![1]!;
-    dst[1]![3] = src[3]![1]!;
+    dst[1][0] = src[0][1];
+    dst[1][1] = src[1][1];
+    dst[1][2] = src[2][1];
+    dst[1][3] = src[3][1];
 
-    dst[2]![0] = src[0]![2]!;
-    dst[2]![1] = src[1]![2]!;
-    dst[2]![2] = src[2]![2]!;
-    dst[2]![3] = src[3]![2]!;
+    // oxlint-disable-next-line typescript/no-non-null-assertion
+    const dst2 = dst[2]!;
+    dst2[0] = src[0][2];
+    dst2[1] = src[1][2];
+    dst2[2] = src[2][2];
+    dst2[3] = src[3][2];
 
-    dst[3]![0] = src[0]![3]!;
-    dst[3]![1] = src[1]![3]!;
-    dst[3]![2] = src[2]![3]!;
-    dst[3]![3] = src[3]![3]!;
+    // oxlint-disable-next-line typescript/no-non-null-assertion
+    const dst3 = dst[3]!;
+    dst3[0] = src[0][3];
+    dst3[1] = src[1][3];
+    dst3[2] = src[2][3];
+    dst3[3] = src[3][3];
   } else {
     assertExhaustive(src, 'std/numeric.ts#cpuTranspose');
   }

--- a/packages/typegpu/tests/std/transpose.test.ts
+++ b/packages/typegpu/tests/std/transpose.test.ts
@@ -1,0 +1,40 @@
+import { it } from 'typegpu-testing-utility';
+import { describe, expect } from 'vitest';
+import { tgpu, d, std } from 'typegpu';
+
+describe('std.transpose', () => {
+  it('transposes mat2x2f in JS', () => {
+    expect(std.transpose(d.mat2x2f(1, 2, 3, 4)).toString()).toMatchInlineSnapshot(
+      `"mat2x2f(1, 3, 2, 4)"`,
+    );
+  });
+
+  it('transposes mat3x3f in JS', () => {
+    expect(std.transpose(d.mat3x3f(1, 2, 3, 4, 5, 6, 7, 8, 9)).toString()).toMatchInlineSnapshot(
+      `"mat3x3f(1, 4, 7, 2, 5, 8, 3, 6, 9)"`,
+    );
+  });
+
+  it('transposes mat4x4f in JS', () => {
+    expect(
+      std.transpose(d.mat4x4f(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)).toString(),
+    ).toMatchInlineSnapshot(`"mat4x4f(1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16)"`);
+  });
+
+  it('generates call to builtin transpose() function', () => {
+    const foo = tgpu.const(d.mat2x2f, d.mat2x2f(1, 2, 3, 4));
+
+    function main() {
+      'use gpu';
+      return std.transpose(foo.$);
+    }
+
+    expect(tgpu.resolve([main])).toMatchInlineSnapshot(`
+      "const foo: mat2x2f = mat2x2f(1, 2, 3, 4);
+
+      fn main() -> mat2x2f {
+        return transpose(foo);
+      }"
+    `);
+  });
+});


### PR DESCRIPTION
In addition, the TS type system is now made aware that matrices have a custom `toString` method, so ignoring the lint rule is no longer necessary.