### PR TITLE
docs: Change default cubemap in "Cubemap Reflection" example

### DIFF
--- a/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/cubemap.ts
+++ b/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/cubemap.ts
@@ -58,7 +58,7 @@ export const cubeVertices: d.Infer<typeof CubeVertex>[] = [
   vert([-1, 1, -1], [1, 0]),
 ];
 
-export type CubemapNames = 'campsite' | 'beach' | 'chapel' | 'city';
+export type CubemapNames = 'city' | 'campsite' | 'beach' | 'chapel';
 function getCubemapUrls(name: CubemapNames) {
   return ['posx', 'negx', 'posy', 'negy', 'posz', 'negz'].map(
     (side) => `/TypeGPU/assets/cubemap-reflection/${name}/${side}.jpg`,

--- a/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/cubemap-reflection/index.ts
@@ -78,7 +78,7 @@ const materialBuffer = root.createBuffer(Material, materialProps).$usage('unifor
 
 // Textures & Samplers
 
-let chosenCubemap: CubemapNames = 'campsite';
+let chosenCubemap: CubemapNames = 'city';
 const size = 2048;
 const texture = root
   .createTexture({
@@ -444,7 +444,7 @@ export const controls = defineControls({
   },
   'cubemap texture': {
     initial: chosenCubemap,
-    options: ['campsite', 'beach', 'chapel', 'city'],
+    options: ['city', 'campsite', 'beach', 'chapel'],
     onSelectChange: async (value) => {
       chosenCubemap = value;
       await loadCubemap(texture, chosenCubemap);


### PR DESCRIPTION
This is to make it more appealing on first load, as well as to match it with the thumbnail.