### PR TITLE
dev: add fast-unit test scripts excluding example tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:built-unit-and-attest": "pnpm run --filter './packages/*' build && TEST_BUILT=1 ENABLE_ATTEST=1 vitest run --project=!browser",
     "test:unit:watch": "vitest --project=!browser",
     "test:fast-unit": "vitest run --project=!browser --exclude '**/individual-example-tests/**'",
-    "test:fast-unit-watch": "vitest --project=!browser --exclude '**/individual-example-tests/**'",
+    "test:fast-unit:watch": "vitest --project=!browser --exclude '**/individual-example-tests/**'",
     "test:browser": "vitest run --browser.enabled --project browser",
     "test:browser:watch": "vitest --browser.enabled --project browser",
     "test:coverage": "vitest --coverage run",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "test:built-unit": "pnpm run --filter './packages/*' build && TEST_BUILT=1 vitest run --project=!browser",
     "test:built-unit-and-attest": "pnpm run --filter './packages/*' build && TEST_BUILT=1 ENABLE_ATTEST=1 vitest run --project=!browser",
     "test:unit:watch": "vitest --project=!browser",
+    "test:fast-unit": "vitest run --project=!browser --exclude '**/individual-example-tests/**'",
+    "test:fast-unit-watch": "vitest --project=!browser --exclude '**/individual-example-tests/**'",
     "test:browser": "vitest run --browser.enabled --project browser",
     "test:browser:watch": "vitest --browser.enabled --project browser",
     "test:coverage": "vitest --coverage run",


### PR DESCRIPTION
## What
Adds `test:fast-unit` and `test:fast-unit-watch` to the root `package.json`.
They run the unit tests but exclude the example tests in
`apps/typegpu-docs/tests/individual-example-tests`, for a faster local loop.

Closes #1638

## Note on the approach
The issue suggests handling this like the browser tests (by project). On
Vitest 4, though, the inner `individual-example-tests` project defined in
`apps/typegpu-docs/vitest.config.mts` is not addressable from the monorepo
root: when that config is pulled in via the root `projects: ['apps/*']`, its
nested `test.projects` is not re-expanded, so the example tests run under the
`typegpu-docs` project and `--project=!individual-example-tests` is a no-op.

I excluded them by path instead: `--exclude '**/individual-example-tests/**'`.
`apps/typegpu-docs` has no other node tests, so nothing else is affected.

Result: `test:fast-unit` runs 2508 tests across 192 files (vs 2567 / 251 with
the examples) and is noticeably faster.

Happy to instead restructure the config so the example tests become a
root-addressable project (then `--project=!individual-example-tests`) if you
prefer that.

## Side note (out of scope for this PR)
`--project=!browser` in the existing scripts also looks like a no-op from the
root, and `test:browser` (`--project browser`) errors with "No projects
matched" when run from the root. Possibly fallout from the Vitest 3->4 upgrade.