### PR TITLE
docs: align GTM noscript container ID

### DIFF
--- a/apps/typegpu-docs/src/layouts/PageLayout.astro
+++ b/apps/typegpu-docs/src/layouts/PageLayout.astro
@@ -128,7 +128,7 @@ const reservationScript = firstZone
       enableAnalytics && (
         <noscript>
           <iframe
-            src="https://www.googletagmanager.com/ns.html?id=GTM-TFGF383S"
+            src="https://www.googletagmanager.com/ns.html?id=GTM-T69W3PKG"
             height="0"
             width="0"
             style="display:none;visibility:hidden"


### PR DESCRIPTION
## Summary
Unify GTM IDs in `apps/typegpu-docs/src/layouts/PageLayout.astro` to `GTM-T69W3PKG`.

Resolves #2777