### PR TITLE
feat: Treat tgpu.lazy as resolvable

### DIFF
--- a/packages/typegpu/src/types.ts
+++ b/packages/typegpu/src/types.ts
@@ -17,6 +17,7 @@ import {
   isSlot,
   type SlotValuePair,
   type TgpuAccessor,
+  type TgpuLazy,
   type TgpuSlot,
 } from './core/slot/slotTypes.ts';
 import type { TgpuExternalTexture } from './core/texture/externalTexture.ts';
@@ -47,6 +48,7 @@ import type { TgpuBufferBinding } from './core/buffer/bufferBinding.ts';
 
 export type ResolvableObject =
   | SelfResolvable
+  | TgpuLazy<unknown>
   | TgpuConst
   | TgpuDeclare
   | TgpuBindGroupLayout

--- a/packages/typegpu/tests/lazy.test.ts
+++ b/packages/typegpu/tests/lazy.test.ts
@@ -249,4 +249,17 @@ describe('TgpuLazy', () => {
       }"
     `);
   });
+
+  it('can be resolved directly', () => {
+    const hello = tgpu.lazy(() => () => {
+      'use gpu';
+      return 1 + 2;
+    });
+
+    expect(tgpu.resolve([hello])).toMatchInlineSnapshot(`
+      "fn item() -> i32 {
+        return 3;
+      }"
+    `);
+  });
 });


### PR DESCRIPTION
This already worked at runtime, it's just that the types were protesting