### PR TITLE
feat: Souls

### DIFF
--- a/packages/typegpu/src/core/buffer/buffer.ts
+++ b/packages/typegpu/src/core/buffer/buffer.ts
@@ -18,7 +18,8 @@ import type {
   IsValidVertexSchema,
   MemIdentity,
 } from '../../shared/repr.ts';
-import { $internal } from '../../shared/symbols.ts';
+import type { TgpuDeviceOwningSoul } from '../../shared/soul.ts';
+import { $internal, $soul } from '../../shared/symbols.ts';
 import type { Prettify, UnionToIntersection } from '../../shared/utilityTypes.ts';
 import { isGPUBuffer } from '../../types.ts';
 import type { TgpuCommandEncoder } from '../commandEncoder/commandEncoder.ts';
@@ -64,7 +65,16 @@ export interface IndirectFlag {
  */
 export type Vertex = VertexFlag;
 
-type UsageLiteral = 'uniform' | 'storage' | 'vertex' | 'index' | 'indirect';
+export type UsageLiteral = 'uniform' | 'storage' | 'vertex' | 'index' | 'indirect';
+
+export interface TgpuBufferSoul<TData extends BaseData = BaseData> extends TgpuDeviceOwningSoul<
+  'buffer',
+  GPUBuffer
+> {
+  readonly dataType: TData;
+  flags: GPUBufferUsageFlags;
+  readonly usages: UsageLiteral[];
+}
 
 type LiteralToUsageType<T extends UsageLiteral> = T extends 'uniform'
   ? UniformFlag
@@ -116,7 +126,10 @@ export type BufferInitialData<TData extends BaseData> =
   | BufferInitCallback<TData>;
 
 export interface TgpuBuffer<TData extends BaseData> extends TgpuNamable {
-  readonly [$internal]: true;
+  readonly [$internal]: {
+    readonly materialize: () => GPUBuffer;
+  };
+  readonly [$soul]: TgpuBufferSoul<TData>;
   readonly resourceType: 'buffer';
   readonly dataType: TData;
   readonly initial?: InferInput<TData> | undefined;
@@ -172,13 +185,12 @@ export function INTERNAL_createBuffer<TData extends AnyData>(
 // Implementation
 // --------------
 class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
-  readonly [$internal] = true;
+  readonly [$internal]: {
+    readonly materialize: () => GPUBuffer;
+  };
+  readonly [$soul]: TgpuBufferSoul<TData>;
   readonly resourceType = 'buffer';
-  flags: GPUBufferUsageFlags = GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC;
-  readonly dataType: TData;
 
-  readonly #device: GPUDevice;
-  #buffer: GPUBuffer | null = null;
   #ownBuffer: boolean;
   #destroyed = false;
   #internalBuffer: ArrayBuffer | undefined;
@@ -204,12 +216,19 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
     initialOrBuffer?: BufferInitialData<TData> | GPUBuffer,
     disallowedUsages?: UsageLiteral[],
   ) {
-    this.dataType = dataType;
+    this[$soul] = {
+      type: 'buffer',
+      device: root.device,
+      dataType,
+      flags: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+      usages: [],
+      raw: undefined,
+      label: undefined,
+    };
     this.#disallowedUsages = disallowedUsages;
-    this.#device = root.device;
     if (isGPUBuffer(initialOrBuffer)) {
       this.#ownBuffer = false;
-      this.#buffer = initialOrBuffer;
+      this[$soul].raw = initialOrBuffer;
     } else {
       this.#ownBuffer = true;
       if (typeof initialOrBuffer === 'function') {
@@ -218,32 +237,50 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
         this.initial = initialOrBuffer;
       }
     }
+    this[$internal] = {
+      materialize: () => {
+        if (this.#destroyed) {
+          throw new Error('This buffer has been destroyed');
+        }
+
+        const soul = this[$soul];
+        if (!soul.raw) {
+          soul.raw = soul.device.createBuffer({
+            size: sizeOf(soul.dataType),
+            usage: soul.flags,
+            mappedAtCreation: !!this.initial || !!this.#initialCallback,
+            label: getName(this) ?? '<unnamed>',
+          });
+
+          if (this.initial || this.#initialCallback) {
+            if (this.#initialCallback) {
+              this.#initialCallback(this);
+            } else if (this.initial) {
+              writeToArrayBuffer(this.#getMappedRange(), this.dataType, this.initial);
+            }
+            this.#unmapBuffer();
+          }
+        }
+
+        return soul.raw;
+      },
+    };
+  }
+
+  get dataType(): TData {
+    return this[$soul].dataType;
+  }
+
+  get flags(): GPUBufferUsageFlags {
+    return this[$soul].flags;
+  }
+
+  set flags(value: GPUBufferUsageFlags) {
+    this[$soul].flags = value;
   }
 
   get buffer() {
-    if (this.#destroyed) {
-      throw new Error('This buffer has been destroyed');
-    }
-
-    if (!this.#buffer) {
-      this.#buffer = this.#device.createBuffer({
-        size: sizeOf(this.dataType),
-        usage: this.flags,
-        mappedAtCreation: !!this.initial || !!this.#initialCallback,
-        label: getName(this) ?? '<unnamed>',
-      });
-
-      if (this.initial || this.#initialCallback) {
-        if (this.#initialCallback) {
-          this.#initialCallback(this);
-        } else if (this.initial) {
-          writeToArrayBuffer(this.#getMappedRange(), this.dataType, this.initial);
-        }
-        this.#unmapBuffer();
-      }
-    }
-
-    return this.#buffer;
+    return this[$internal].materialize();
   }
 
   get destroyed() {
@@ -260,27 +297,30 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
   }
 
   #getMappedRange(): ArrayBuffer {
-    if (!this.#buffer || this.#buffer.mapState !== 'mapped') {
+    const raw = this[$soul].raw;
+    if (!raw || raw.mapState !== 'mapped') {
       throw new Error('Buffer is not mapped.');
     }
 
-    this.#mappedRange ??= this.#buffer.getMappedRange();
+    this.#mappedRange ??= raw.getMappedRange();
     return this.#mappedRange;
   }
 
   #unmapBuffer(): void {
-    if (!this.#buffer || this.#buffer.mapState !== 'mapped') {
+    const raw = this[$soul].raw;
+    if (!raw || raw.mapState !== 'mapped') {
       return;
     }
 
     this.#mappedRange = undefined;
-    this.#buffer.unmap();
+    raw.unmap();
   }
 
   $name(label: string) {
     setName(this, label);
-    if (this.#buffer) {
-      this.#buffer.label = label;
+    const raw = this[$soul].raw;
+    if (raw) {
+      raw.label = label;
     }
     return this;
   }
@@ -303,6 +343,9 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
       this.usableAsVertex = this.usableAsVertex || usage === 'vertex';
       this.usableAsIndex = this.usableAsIndex || usage === 'index';
       this.usableAsIndirect = this.usableAsIndirect || usage === 'indirect';
+      if (!this[$soul].usages.includes(usage)) {
+        this[$soul].usages.push(usage);
+      }
     }
     return this as this & UnionToIntersection<LiteralToUsageType<T[number]>>;
   }
@@ -355,7 +398,13 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
     const { startOffset, endOffset } = calculateOffsets(options, this.dataType, data);
     const size = endOffset - startOffset;
 
-    this.#device.queue.writeBuffer(gpuBuffer, startOffset, this.#hostBuffer, startOffset, size);
+    this[$soul].device.queue.writeBuffer(
+      gpuBuffer,
+      startOffset,
+      this.#hostBuffer,
+      startOffset,
+      size,
+    );
   }
 
   /** @deprecated Use {@link patch} instead. */
@@ -371,7 +420,7 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
     } else {
       const instructions = getPatchInstructions(this.dataType, data, this.#hostBuffer);
       for (const { data, gpuOffset } of instructions) {
-        this.#device.queue.writeBuffer(gpuBuffer, gpuOffset, data);
+        this[$soul].device.queue.writeBuffer(gpuBuffer, gpuOffset, data);
       }
     }
   }
@@ -389,9 +438,9 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
       return;
     }
 
-    const rawEncoder = this.#device.createCommandEncoder();
+    const rawEncoder = this[$soul].device.createCommandEncoder();
     rawEncoder.clearBuffer(gpuBuffer);
-    this.#device.queue.submit([rawEncoder.finish()]);
+    this[$soul].device.queue.submit([rawEncoder.finish()]);
   }
 
   copyFrom(srcBuffer: TgpuBuffer<MemIdentity<TData>>, encoder?: TgpuCommandEncoder): void {
@@ -406,9 +455,9 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
       return;
     }
 
-    const rawEncoder = this.#device.createCommandEncoder();
+    const rawEncoder = this[$soul].device.createCommandEncoder();
     rawEncoder.copyBufferToBuffer(srcBuffer.buffer, 0, this.buffer, 0, size);
-    this.#device.queue.submit([rawEncoder.finish()]);
+    this[$soul].device.queue.submit([rawEncoder.finish()]);
   }
 
   async read(): Promise<Infer<TData>> {
@@ -425,15 +474,15 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
       return res;
     }
 
-    const stagingBuffer = this.#device.createBuffer({
+    const stagingBuffer = this[$soul].device.createBuffer({
       size: sizeOf(this.dataType),
       usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
     });
 
-    const commandEncoder = this.#device.createCommandEncoder();
+    const commandEncoder = this[$soul].device.createCommandEncoder();
     commandEncoder.copyBufferToBuffer(gpuBuffer, 0, stagingBuffer, 0, sizeOf(this.dataType));
 
-    this.#device.queue.submit([commandEncoder.finish()]);
+    this[$soul].device.queue.submit([commandEncoder.finish()]);
     await stagingBuffer.mapAsync(GPUMapMode.READ, 0, sizeOf(this.dataType));
 
     const res = readFromArrayBuffer(stagingBuffer.getMappedRange(), this.dataType);
@@ -455,7 +504,7 @@ class TgpuBufferImpl<TData extends BaseData> implements TgpuBuffer<TData> {
     this.#destroyed = true;
     this.#mappedRange = undefined;
     if (this.#ownBuffer) {
-      this.#buffer?.destroy();
+      this[$soul].raw?.destroy();
     }
   }
 

--- a/packages/typegpu/src/core/buffer/bufferBinding.ts
+++ b/packages/typegpu/src/core/buffer/bufferBinding.ts
@@ -6,7 +6,8 @@ import { isInsideTgpuFn } from '../../execMode.ts';
 import { type StorageFlag } from '../../extension.ts';
 import { getName, setName, type TgpuNamable } from '../../shared/meta.ts';
 import type { Infer, InferGPU, InferInput, InferPatch, InferPartial } from '../../shared/repr.ts';
-import { $getNameForward, $gpuValueOf, $internal, $repr } from '../../shared/symbols.ts';
+import type { TgpuSoul } from '../../shared/soul.ts';
+import { $getNameForward, $gpuValueOf, $internal, $repr, $soul } from '../../shared/symbols.ts';
 import { isUsableAsStorage, isUsableAsUniform } from '../../types.ts';
 import { makeDereferenceable } from '../../tgsl/makeDereferenceable.ts';
 import { makeResolvable } from '../../tgsl/makeResolvable.ts';
@@ -16,8 +17,15 @@ import { type BufferWriteOptions, type TgpuBuffer, type UniformFlag } from './bu
 // Public API
 // ----------
 
+export interface TgpuBufferBindingSoul<
+  TBuffer extends TgpuBuffer<BaseData> = TgpuBuffer<BaseData>,
+> extends TgpuSoul<'uniform' | 'mutable' | 'readonly'> {
+  readonly buffer: TBuffer;
+}
+
 interface TgpuBufferBindingBase<TData extends BaseData> extends TgpuNamable {
   readonly [$internal]: true;
+  readonly [$soul]: TgpuBufferBindingSoul<TgpuBuffer<TData>>;
 
   // Accessible on the CPU
   write(data: InferInput<TData>, options?: BufferWriteOptions): void;
@@ -105,6 +113,9 @@ export const isBufferShorthand = isBufferBinding;
 // Implementation
 // --------------
 
+type BoundBuffer<TType, TData extends BaseData> = TgpuBuffer<TData> &
+  (TType extends 'mutable' | 'readonly' ? StorageFlag : UniformFlag);
+
 export class TgpuBufferBindingImpl<
   TType extends 'mutable' | 'readonly' | 'uniform',
   TData extends BaseData,
@@ -112,10 +123,9 @@ export class TgpuBufferBindingImpl<
   /** Type-token, not available at runtime */
   declare readonly [$repr]: Infer<TData>;
 
+  readonly [$soul]: TgpuBufferBindingSoul<BoundBuffer<TType, TData>>;
   readonly [$getNameForward]: object;
   readonly resourceType: TType;
-  readonly buffer: TgpuBuffer<TData> &
-    (TType extends 'mutable' | 'readonly' ? StorageFlag : UniformFlag);
 
   // prototype properties
   declare [$internal]: true;
@@ -200,13 +210,18 @@ export class TgpuBufferBindingImpl<
     );
   }
 
-  constructor(
-    usage: TType,
-    buffer: TgpuBuffer<TData> & (TType extends 'mutable' | 'readonly' ? StorageFlag : UniformFlag),
-  ) {
+  constructor(usage: TType, buffer: BoundBuffer<TType, TData>) {
     this.resourceType = usage;
-    this.buffer = buffer;
     this[$getNameForward] = buffer;
+    this[$soul] = {
+      type: usage,
+      buffer,
+      label: undefined,
+    };
+  }
+
+  get buffer(): BoundBuffer<TType, TData> {
+    return this[$soul].buffer;
   }
 
   $name(label: string): this {

--- a/packages/typegpu/src/core/constant/tgpuConstant.ts
+++ b/packages/typegpu/src/core/constant/tgpuConstant.ts
@@ -6,13 +6,14 @@ import { makeResolvable } from '../../tgsl/makeResolvable.ts';
 import type { TgpuNamable } from '../../shared/meta.ts';
 import { getName, setName } from '../../shared/meta.ts';
 import type { InferGPU } from '../../shared/repr.ts';
-import { $gpuValueOf, $internal } from '../../shared/symbols.ts';
+import type { TgpuSoul } from '../../shared/soul.ts';
+import { $gpuValueOf, $internal, $soul } from '../../shared/symbols.ts';
 
 // ----------
 // Public API
 // ----------
 
-type DeepReadonly<T> = T extends { [$internal]: unknown }
+export type DeepReadonly<T> = T extends { [$internal]: unknown }
   ? T
   : T extends unknown[]
     ? ReadonlyArray<DeepReadonly<T[number]>>
@@ -20,11 +21,17 @@ type DeepReadonly<T> = T extends { [$internal]: unknown }
       ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
       : T;
 
+export interface TgpuConstSoul<TDataType extends BaseData = BaseData> extends TgpuSoul<'const'> {
+  readonly dataType: TDataType;
+  readonly value: DeepReadonly<InferGPU<TDataType>>;
+}
+
 export interface TgpuConst<TDataType extends BaseData = BaseData> extends TgpuNamable {
   readonly resourceType: 'const';
   readonly [$gpuValueOf]: DeepReadonly<InferGPU<TDataType>>;
   readonly $: DeepReadonly<InferGPU<TDataType>>;
 
+  readonly [$soul]: TgpuConstSoul<TDataType>;
   readonly [$internal]: {
     /** Makes it differentiable on the type level. Does not exist at runtime. */
     dataType?: TDataType;
@@ -82,8 +89,7 @@ function deepFreeze<T extends object>(object: T): T {
 }
 
 class TgpuConstImpl<TDataType extends BaseData> implements TgpuConst<TDataType> {
-  readonly dataType: TDataType;
-  readonly #value: DeepReadonly<InferGPU<TDataType>>;
+  readonly [$soul]: TgpuConstSoul<TDataType>;
 
   // prototype properties
   declare [$internal]: {};
@@ -106,7 +112,7 @@ class TgpuConstImpl<TDataType extends BaseData> implements TgpuConst<TDataType> 
           return ctx.gen.declareGlobalConst({
             id,
             dataType: this.dataType,
-            init: snip(this.#value, this.dataType, 'constant'),
+            init: snip(this[$soul].value, this.dataType, 'constant'),
           });
         },
       }),
@@ -123,7 +129,7 @@ class TgpuConstImpl<TDataType extends BaseData> implements TgpuConst<TDataType> 
         },
         normalMode: {
           get() {
-            return this.#value;
+            return this[$soul].value;
           },
         },
       },
@@ -131,11 +137,19 @@ class TgpuConstImpl<TDataType extends BaseData> implements TgpuConst<TDataType> 
   }
 
   constructor(dataType: TDataType, value: InferGPU<TDataType>) {
-    this.dataType = dataType;
-    this.#value =
-      value && typeof value === 'object'
-        ? (deepFreeze(value) as DeepReadonly<InferGPU<TDataType>>)
-        : (value as DeepReadonly<InferGPU<TDataType>>);
+    this[$soul] = {
+      type: 'const',
+      dataType,
+      value:
+        value && typeof value === 'object'
+          ? (deepFreeze(value) as DeepReadonly<InferGPU<TDataType>>)
+          : (value as DeepReadonly<InferGPU<TDataType>>),
+      label: undefined,
+    };
+  }
+
+  get dataType(): TDataType {
+    return this[$soul].dataType;
   }
 
   $name(label: string) {

--- a/packages/typegpu/src/core/pipeline/computePipeline.ts
+++ b/packages/typegpu/src/core/pipeline/computePipeline.ts
@@ -7,7 +7,8 @@ import { resolve } from '../../resolutionCtx.ts';
 import type { TgpuNamable } from '../../shared/meta.ts';
 import { getName, PERF, setName } from '../../shared/meta.ts';
 
-import { $getNameForward, $internal, $resolve } from '../../shared/symbols.ts';
+import type { TgpuDeviceOwningSoul } from '../../shared/soul.ts';
+import { $getNameForward, $internal, $resolve, $soul } from '../../shared/symbols.ts';
 import {
   isBindGroup,
   isBindGroupLayout,
@@ -46,6 +47,7 @@ import {
   type Timeable,
   type TimestampWritesPriors,
 } from './timeable.ts';
+import { nonTransferablePriorsOf } from './priors.ts';
 import type { IndirectFlag, TgpuBuffer } from '../buffer/buffer.ts';
 import {
   NullPerformanceTracker,
@@ -58,6 +60,18 @@ export interface ComputePipelineInternals {
   readonly core: ComputePipelineCore;
   readonly priors: TgpuComputePipelinePriors & TimestampWritesPriors;
   readonly root: ExperimentalTgpuRoot;
+  readonly materialize: () => GPUComputePipeline;
+}
+
+export interface TgpuComputePipelineSoul extends TgpuDeviceOwningSoul<
+  'compute-pipeline',
+  GPUComputePipeline
+> {
+  usedBindGroupLayouts?: TgpuBindGroupLayout[] | undefined;
+  bindGroups?: [TgpuBindGroupLayout, TgpuBindGroup | GPUBindGroup][] | undefined;
+  timestampWrites?: TimestampWritesPriors['timestampWrites'];
+  performanceCallback?: TimestampWritesPriors['performanceCallback'];
+  nonTransferablePriors?: string[] | undefined;
 }
 
 // ----------
@@ -66,6 +80,7 @@ export interface ComputePipelineInternals {
 
 export interface TgpuComputePipeline extends TgpuNamable, SelfResolvable, Timeable {
   readonly [$internal]: ComputePipelineInternals;
+  readonly [$soul]: TgpuComputePipelineSoul;
   readonly resourceType: 'compute-pipeline';
 
   /**
@@ -155,11 +170,35 @@ type Memo = {
 
 class TgpuComputePipelineImpl implements TgpuComputePipeline {
   public readonly [$internal]: ComputePipelineInternals;
+  public readonly [$soul]: TgpuComputePipelineSoul;
   public readonly resourceType = 'compute-pipeline';
   readonly [$getNameForward]: ComputePipelineCore;
 
   constructor(core: ComputePipelineCore, priors: TgpuComputePipelinePriors) {
-    this[$internal] = { core, priors, root: core.root };
+    this[$soul] = {
+      type: 'compute-pipeline',
+      device: core.root.device,
+      raw: undefined,
+      label: undefined,
+    };
+    this[$internal] = {
+      core,
+      priors,
+      root: core.root,
+      materialize: () => {
+        const soul = this[$soul];
+        if (!soul.raw) {
+          const memo = core.unwrap();
+          soul.raw = memo.pipeline;
+          soul.usedBindGroupLayouts = memo.usedBindGroupLayouts;
+          soul.bindGroups = priors.bindGroupLayoutMap ? [...priors.bindGroupLayoutMap] : [];
+          soul.timestampWrites = priors.timestampWrites;
+          soul.performanceCallback = priors.performanceCallback;
+          soul.nonTransferablePriors = nonTransferablePriorsOf(priors);
+        }
+        return soul.raw;
+      },
+    };
     this[$getNameForward] = core;
   }
 

--- a/packages/typegpu/src/core/pipeline/computePipeline.ts
+++ b/packages/typegpu/src/core/pipeline/computePipeline.ts
@@ -142,11 +142,11 @@ export declare namespace TgpuComputePipeline {
 }
 
 export function INTERNAL_createComputePipeline(
-  branch: ExperimentalTgpuRoot,
+  root: ExperimentalTgpuRoot,
   slotBindings: [TgpuSlot<unknown>, unknown][],
   descriptor: TgpuComputePipeline.Descriptor,
 ) {
-  return new TgpuComputePipelineImpl(new ComputePipelineCore(branch, slotBindings, descriptor), {});
+  return new TgpuComputePipelineImpl(new ComputePipelineCore(root, slotBindings, descriptor), {});
 }
 
 // --------------

--- a/packages/typegpu/src/core/pipeline/priors.ts
+++ b/packages/typegpu/src/core/pipeline/priors.ts
@@ -1,0 +1,15 @@
+const TRANSFERABLE_PRIORS = new Set([
+  'bindGroupLayoutMap',
+  'vertexLayoutMap',
+  'indexBuffer',
+  'stencilReference',
+  'timestampWrites',
+  'performanceCallback',
+]);
+
+export function nonTransferablePriorsOf(priors: object): string[] {
+  return Object.keys(priors).filter(
+    (key) =>
+      !TRANSFERABLE_PRIORS.has(key) && (priors as Record<string, unknown>)[key] !== undefined,
+  );
+}

--- a/packages/typegpu/src/core/pipeline/priors.ts
+++ b/packages/typegpu/src/core/pipeline/priors.ts
@@ -1,3 +1,4 @@
+// GPU objects like query sets cross runtimes as shareable host objects, performanceCallback crosses only if it is a worklet
 const TRANSFERABLE_PRIORS = new Set([
   'bindGroupLayoutMap',
   'vertexLayoutMap',

--- a/packages/typegpu/src/core/pipeline/renderPipeline.ts
+++ b/packages/typegpu/src/core/pipeline/renderPipeline.ts
@@ -20,7 +20,8 @@ import {
 import { resolve } from '../../resolutionCtx.ts';
 import type { TgpuNamable } from '../../shared/meta.ts';
 import { getName, PERF, setName } from '../../shared/meta.ts';
-import { $getNameForward, $internal, $resolve } from '../../shared/symbols.ts';
+import type { TgpuDeviceOwningSoul } from '../../shared/soul.ts';
+import { $getNameForward, $internal, $resolve, $soul } from '../../shared/symbols.ts';
 import type { AnyVertexAttribs, TgpuVertexAttrib } from '../../shared/vertexFormat.ts';
 import {
   isBindGroup,
@@ -76,6 +77,7 @@ import {
   type Timeable,
   type TimestampWritesPriors,
 } from './timeable.ts';
+import { nonTransferablePriorsOf } from './priors.ts';
 import { type PrimitiveOffsetInfo } from '../../data/offsetUtils.ts';
 import { warnIfOverflow } from './limitsOverflow.ts';
 import {
@@ -94,6 +96,30 @@ export interface RenderPipelineInternals {
   readonly core: RenderPipelineCore;
   readonly priors: TgpuRenderPipelinePriors & TimestampWritesPriors;
   readonly root: ExperimentalTgpuRoot;
+  readonly materialize: () => GPURenderPipeline;
+}
+
+export interface TgpuRenderPipelineSoul extends TgpuDeviceOwningSoul<
+  'render-pipeline',
+  GPURenderPipeline
+> {
+  usedBindGroupLayouts?: TgpuBindGroupLayout[] | undefined;
+  usedVertexLayouts?: TgpuVertexLayout[] | undefined;
+  fragmentOut?: BaseData | undefined;
+  bindGroups?: [TgpuBindGroupLayout, TgpuBindGroup | GPUBindGroup][] | undefined;
+  vertexBuffers?: [TgpuVertexLayout, (TgpuBuffer<BaseData> & VertexFlag) | GPUBuffer][] | undefined;
+  indexBuffer?:
+    | {
+        buffer: (TgpuBuffer<BaseData> & IndexFlag) | GPUBuffer;
+        indexFormat: GPUIndexFormat;
+        offsetBytes?: number | undefined;
+        sizeBytes?: number | undefined;
+      }
+    | undefined;
+  stencilReference?: GPUStencilValue | undefined;
+  timestampWrites?: TimestampWritesPriors['timestampWrites'];
+  performanceCallback?: TimestampWritesPriors['performanceCallback'];
+  nonTransferablePriors?: string[] | undefined;
 }
 
 // ----------
@@ -135,6 +161,7 @@ export interface HasIndexBuffer {
 export interface TgpuRenderPipeline<in Targets = never>
   extends TgpuNamable, SelfResolvable, Timeable {
   readonly [$internal]: RenderPipelineInternals;
+  readonly [$soul]: TgpuRenderPipelineSoul;
   readonly resourceType: 'render-pipeline';
   readonly hasIndexBuffer: boolean;
 
@@ -361,15 +388,42 @@ type Memo = {
 
 class TgpuRenderPipelineImpl implements TgpuRenderPipeline {
   public readonly [$internal]: RenderPipelineInternals;
+  public readonly [$soul]: TgpuRenderPipelineSoul;
   public readonly resourceType = 'render-pipeline';
   [$getNameForward]: RenderPipelineCore;
   public readonly hasIndexBuffer: boolean = false;
 
   constructor(core: RenderPipelineCore, priors: TgpuRenderPipelinePriors) {
+    this[$soul] = {
+      type: 'render-pipeline',
+      device: core.options.root.device,
+      raw: undefined,
+      label: undefined,
+    };
     this[$internal] = {
       core,
       priors,
       root: core.options.root,
+      materialize: () => {
+        const soul = this[$soul];
+        if (!soul.raw) {
+          const memo = core.unwrap();
+          soul.raw = memo.pipeline;
+          soul.usedBindGroupLayouts = memo.usedBindGroupLayouts;
+          soul.usedVertexLayouts = memo.usedVertexLayouts;
+          soul.fragmentOut =
+            (core.options.descriptor.fragment as TgpuFragmentFn | undefined)?.shell?.returnType ??
+            memo.fragmentOut;
+          soul.bindGroups = priors.bindGroupLayoutMap ? [...priors.bindGroupLayoutMap] : [];
+          soul.vertexBuffers = priors.vertexLayoutMap ? [...priors.vertexLayoutMap] : [];
+          soul.indexBuffer = priors.indexBuffer;
+          soul.stencilReference = priors.stencilReference;
+          soul.timestampWrites = priors.timestampWrites;
+          soul.performanceCallback = priors.performanceCallback;
+          soul.nonTransferablePriors = nonTransferablePriorsOf(priors);
+        }
+        return soul.raw;
+      },
     };
     this[$getNameForward] = core;
   }

--- a/packages/typegpu/src/core/querySet/querySet.ts
+++ b/packages/typegpu/src/core/querySet/querySet.ts
@@ -1,6 +1,14 @@
 import { setName, type TgpuNamable } from '../../shared/meta.ts';
 import type { ExperimentalTgpuRoot } from '../root/rootTypes.ts';
-import { $internal } from '../../shared/symbols.ts';
+import type { TgpuDeviceOwningSoul } from '../../shared/soul.ts';
+import { $internal, $soul } from '../../shared/symbols.ts';
+
+export interface TgpuQuerySetSoul<
+  T extends GPUQueryType = GPUQueryType,
+> extends TgpuDeviceOwningSoul<'query-set', GPUQuerySet> {
+  readonly queryType: T;
+  readonly count: number;
+}
 
 export interface TgpuQuerySet<T extends GPUQueryType> extends TgpuNamable {
   readonly resourceType: 'query-set';
@@ -11,9 +19,11 @@ export interface TgpuQuerySet<T extends GPUQueryType> extends TgpuNamable {
   readonly destroyed: boolean;
   readonly available: boolean;
 
+  readonly [$soul]: TgpuQuerySetSoul<T>;
   readonly [$internal]: {
     readonly readBuffer: GPUBuffer;
     readonly resolveBuffer: GPUBuffer;
+    readonly materialize: () => GPUQuerySet;
   };
 
   resolve(): void;
@@ -37,43 +47,80 @@ export function isQuerySet<T extends GPUQueryType>(value: unknown): value is Tgp
 
 class TgpuQuerySetImpl<T extends GPUQueryType> implements TgpuQuerySet<T> {
   readonly resourceType = 'query-set' as const;
-  readonly type: T;
-  readonly count: number;
 
-  readonly #rawQuerySet: GPUQuerySet | undefined;
-  readonly #device: GPUDevice;
-  #querySet: GPUQuerySet | undefined;
   readonly #ownQuerySet: boolean;
   #destroyed = false;
   #available = true;
   #readBuffer: GPUBuffer | undefined = undefined;
   #resolveBuffer: GPUBuffer | undefined = undefined;
 
+  readonly [$soul]: TgpuQuerySetSoul<T>;
+  readonly [$internal]: {
+    readonly readBuffer: GPUBuffer;
+    readonly resolveBuffer: GPUBuffer;
+    readonly materialize: () => GPUQuerySet;
+  };
+
   constructor(root: ExperimentalTgpuRoot, type: T, count: number, rawQuerySet?: GPUQuerySet) {
-    this.#device = root.device;
-    this.type = type;
-    this.count = count;
-    this.#rawQuerySet = rawQuerySet;
     this.#ownQuerySet = !rawQuerySet;
-    this.#querySet = rawQuerySet;
+
+    this[$soul] = {
+      type: 'query-set',
+      device: root.device,
+      queryType: type,
+      count,
+      raw: rawQuerySet,
+      label: undefined,
+    };
+
+    // oxlint-disable-next-line typescript/no-this-alias
+    const self = this;
+    this[$internal] = {
+      get readBuffer(): GPUBuffer {
+        if (!self.#readBuffer) {
+          self.#readBuffer = self[$soul].device.createBuffer({
+            size: self.count * BigUint64Array.BYTES_PER_ELEMENT,
+            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+          });
+        }
+        return self.#readBuffer;
+      },
+      get resolveBuffer(): GPUBuffer {
+        if (!self.#resolveBuffer) {
+          self.#resolveBuffer = self[$soul].device.createBuffer({
+            size: self.count * BigUint64Array.BYTES_PER_ELEMENT,
+            usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.COPY_SRC,
+          });
+        }
+        return self.#resolveBuffer;
+      },
+      materialize: () => {
+        if (this.#destroyed) {
+          throw new Error('This QuerySet has been destroyed.');
+        }
+
+        const soul = this[$soul];
+        if (!soul.raw) {
+          soul.raw = soul.device.createQuerySet({
+            type: soul.queryType,
+            count: soul.count,
+          });
+        }
+        return soul.raw;
+      },
+    };
+  }
+
+  get type(): T {
+    return this[$soul].queryType;
+  }
+
+  get count(): number {
+    return this[$soul].count;
   }
 
   get querySet(): GPUQuerySet {
-    if (this.#destroyed) {
-      throw new Error('This QuerySet has been destroyed.');
-    }
-    if (this.#rawQuerySet) {
-      return this.#rawQuerySet;
-    }
-    if (this.#querySet) {
-      return this.#querySet;
-    }
-
-    this.#querySet = this.#device.createQuerySet({
-      type: this.type,
-      count: this.count,
-    });
-    return this.#querySet;
+    return this[$internal].materialize();
   }
 
   get destroyed(): boolean {
@@ -84,35 +131,11 @@ class TgpuQuerySetImpl<T extends GPUQueryType> implements TgpuQuerySet<T> {
     return this.#available;
   }
 
-  get [$internal]() {
-    // oxlint-disable-next-line typescript/no-this-alias
-    const self = this;
-    return {
-      get readBuffer(): GPUBuffer {
-        if (!self.#readBuffer) {
-          self.#readBuffer = self.#device.createBuffer({
-            size: self.count * BigUint64Array.BYTES_PER_ELEMENT,
-            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
-          });
-        }
-        return self.#readBuffer;
-      },
-      get resolveBuffer(): GPUBuffer {
-        if (!self.#resolveBuffer) {
-          self.#resolveBuffer = self.#device.createBuffer({
-            size: self.count * BigUint64Array.BYTES_PER_ELEMENT,
-            usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.COPY_SRC,
-          });
-        }
-        return self.#resolveBuffer;
-      },
-    };
-  }
-
   $name(label: string) {
     setName(this, label);
-    if (this.#querySet) {
-      this.#querySet.label = label;
+    const raw = this[$soul].raw;
+    if (raw) {
+      raw.label = label;
     }
     return this;
   }
@@ -125,9 +148,9 @@ class TgpuQuerySetImpl<T extends GPUQueryType> implements TgpuQuerySet<T> {
       throw new Error('This QuerySet is busy resolving or reading.');
     }
 
-    const commandEncoder = this.#device.createCommandEncoder();
+    const commandEncoder = this[$soul].device.createCommandEncoder();
     commandEncoder.resolveQuerySet(this.querySet, 0, this.count, this[$internal].resolveBuffer, 0);
-    this.#device.queue.submit([commandEncoder.finish()]);
+    this[$soul].device.queue.submit([commandEncoder.finish()]);
   }
 
   async read(): Promise<bigint[]> {
@@ -137,7 +160,7 @@ class TgpuQuerySetImpl<T extends GPUQueryType> implements TgpuQuerySet<T> {
 
     this.#available = false;
     try {
-      const commandEncoder = this.#device.createCommandEncoder();
+      const commandEncoder = this[$soul].device.createCommandEncoder();
       commandEncoder.copyBufferToBuffer(
         this[$internal].resolveBuffer,
         0,
@@ -145,7 +168,7 @@ class TgpuQuerySetImpl<T extends GPUQueryType> implements TgpuQuerySet<T> {
         0,
         this.count * BigUint64Array.BYTES_PER_ELEMENT,
       );
-      this.#device.queue.submit([commandEncoder.finish()]);
+      this[$soul].device.queue.submit([commandEncoder.finish()]);
 
       const readBuffer = this[$internal].readBuffer;
       await readBuffer.mapAsync(GPUMapMode.READ);
@@ -163,8 +186,8 @@ class TgpuQuerySetImpl<T extends GPUQueryType> implements TgpuQuerySet<T> {
     }
     this.#destroyed = true;
 
-    if (this.#querySet && this.#ownQuerySet) {
-      this.#querySet.destroy();
+    if (this[$soul].raw && this.#ownQuerySet) {
+      this[$soul].raw.destroy();
     }
     this.#readBuffer?.destroy();
     this.#resolveBuffer?.destroy();

--- a/packages/typegpu/src/core/root/init.ts
+++ b/packages/typegpu/src/core/root/init.ts
@@ -297,10 +297,6 @@ class WithBindingImpl implements WithBinding {
   }
 }
 
-/**
- * Holds all data that is necessary to facilitate CPU and GPU communication.
- * Programs that share a root can interact via GPU buffers.
- */
 type MaterializeInternals = {
   readonly materialize?: (() => unknown) | undefined;
 };
@@ -321,6 +317,10 @@ type UnwrapResult =
   | GPUSampler
   | GPUQuerySet;
 
+/**
+ * Holds all data that is necessary to facilitate CPU and GPU communication.
+ * Programs that share a root can interact via GPU buffers.
+ */
 class TgpuRootImpl extends WithBindingImpl implements TgpuRoot, ExperimentalTgpuRoot {
   '~unstable': TgpuRoot['~unstable'];
 

--- a/packages/typegpu/src/core/root/init.ts
+++ b/packages/typegpu/src/core/root/init.ts
@@ -1,11 +1,11 @@
 import { type AnyComputeBuiltin, builtin } from '../../builtin.ts';
-import { INTERNAL_createQuerySet, isQuerySet, type TgpuQuerySet } from '../querySet/querySet.ts';
+import { INTERNAL_createQuerySet, type TgpuQuerySet } from '../querySet/querySet.ts';
 import type { AnyData } from '../../data/dataTypes.ts';
 import type { AnyWgslData, BaseData, v3u, Vec3u } from '../../data/wgslTypes.ts';
 import { WeakMemo } from '../../memo.ts';
 import { clearTextureUtilsCache } from '../texture/textureUtils.ts';
 import type { BufferInitialData } from '../buffer/buffer.ts';
-import { $getNameForward, $internal } from '../../shared/symbols.ts';
+import { $getNameForward, $internal, $soul } from '../../shared/symbols.ts';
 import type {
   ExtractBindGroupInputFromLayout,
   TgpuBindGroup,
@@ -16,7 +16,6 @@ import { isBindGroup, isBindGroupLayout, TgpuBindGroupImpl } from '../../tgpuBin
 import type { LogGeneratorOptions } from '../../tgsl/consoleLog/types.ts';
 import type { ShaderGenerator } from '../../tgsl/shaderGenerator.ts';
 import { INTERNAL_createBuffer, type TgpuBuffer } from '../buffer/buffer.ts';
-import { isBuffer } from '../../types.ts';
 import {
   isBufferBinding,
   TgpuBufferBindingImpl,
@@ -36,8 +35,6 @@ import {
   type TgpuRenderPipeline,
 } from '../pipeline/renderPipeline.ts';
 import {
-  isComputePipeline,
-  isRenderPipeline,
   isTgpuCommandEncoder,
   isTgpuComputePass,
   isTgpuRenderCommands,
@@ -72,7 +69,6 @@ import {
 } from '../slot/slotTypes.ts';
 import {
   INTERNAL_createTexture,
-  isTexture,
   isTextureView,
   type TgpuTexture,
   type TgpuTextureView,
@@ -86,6 +82,8 @@ import type {
   CreateTextureResult,
   ExperimentalTgpuRoot,
   TgpuGuardedComputePipeline,
+  TgpuGuardedComputePipelineSoul,
+  TgpuRootSoul,
   TgpuRoot,
   WithBinding,
 } from './rootTypes.ts';
@@ -95,6 +93,7 @@ import { ceil } from '../../std/numeric.ts';
 import { allEq } from '../../std/boolean.ts';
 import { getName, setName } from '../../shared/meta.ts';
 import { logger } from '../../tgpuLogger.ts';
+import { safeStringify } from '../../shared/stringify.ts';
 
 /**
  * Changes the given array to a vec of 3 numbers, filling missing values with 1.
@@ -116,11 +115,10 @@ const workgroupSizeConfigs = [
 export class TgpuGuardedComputePipelineImpl<
   TArgs extends number[],
 > implements TgpuGuardedComputePipeline<TArgs> {
-  #root: ExperimentalTgpuRoot;
-  #pipeline: TgpuComputePipeline;
-  #sizeUniform: TgpuUniform<Vec3u>;
-  #workgroupSize: v3u;
+  readonly resourceType = 'guarded-compute-pipeline';
+  readonly [$soul]: TgpuGuardedComputePipelineSoul;
 
+  #root: ExperimentalTgpuRoot;
   #lastSize: v3u;
 
   constructor(
@@ -130,10 +128,15 @@ export class TgpuGuardedComputePipelineImpl<
     workgroupSize: v3u,
   ) {
     this.#root = root;
-    this.#pipeline = pipeline;
-    this.#sizeUniform = sizeUniform;
-    this.#workgroupSize = workgroupSize;
     this.#lastSize = vec3u();
+    this[$soul] = {
+      type: 'guarded-compute-pipeline',
+      device: root.device,
+      pipeline,
+      sizeUniform,
+      workgroupSize,
+      label: undefined,
+    };
   }
 
   with(bindGroup: TgpuBindGroup): TgpuGuardedComputePipeline<TArgs> {
@@ -145,9 +148,9 @@ export class TgpuGuardedComputePipelineImpl<
 
     return new TgpuGuardedComputePipelineImpl(
       this.#root,
-      this.#pipeline.with(bindGroup),
-      this.#sizeUniform,
-      this.#workgroupSize,
+      this[$soul].pipeline.with(bindGroup),
+      this[$soul].sizeUniform,
+      this[$soul].workgroupSize,
     );
   }
 
@@ -156,9 +159,9 @@ export class TgpuGuardedComputePipelineImpl<
   ): TgpuGuardedComputePipeline<TArgs> {
     return new TgpuGuardedComputePipelineImpl(
       this.#root,
-      this.#pipeline.withPerformanceCallback(callback),
-      this.#sizeUniform,
-      this.#workgroupSize,
+      this[$soul].pipeline.withPerformanceCallback(callback),
+      this[$soul].sizeUniform,
+      this[$soul].workgroupSize,
     );
   }
 
@@ -169,43 +172,43 @@ export class TgpuGuardedComputePipelineImpl<
   }): TgpuGuardedComputePipeline<TArgs> {
     return new TgpuGuardedComputePipelineImpl(
       this.#root,
-      this.#pipeline.withTimestampWrites(options),
-      this.#sizeUniform,
-      this.#workgroupSize,
+      this[$soul].pipeline.withTimestampWrites(options),
+      this[$soul].sizeUniform,
+      this[$soul].workgroupSize,
     );
   }
 
   dispatchThreads(...threads: TArgs): void {
     const sanitizedSize = toVec3(threads);
-    const workgroupCount = ceil(vec3f(sanitizedSize).div(vec3f(this.#workgroupSize)));
+    const workgroupCount = ceil(vec3f(sanitizedSize).div(vec3f(this[$soul].workgroupSize)));
     if (!allEq(sanitizedSize, this.#lastSize)) {
       // Only updating the size if it has changed from the last
       // invocation. This removes the need for flushing.
       this.#lastSize = sanitizedSize;
-      this.#sizeUniform.write(sanitizedSize);
+      this[$soul].sizeUniform.write(sanitizedSize);
     }
-    this.#pipeline.dispatchWorkgroups(workgroupCount.x, workgroupCount.y, workgroupCount.z);
+    this[$soul].pipeline.dispatchWorkgroups(workgroupCount.x, workgroupCount.y, workgroupCount.z);
   }
 
   initAsync(): Promise<void> {
-    return this.#pipeline.initAsync();
+    return this[$soul].pipeline.initAsync();
   }
 
   initSync(): void {
-    this.#pipeline.initSync();
+    this[$soul].pipeline.initSync();
   }
 
   get pipeline() {
-    return this.#pipeline;
+    return this[$soul].pipeline;
   }
 
   get sizeUniform() {
-    return this.#sizeUniform;
+    return this[$soul].sizeUniform;
   }
 
   [$internal] = true;
   get [$getNameForward]() {
-    return this.#pipeline;
+    return this[$soul].pipeline;
   }
   $name(label: string): this {
     setName(this, label);
@@ -298,9 +301,31 @@ class WithBindingImpl implements WithBinding {
  * Holds all data that is necessary to facilitate CPU and GPU communication.
  * Programs that share a root can interact via GPU buffers.
  */
+type MaterializeInternals = {
+  readonly materialize?: (() => unknown) | undefined;
+};
+
+type UnwrapResult =
+  | GPUComputePipeline
+  | GPURenderPipeline
+  | GPUCommandEncoder
+  | GPURenderPassEncoder
+  | GPUComputePassEncoder
+  | GPURenderBundleEncoder
+  | GPUBindGroupLayout
+  | GPUBindGroup
+  | GPUBuffer
+  | GPUTexture
+  | GPUTextureView
+  | GPUVertexBufferLayout
+  | GPUSampler
+  | GPUQuerySet;
+
 class TgpuRootImpl extends WithBindingImpl implements TgpuRoot, ExperimentalTgpuRoot {
   '~unstable': TgpuRoot['~unstable'];
 
+  readonly resourceType = 'root';
+  readonly [$soul]: TgpuRootSoul;
   readonly device: GPUDevice;
   readonly nameRegistrySetting: 'random' | 'strict';
   readonly shaderGenerator: ShaderGenerator | undefined;
@@ -328,6 +353,11 @@ class TgpuRootImpl extends WithBindingImpl implements TgpuRoot, ExperimentalTgpu
     this.shaderGenerator = shaderGenerator;
 
     this['~unstable'] = this;
+    this[$soul] = {
+      type: 'root',
+      device,
+      label: undefined,
+    };
     this[$internal] = {
       logOptions,
     };
@@ -484,25 +514,7 @@ class TgpuRootImpl extends WithBindingImpl implements TgpuRoot, ExperimentalTgpu
       | TgpuSampler
       | TgpuComparisonSampler
       | TgpuQuerySet<GPUQueryType>,
-  ):
-    | GPUComputePipeline
-    | GPURenderPipeline
-    | GPUCommandEncoder
-    | GPURenderPassEncoder
-    | GPUComputePassEncoder
-    | GPURenderBundleEncoder
-    | GPUBindGroupLayout
-    | GPUBindGroup
-    | GPUBuffer
-    | GPUTexture
-    | GPUTextureView
-    | GPUVertexBufferLayout
-    | GPUSampler
-    | GPUQuerySet {
-    if (isComputePipeline(resource)) {
-      return resource[$internal].core.unwrap().pipeline;
-    }
-
+  ): UnwrapResult {
     if (isTgpuCommandEncoder(resource)) {
       return resource[$internal].rawEncoder;
     }
@@ -510,10 +522,6 @@ class TgpuRootImpl extends WithBindingImpl implements TgpuRoot, ExperimentalTgpu
     if (isTgpuRenderCommands(resource) || isTgpuComputePass(resource)) {
       resource[$internal].state.rawAccessed = true;
       return resource[$internal].rawPass;
-    }
-
-    if (isRenderPipeline(resource)) {
-      return resource[$internal].core.unwrap().pipeline;
     }
 
     if (isBindGroupLayout(resource)) {
@@ -524,16 +532,8 @@ class TgpuRootImpl extends WithBindingImpl implements TgpuRoot, ExperimentalTgpu
       return this.#unwrappedBindGroups.getOrMake(resource);
     }
 
-    if (isBuffer(resource)) {
-      return resource.buffer;
-    }
-
     if (isBufferBinding(resource)) {
       return resource.buffer.buffer;
-    }
-
-    if (isTexture(resource)) {
-      return resource[$internal].unwrap();
     }
 
     if (isTextureView(resource)) {
@@ -547,18 +547,16 @@ class TgpuRootImpl extends WithBindingImpl implements TgpuRoot, ExperimentalTgpu
       return resource.vertexLayout;
     }
 
+    const internals = (resource as { [$internal]?: MaterializeInternals })[$internal];
+    if (internals?.materialize) {
+      return internals.materialize() as UnwrapResult;
+    }
+
     if (isSampler(resource) || isComparisonSampler(resource)) {
-      if (resource[$internal].unwrap) {
-        return resource[$internal].unwrap();
-      }
       throw new Error('Cannot unwrap laid-out sampler.');
     }
 
-    if (isQuerySet(resource)) {
-      return resource.querySet;
-    }
-
-    throw new Error(`Unknown resource type: ${resource}`);
+    throw new Error(`Unknown resource type: ${safeStringify(resource)}`);
   }
 
   createCommandEncoder(descriptor?: GPUCommandEncoderDescriptor): TgpuCommandEncoder {

--- a/packages/typegpu/src/core/root/init.ts
+++ b/packages/typegpu/src/core/root/init.ts
@@ -356,6 +356,9 @@ class TgpuRootImpl extends WithBindingImpl implements TgpuRoot, ExperimentalTgpu
     this[$soul] = {
       type: 'root',
       device,
+      nameRegistrySetting,
+      logOptions,
+      nonTransferablePriors: shaderGenerator ? ['shaderGenerator'] : undefined,
       label: undefined,
     };
     this[$internal] = {

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -55,6 +55,9 @@ import type {
 
 export interface TgpuRootSoul extends TgpuSoul<'root'> {
   readonly device: GPUDevice;
+  readonly nameRegistrySetting: 'random' | 'strict';
+  readonly logOptions: LogGeneratorOptions;
+  readonly nonTransferablePriors?: string[] | undefined;
 }
 
 export interface TgpuGuardedComputePipelineSoul extends TgpuSoul<'guarded-compute-pipeline'> {

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -3,8 +3,9 @@ import type { TgpuQuerySet } from '../querySet/querySet.ts';
 import type { AnyData } from '../../data/dataTypes.ts';
 import type { InstanceToSchema } from '../../data/instanceToSchema.ts';
 import type { WgslComparisonSamplerProps, WgslSamplerProps } from '../../data/sampler.ts';
-import type { AnyWgslData, BaseData, v4f, Vec3u, Void } from '../../data/wgslTypes.ts';
+import type { AnyWgslData, BaseData, v3u, v4f, Vec3u, Void } from '../../data/wgslTypes.ts';
 import type { TgpuNamable } from '../../shared/meta.ts';
+import type { TgpuSoul } from '../../shared/soul.ts';
 import type {
   ExtractInvalidSchemaError,
   InferGPURecord,
@@ -13,7 +14,7 @@ import type {
   IsValidStorageSchema,
   IsValidUniformSchema,
 } from '../../shared/repr.ts';
-import { $internal } from '../../shared/symbols.ts';
+import { $internal, $soul } from '../../shared/symbols.ts';
 import type { Assume, Mutable, OmitProps, Prettify } from '../../shared/utilityTypes.ts';
 import type {
   ExtractBindGroupInputFromLayout,
@@ -52,7 +53,20 @@ import type {
 // Public API
 // ----------
 
+export interface TgpuRootSoul extends TgpuSoul<'root'> {
+  readonly device: GPUDevice;
+}
+
+export interface TgpuGuardedComputePipelineSoul extends TgpuSoul<'guarded-compute-pipeline'> {
+  readonly device: GPUDevice;
+  readonly pipeline: TgpuComputePipeline;
+  readonly sizeUniform: TgpuUniform<Vec3u>;
+  readonly workgroupSize: v3u;
+}
+
 export interface TgpuGuardedComputePipeline<TArgs extends number[] = number[]> extends TgpuNamable {
+  readonly resourceType: 'guarded-compute-pipeline';
+  readonly [$soul]: TgpuGuardedComputePipelineSoul;
   /**
    * Returns a pipeline wrapper with the specified bind group bound.
    * Analogous to `TgpuComputePipeline.with(bindGroup)`.
@@ -480,6 +494,8 @@ export type ConfigureContextOptions = {
 } & Omit<GPUCanvasConfiguration, 'device' | 'format'>;
 
 export interface TgpuRoot extends Unwrapper, WithBinding {
+  readonly resourceType: 'root';
+  readonly [$soul]: TgpuRootSoul;
   [$internal]: {
     logOptions: LogGeneratorOptions;
   };

--- a/packages/typegpu/src/core/sampler/sampler.ts
+++ b/packages/typegpu/src/core/sampler/sampler.ts
@@ -62,21 +62,18 @@ export interface TgpuFixedComparisonSampler extends TgpuComparisonSampler, TgpuN
   readonly [$soul]: TgpuSamplerSoul;
 }
 
-export function INTERNAL_createSampler(
-  props: WgslSamplerProps,
-  branch: Unwrapper,
-): TgpuFixedSampler {
-  return new TgpuFixedSamplerImpl(wgslSampler(), props, branch) as TgpuFixedSampler;
+export function INTERNAL_createSampler(props: WgslSamplerProps, root: Unwrapper): TgpuFixedSampler {
+  return new TgpuFixedSamplerImpl(wgslSampler(), props, root) as TgpuFixedSampler;
 }
 
 export function INTERNAL_createComparisonSampler(
   props: WgslComparisonSamplerProps,
-  branch: Unwrapper,
+  root: Unwrapper,
 ): TgpuFixedComparisonSampler {
   return new TgpuFixedSamplerImpl(
     wgslComparisonSampler(),
     props,
-    branch,
+    root,
   ) as TgpuFixedComparisonSampler;
 }
 
@@ -209,14 +206,14 @@ class TgpuFixedSamplerImpl<T extends WgslSampler | WgslComparisonSampler> implem
     );
   }
 
-  constructor(schema: T, props: WgslSamplerProps | WgslComparisonSamplerProps, branch: Unwrapper) {
+  constructor(schema: T, props: WgslSamplerProps | WgslComparisonSamplerProps, root: Unwrapper) {
     this.schema = schema;
     this.resourceType = (
       schema.type === 'sampler_comparison' ? 'sampler-comparison' : 'sampler'
     ) as T extends WgslComparisonSampler ? 'sampler-comparison' : 'sampler';
     this[$soul] = {
       type: this.resourceType,
-      device: branch.device,
+      device: root.device,
       props,
       raw: undefined,
       label: undefined,

--- a/packages/typegpu/src/core/sampler/sampler.ts
+++ b/packages/typegpu/src/core/sampler/sampler.ts
@@ -3,7 +3,8 @@ import { snip } from '../../data/snippet.ts';
 import type { TgpuNamable } from '../../shared/meta.ts';
 import { getName, setName } from '../../shared/meta.ts';
 import type { Infer, InferGPU } from '../../shared/repr.ts';
-import { $gpuValueOf, $internal, $repr, $resolve } from '../../shared/symbols.ts';
+import type { TgpuDeviceOwningSoul } from '../../shared/soul.ts';
+import { $gpuValueOf, $internal, $repr, $resolve, $soul } from '../../shared/symbols.ts';
 import type { LayoutMembership } from '../../tgpuBindGroupLayout.ts';
 import type { Unwrapper } from '../../unwrapper.ts';
 import {
@@ -17,7 +18,14 @@ import { makeResolvable } from '../../tgsl/makeResolvable.ts';
 import type { SelfResolvable } from '../../types.ts';
 
 interface SamplerInternals {
-  readonly unwrap?: (() => GPUSampler) | undefined;
+  readonly materialize?: (() => GPUSampler) | undefined;
+}
+
+export interface TgpuSamplerSoul extends TgpuDeviceOwningSoul<
+  'sampler' | 'sampler-comparison',
+  GPUSampler
+> {
+  readonly props: WgslSamplerProps | WgslComparisonSamplerProps;
 }
 
 // ----------
@@ -46,9 +54,13 @@ export interface TgpuComparisonSampler {
   toString(): string;
 }
 
-export interface TgpuFixedSampler extends TgpuSampler, TgpuNamable {}
+export interface TgpuFixedSampler extends TgpuSampler, TgpuNamable {
+  readonly [$soul]: TgpuSamplerSoul;
+}
 
-export interface TgpuFixedComparisonSampler extends TgpuComparisonSampler, TgpuNamable {}
+export interface TgpuFixedComparisonSampler extends TgpuComparisonSampler, TgpuNamable {
+  readonly [$soul]: TgpuSamplerSoul;
+}
 
 export function INTERNAL_createSampler(
   props: WgslSamplerProps,
@@ -86,7 +98,7 @@ export class TgpuLaidOutSamplerImpl<
   T extends WgslSampler | WgslComparisonSampler,
 > implements SelfResolvable {
   declare readonly [$repr]: Infer<T>;
-  readonly [$internal]: SamplerInternals = { unwrap: undefined };
+  readonly [$internal]: SamplerInternals = { materialize: undefined };
   readonly resourceType: T extends WgslComparisonSampler ? 'sampler-comparison' : 'sampler';
   readonly schema: T;
   readonly #membership: LayoutMembership;
@@ -146,13 +158,11 @@ export class TgpuLaidOutSamplerImpl<
 class TgpuFixedSamplerImpl<T extends WgslSampler | WgslComparisonSampler> implements TgpuNamable {
   declare readonly [$repr]: Infer<T>;
   readonly [$internal]: SamplerInternals;
+  readonly [$soul]: TgpuSamplerSoul;
   readonly resourceType: T extends WgslComparisonSampler ? 'sampler-comparison' : 'sampler';
   readonly schema: T;
 
   #filtering: boolean;
-  #sampler: GPUSampler | null = null;
-  #props: WgslSamplerProps | WgslComparisonSamplerProps;
-  #branch: Unwrapper;
 
   // prototype props
   declare readonly [$gpuValueOf]: InferGPU<T>;
@@ -201,21 +211,27 @@ class TgpuFixedSamplerImpl<T extends WgslSampler | WgslComparisonSampler> implem
 
   constructor(schema: T, props: WgslSamplerProps | WgslComparisonSamplerProps, branch: Unwrapper) {
     this.schema = schema;
-    this.#props = props;
-    this.#branch = branch;
     this.resourceType = (
       schema.type === 'sampler_comparison' ? 'sampler-comparison' : 'sampler'
     ) as T extends WgslComparisonSampler ? 'sampler-comparison' : 'sampler';
+    this[$soul] = {
+      type: this.resourceType,
+      device: branch.device,
+      props,
+      raw: undefined,
+      label: undefined,
+    };
     this[$internal] = {
-      unwrap: () => {
-        if (!this.#sampler) {
-          this.#sampler = this.#branch.device.createSampler({
-            ...this.#props,
+      materialize: () => {
+        const soul = this[$soul];
+        if (!soul.raw) {
+          soul.raw = soul.device.createSampler({
+            ...soul.props,
             label: getName(this) ?? '<unnamed>',
           });
         }
 
-        return this.#sampler;
+        return soul.raw;
       },
     };
 

--- a/packages/typegpu/src/core/slot/accessor.ts
+++ b/packages/typegpu/src/core/slot/accessor.ts
@@ -13,13 +13,14 @@ import {
   $gpuValueOf,
   $internal,
   $resolve,
+  $soul,
 } from '../../shared/symbols.ts';
 import type { UnwrapRuntimeConstructor } from '../../tgpuBindGroupLayout.ts';
 import { getOwnSnippet, isGPUCallable, NormalState, type SelfResolvable } from '../../types.ts';
 import { isTgpuFn } from '../function/tgpuFn.ts';
 import { getGpuValueRecursively } from '../valueProxyUtils.ts';
 import { slot } from './slot.ts';
-import type { TgpuAccessor, TgpuMutableAccessor, TgpuSlot } from './slotTypes.ts';
+import type { TgpuAccessor, TgpuAccessorSoul, TgpuMutableAccessor, TgpuSlot } from './slotTypes.ts';
 
 // ----------
 // Public API
@@ -116,9 +117,8 @@ abstract class AccessorBase<
   TValue extends TgpuAccessor.In<T> | TgpuMutableAccessor.In<T>,
 > {
   readonly [$getNameForward]: unknown;
+  readonly [$soul]: TgpuAccessorSoul<T, TValue>;
   readonly slot: TgpuSlot<TValue>;
-  readonly schema: T;
-  readonly defaultValue: TValue | undefined;
 
   abstract readonly resourceType: string;
 
@@ -142,17 +142,30 @@ abstract class AccessorBase<
   }
 
   constructor(
+    type: 'accessor' | 'mutable-accessor',
     schemaOrConstructor: T | ((count: number) => T),
     defaultValue: TValue | undefined = undefined,
   ) {
-    this.schema = isData(schemaOrConstructor)
-      ? schemaOrConstructor
-      : (schemaOrConstructor as (count: number) => T)(0);
-    this.defaultValue = defaultValue;
+    this[$soul] = {
+      type,
+      schema: isData(schemaOrConstructor)
+        ? schemaOrConstructor
+        : (schemaOrConstructor as (count: number) => T)(0),
+      defaultValue,
+      label: undefined,
+    };
 
     // NOTE: in certain setups, unplugin can run on package typegpu, so we have to avoid auto-naming triggering here
     this.slot = (() => slot(defaultValue))();
     this[$getNameForward] = this.slot;
+  }
+
+  get schema(): T {
+    return this[$soul].schema;
+  }
+
+  get defaultValue(): TValue | undefined {
+    return this[$soul].defaultValue;
   }
 
   $name(label: string) {
@@ -202,7 +215,7 @@ export class TgpuAccessorImpl<T extends BaseData>
     schemaOrConstructor: T | ((count: number) => T),
     defaultValue: TgpuAccessor.In<T> | undefined = undefined,
   ) {
-    super(schemaOrConstructor, defaultValue);
+    super('accessor', schemaOrConstructor, defaultValue);
   }
 }
 
@@ -237,6 +250,6 @@ export class TgpuMutableAccessorImpl<T extends BaseData>
     schemaOrConstructor: T | ((count: number) => T),
     defaultValue: TgpuMutableAccessor.In<T> | undefined = undefined,
   ) {
-    super(schemaOrConstructor, defaultValue);
+    super('mutable-accessor', schemaOrConstructor, defaultValue);
   }
 }

--- a/packages/typegpu/src/core/slot/slot.ts
+++ b/packages/typegpu/src/core/slot/slot.ts
@@ -1,9 +1,9 @@
 import { getResolutionCtx } from '../../execMode.ts';
 import { getName, setName } from '../../shared/meta.ts';
 import type { GPUValueOf } from '../../shared/repr.ts';
-import { $gpuValueOf, $internal } from '../../shared/symbols.ts';
+import { $gpuValueOf, $internal, $soul } from '../../shared/symbols.ts';
 import { getGpuValueRecursively } from '../valueProxyUtils.ts';
-import type { TgpuSlot } from './slotTypes.ts';
+import type { TgpuSlot, TgpuSlotSoul } from './slotTypes.ts';
 
 // ----------
 // Public API
@@ -19,11 +19,19 @@ export function slot<T>(defaultValue?: T): TgpuSlot<T> {
 
 class TgpuSlotImpl<T> implements TgpuSlot<T> {
   readonly [$internal] = true;
+  readonly [$soul]: TgpuSlotSoul<T>;
   readonly resourceType = 'slot';
-  readonly defaultValue: T | undefined;
 
   constructor(defaultValue: T | undefined = undefined) {
-    this.defaultValue = defaultValue;
+    this[$soul] = {
+      type: 'slot',
+      defaultValue,
+      label: undefined,
+    };
+  }
+
+  get defaultValue(): T | undefined {
+    return this[$soul].defaultValue;
   }
 
   $name(label: string) {

--- a/packages/typegpu/src/core/slot/slotTypes.ts
+++ b/packages/typegpu/src/core/slot/slotTypes.ts
@@ -2,7 +2,8 @@ import type { WgslStorageTexture, WgslTexture } from '../../data/texture.ts';
 import type { BaseData } from '../../data/wgslTypes.ts';
 import type { TgpuNamable } from '../../shared/meta.ts';
 import type { GPUValueOf, Infer, InferGPU } from '../../shared/repr.ts';
-import { $gpuValueOf, $internal, $providing } from '../../shared/symbols.ts';
+import type { TgpuSoul } from '../../shared/soul.ts';
+import { $gpuValueOf, $internal, $providing, $soul } from '../../shared/symbols.ts';
 import type { UnwrapRuntimeConstructor } from '../../tgpuBindGroupLayout.ts';
 import type { TgpuBufferBinding } from '../buffer/bufferBinding.ts';
 import type { TgpuConst } from '../constant/tgpuConstant.ts';
@@ -10,8 +11,20 @@ import type { Withable } from '../root/rootTypes.ts';
 import type { TgpuTextureView } from '../texture/texture.ts';
 import type { TgpuVar, VariableScope } from '../variable/tgpuVariable.ts';
 
+export interface TgpuSlotSoul<T = unknown> extends TgpuSoul<'slot'> {
+  readonly defaultValue: T | undefined;
+}
+
+export interface TgpuAccessorSoul<T extends BaseData = BaseData, TValue = unknown> extends TgpuSoul<
+  'accessor' | 'mutable-accessor'
+> {
+  readonly schema: T;
+  readonly defaultValue: TValue | undefined;
+}
+
 export interface TgpuSlot<T> extends TgpuNamable {
   readonly [$internal]: true;
+  readonly [$soul]: TgpuSlotSoul<T>;
   readonly resourceType: 'slot';
 
   readonly defaultValue: T | undefined;
@@ -43,6 +56,7 @@ export interface TgpuLazy<out T> extends Withable<TgpuLazy<T>> {
 
 export interface TgpuAccessor<T extends BaseData = BaseData> extends TgpuNamable {
   readonly [$internal]: true;
+  readonly [$soul]: TgpuAccessorSoul<T, TgpuAccessor.In<T>>;
   readonly resourceType: 'accessor';
 
   readonly schema: T;
@@ -76,6 +90,7 @@ export declare namespace TgpuAccessor {
 
 export interface TgpuMutableAccessor<T extends BaseData = BaseData> extends TgpuNamable {
   readonly [$internal]: true;
+  readonly [$soul]: TgpuAccessorSoul<T, TgpuMutableAccessor.In<T>>;
   readonly resourceType: 'mutable-accessor';
 
   readonly schema: T;

--- a/packages/typegpu/src/core/texture/texture.ts
+++ b/packages/typegpu/src/core/texture/texture.ts
@@ -19,7 +19,15 @@ import {
   type TextureFormats,
   type ViewDimensionToDimension,
 } from './textureFormats.ts';
-import { $gpuValueOf, $internal, $ownSnippet, $repr, $resolve } from '../../shared/symbols.ts';
+import type { TgpuDeviceOwningSoul } from '../../shared/soul.ts';
+import {
+  $gpuValueOf,
+  $internal,
+  $ownSnippet,
+  $repr,
+  $resolve,
+  $soul,
+} from '../../shared/symbols.ts';
 import type { Default, TypedArray, UnionToIntersection } from '../../shared/utilityTypes.ts';
 import type { LayoutMembership } from '../../tgpuBindGroupLayout.ts';
 import type { ResolutionCtx, SelfResolvable } from '../../types.ts';
@@ -36,8 +44,19 @@ import { generateTextureMipmaps, getImageSourceDimensions, resampleImage } from 
 import { logger } from '../../tgpuLogger.ts';
 
 export type TextureInternals = {
-  unwrap(): GPUTexture;
+  materialize(): GPUTexture;
 };
+
+export type TextureUsageLiteral = 'sampled' | 'storage' | 'render' | 'transient';
+
+export interface TgpuTextureSoul<
+  TProps extends TextureProps = TextureProps,
+> extends TgpuDeviceOwningSoul<'texture', GPUTexture> {
+  readonly props: TProps;
+  flags: GPUTextureUsageFlags;
+  flagsOverridden: boolean;
+  readonly usages: TextureUsageLiteral[];
+}
 
 type TextureViewInternals = {
   readonly unwrap: (() => GPUTextureView) | undefined;
@@ -139,6 +158,7 @@ type CopyCompatibleTexture<T extends TextureProps> = TgpuTexture<{
 // oxlint-disable-next-line typescript/no-explicit-any -- we can't tame the validation otherwise
 export interface TgpuTexture<TProps extends TextureProps = any> extends TgpuNamable {
   readonly [$internal]: TextureInternals;
+  readonly [$soul]: TgpuTextureSoul<TProps>;
   readonly resourceType: 'texture';
   readonly props: TProps; // <- storing to be able to differentiate structurally between different textures.
   readonly destroyed: boolean;
@@ -224,40 +244,44 @@ export function isTextureView(value: unknown): value is TgpuTextureView {
 
 class TgpuTextureImpl<TProps extends TextureProps> implements TgpuTexture<TProps> {
   readonly [$internal]: TextureInternals;
+  readonly [$soul]: TgpuTextureSoul<TProps>;
   readonly resourceType = 'texture';
-  readonly props: TProps;
   usableAsSampled = false;
   usableAsStorage = false;
   usableAsRender = false;
 
   #formatInfo: TextureFormatInfo;
   #destroyed = false;
-  #flags = GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC;
-  #flagsOverridden = false;
-  #texture: GPUTexture | null = null;
-  #branch: ExperimentalTgpuRoot;
 
   constructor(props: TProps, branch: ExperimentalTgpuRoot) {
-    this.props = props;
+    this[$soul] = {
+      type: 'texture',
+      device: branch.device,
+      props,
+      flags: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+      flagsOverridden: false,
+      usages: [],
+      raw: undefined,
+      label: undefined,
+    };
 
-    const format = props.format as TProps['format'];
-
-    this.#branch = branch;
-    this.#formatInfo = getTextureFormatInfo(format);
+    this.#formatInfo = getTextureFormatInfo(props.format as TProps['format']);
 
     this[$internal] = {
-      unwrap: () => {
+      materialize: () => {
         if (this.#destroyed) {
           throw new Error('This texture has been destroyed');
         }
 
-        if (!this.#texture) {
-          this.#texture = branch.device.createTexture({
+        const soul = this[$soul];
+        if (!soul.raw) {
+          const props = soul.props;
+          soul.raw = soul.device.createTexture({
             label: getName(this) ?? '<unnamed>',
             format: props.format,
             // The WebGPU types accept only mutable arrays, which is too loosely typed
             size: props.size as number[],
-            usage: this.#flags,
+            usage: soul.flags,
             dimension: props.dimension ?? '2d',
             viewFormats: props.viewFormats ?? [],
             mipLevelCount: props.mipLevelCount ?? 1,
@@ -265,9 +289,13 @@ class TgpuTextureImpl<TProps extends TextureProps> implements TgpuTexture<TProps
           });
         }
 
-        return this.#texture;
+        return soul.raw;
       },
     };
+  }
+
+  get props(): TProps {
+    return this[$soul].props;
   }
 
   $name(label: string) {
@@ -275,10 +303,11 @@ class TgpuTextureImpl<TProps extends TextureProps> implements TgpuTexture<TProps
     return this;
   }
 
-  $usage<T extends ('sampled' | 'storage' | 'render' | 'transient')[]>(
+  $usage<T extends TextureUsageLiteral[]>(
     ...usages: T
   ): this & UnionToIntersection<LiteralToExtensionMap[T[number]]> {
-    if (this.#flagsOverridden) {
+    const soul = this[$soul];
+    if (soul.flagsOverridden) {
       throw new Error('Cannot call $usage() after $overrideFlags().');
     }
 
@@ -292,10 +321,9 @@ class TgpuTextureImpl<TProps extends TextureProps> implements TgpuTexture<TProps
       (hasStorage ? GPUTextureUsage.STORAGE_BINDING : 0);
     const transientFlags = GPUTextureUsage.TRANSIENT_ATTACHMENT | GPUTextureUsage.RENDER_ATTACHMENT;
     const nextFlags =
-      this.#flags | bindingFlags | (hasRender ? GPUTextureUsage.RENDER_ATTACHMENT : 0);
+      soul.flags | bindingFlags | (hasRender ? GPUTextureUsage.RENDER_ATTACHMENT : 0);
 
-    const hasTransientUsage =
-      hasTransient || !!(this.#flags & GPUTextureUsage.TRANSIENT_ATTACHMENT);
+    const hasTransientUsage = hasTransient || !!(soul.flags & GPUTextureUsage.TRANSIENT_ATTACHMENT);
     const hasSampledOrStorageUsage = !!(
       nextFlags &
       (GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.STORAGE_BINDING)
@@ -305,17 +333,23 @@ class TgpuTextureImpl<TProps extends TextureProps> implements TgpuTexture<TProps
       throw new Error("Transient texture usage cannot be combined with 'sampled' or 'storage'.");
     }
 
-    this.#flags = hasTransient ? transientFlags : nextFlags;
+    soul.flags = hasTransient ? transientFlags : nextFlags;
     this.usableAsStorage ||= hasStorage;
     this.usableAsSampled ||= hasSampled;
     this.usableAsRender ||= hasRender || hasTransient;
+    for (const usage of usages) {
+      if (!soul.usages.includes(usage)) {
+        soul.usages.push(usage);
+      }
+    }
 
     return this as this & UnionToIntersection<LiteralToExtensionMap[T[number]]>;
   }
 
   $overrideFlags(flags: GPUTextureUsageFlags): this & StorageFlag & SampledFlag & RenderFlag {
-    this.#flags = flags;
-    this.#flagsOverridden = true;
+    const soul = this[$soul];
+    soul.flags = flags;
+    soul.flagsOverridden = true;
     this.usableAsSampled = true;
     this.usableAsStorage = true;
     this.usableAsRender = true;
@@ -368,8 +402,8 @@ class TgpuTextureImpl<TProps extends TextureProps> implements TgpuTexture<TProps
       );
     }
 
-    this.#branch.device.queue.writeTexture(
-      { texture: this[$internal].unwrap(), mipLevel: mip },
+    this[$soul].device.queue.writeTexture(
+      { texture: this[$internal].materialize(), mipLevel: mip },
       new Uint8Array(width * height * depth * texelSize),
       { bytesPerRow: texelSize * width, rowsPerImage: height },
       [width, height, depth],
@@ -415,8 +449,8 @@ class TgpuTextureImpl<TProps extends TextureProps> implements TgpuTexture<TProps
     }
 
     generateTextureMipmaps(
-      this.#branch.device,
-      this[$internal].unwrap(),
+      this[$soul].device,
+      this[$internal].materialize(),
       baseMipLevel,
       actualMipLevels,
     );
@@ -478,9 +512,9 @@ class TgpuTextureImpl<TProps extends TextureProps> implements TgpuTexture<TProps
       );
     }
 
-    this.#branch.device.queue.writeTexture(
+    this[$soul].device.queue.writeTexture(
       {
-        texture: this[$internal].unwrap(),
+        texture: this[$internal].materialize(),
         mipLevel,
       },
       'buffer' in source ? source.buffer : source,
@@ -499,14 +533,14 @@ class TgpuTextureImpl<TProps extends TextureProps> implements TgpuTexture<TProps
     const needsResampling = sourceWidth !== targetWidth || sourceHeight !== targetHeight;
 
     if (needsResampling) {
-      resampleImage(this.#branch.device, this[$internal].unwrap(), source, layer);
+      resampleImage(this[$soul].device, this[$internal].materialize(), source, layer);
       return;
     }
 
-    this.#branch.device.queue.copyExternalImageToTexture(
+    this[$soul].device.queue.copyExternalImageToTexture(
       { source },
       {
-        texture: this[$internal].unwrap(),
+        texture: this[$internal].materialize(),
         ...(layer !== undefined && { origin: { x: 0, y: 0, z: layer } }),
       },
       layer !== undefined ? [targetWidth, targetHeight, 1] : this.props.size,
@@ -531,13 +565,13 @@ class TgpuTextureImpl<TProps extends TextureProps> implements TgpuTexture<TProps
       );
     }
 
-    const commandEncoder = this.#branch.device.createCommandEncoder();
+    const commandEncoder = this[$soul].device.createCommandEncoder();
     commandEncoder.copyTextureToTexture(
-      { texture: source[$internal].unwrap() },
-      { texture: this[$internal].unwrap() },
+      { texture: source[$internal].materialize() },
+      { texture: this[$internal].materialize() },
       source.props.size,
     );
-    this.#branch.device.queue.submit([commandEncoder.finish()]);
+    this[$soul].device.queue.submit([commandEncoder.finish()]);
   }
 
   toString(): string {
@@ -553,7 +587,7 @@ class TgpuTextureImpl<TProps extends TextureProps> implements TgpuTexture<TProps
       return;
     }
     this.#destroyed = true;
-    this.#texture?.destroy();
+    this[$soul].raw?.destroy();
   }
 }
 
@@ -587,7 +621,7 @@ class TgpuFixedTextureViewImpl<T extends WgslTexture | WgslStorageTexture>
             ? schema.format
             : this.#baseTexture.props.format;
 
-          this.#view = this.#baseTexture[$internal].unwrap().createView({
+          this.#view = this.#baseTexture[$internal].materialize().createView({
             ...this.#descriptor,
             label: getName(this) ?? '<unnamed>',
             format: this.#descriptor?.format ?? format,
@@ -746,7 +780,7 @@ export class TgpuTextureRenderViewImpl implements TgpuTextureRenderView {
     this.descriptor = descriptor;
     this[$internal] = {
       unwrap: () => {
-        return baseTexture[$internal].unwrap().createView({
+        return baseTexture[$internal].materialize().createView({
           label: getName(this) ?? '<unnamed>',
           ...this.descriptor,
         });

--- a/packages/typegpu/src/core/texture/texture.ts
+++ b/packages/typegpu/src/core/texture/texture.ts
@@ -19,7 +19,7 @@ import {
   type TextureFormats,
   type ViewDimensionToDimension,
 } from './textureFormats.ts';
-import type { TgpuDeviceOwningSoul } from '../../shared/soul.ts';
+import type { TgpuDeviceOwningSoul, TgpuSoul } from '../../shared/soul.ts';
 import {
   $gpuValueOf,
   $internal,
@@ -56,6 +56,22 @@ export interface TgpuTextureSoul<
   flags: GPUTextureUsageFlags;
   flagsOverridden: boolean;
   readonly usages: TextureUsageLiteral[];
+}
+
+export interface TgpuTextureViewSoul<
+  T extends WgslTexture | WgslStorageTexture | 'render' =
+    | WgslTexture
+    | WgslStorageTexture
+    | 'render',
+> extends TgpuSoul<'texture-view'> {
+  readonly texture: TgpuTexture;
+  readonly schema: T;
+  readonly descriptor:
+    | (TgpuTextureViewDescriptor & {
+        sampleType?: T extends WgslTexture ? 'float' | 'unfilterable-float' : never;
+      })
+    | undefined;
+  raw?: GPUTextureView | undefined;
 }
 
 type TextureViewInternals = {
@@ -222,9 +238,9 @@ export interface TgpuTextureRenderView {
 
 export function INTERNAL_createTexture(
   props: TextureProps,
-  branch: ExperimentalTgpuRoot,
+  root: ExperimentalTgpuRoot,
 ): TgpuTexture<TextureProps> {
-  return new TgpuTextureImpl(props, branch);
+  return new TgpuTextureImpl(props, root);
 }
 
 export function isTexture(value: unknown): value is TgpuTexture {
@@ -253,10 +269,10 @@ class TgpuTextureImpl<TProps extends TextureProps> implements TgpuTexture<TProps
   #formatInfo: TextureFormatInfo;
   #destroyed = false;
 
-  constructor(props: TProps, branch: ExperimentalTgpuRoot) {
+  constructor(props: TProps, root: ExperimentalTgpuRoot) {
     this[$soul] = {
       type: 'texture',
-      device: branch.device,
+      device: root.device,
       props,
       flags: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
       flagsOverridden: false,
@@ -597,38 +613,34 @@ class TgpuFixedTextureViewImpl<T extends WgslTexture | WgslStorageTexture>
   /** Type-token, not available at runtime */
   declare readonly [$repr]: Infer<T>;
   readonly [$internal]: TextureViewInternals;
+  readonly [$soul]: TgpuTextureViewSoul<T>;
   readonly resourceType = 'texture-view' as const;
-  readonly schema: T;
-
-  #baseTexture: TgpuTexture;
-  #view: GPUTextureView | undefined;
-  #descriptor:
-    | (TgpuTextureViewDescriptor & {
-        sampleType?: T extends WgslTexture ? 'float' | 'unfilterable-float' : never;
-      })
-    | undefined;
 
   constructor(schema: T, baseTexture: TgpuTexture, descriptor?: TgpuTextureViewDescriptor) {
-    this.schema = schema;
-    this.#baseTexture = baseTexture;
-    this.#descriptor = descriptor;
+    this[$soul] = {
+      type: 'texture-view',
+      texture: baseTexture,
+      schema,
+      descriptor,
+      raw: undefined,
+      label: undefined,
+    };
 
     this[$internal] = {
       unwrap: () => {
-        if (!this.#view) {
-          const schema = this.schema;
-          const format = isWgslStorageTexture(schema)
-            ? schema.format
-            : this.#baseTexture.props.format;
+        const soul = this[$soul];
+        if (!soul.raw) {
+          const schema = soul.schema;
+          const format = isWgslStorageTexture(schema) ? schema.format : soul.texture.props.format;
 
-          this.#view = this.#baseTexture[$internal].materialize().createView({
-            ...this.#descriptor,
+          soul.raw = soul.texture[$internal].materialize().createView({
+            ...soul.descriptor,
             label: getName(this) ?? '<unnamed>',
-            format: this.#descriptor?.format ?? format,
+            format: soul.descriptor?.format ?? format,
             dimension: schema.dimension,
           });
         }
-        return this.#view;
+        return soul.raw;
       },
       format:
         descriptor?.format ??
@@ -637,10 +649,14 @@ class TgpuFixedTextureViewImpl<T extends WgslTexture | WgslStorageTexture>
     };
   }
 
+  get schema(): T {
+    return this[$soul].schema;
+  }
+
   $name(label: string) {
     setName(this, label);
-    if (this.#view) {
-      this.#view.label = label;
+    if (this[$soul].raw) {
+      this[$soul].raw.label = label;
     }
     return this;
   }
@@ -672,7 +688,7 @@ class TgpuFixedTextureViewImpl<T extends WgslTexture | WgslStorageTexture>
   }
 
   get size(): number[] {
-    return this.#baseTexture.props.size;
+    return this[$soul].texture.props.size;
   }
 
   toString() {
@@ -688,7 +704,7 @@ class TgpuFixedTextureViewImpl<T extends WgslTexture | WgslStorageTexture>
           }
         : {
             texture: this.schema,
-            sampleType: this.#descriptor?.sampleType ?? this.schema.bindingSampleType[0],
+            sampleType: this[$soul].descriptor?.sampleType ?? this.schema.bindingSampleType[0],
           },
       this,
     );
@@ -773,11 +789,18 @@ export class TgpuLaidOutTextureViewImpl<T extends WgslTexture | WgslStorageTextu
 
 export class TgpuTextureRenderViewImpl implements TgpuTextureRenderView {
   readonly [$internal]: TextureViewInternals;
+  readonly [$soul]: TgpuTextureViewSoul<'render'>;
   readonly resourceType = 'texture-view' as const;
-  readonly descriptor: TgpuTextureViewDescriptor;
 
   constructor(baseTexture: TgpuTexture, descriptor: TgpuTextureViewDescriptor = {}) {
-    this.descriptor = descriptor;
+    this[$soul] = {
+      type: 'texture-view',
+      texture: baseTexture,
+      schema: 'render',
+      descriptor,
+      raw: undefined,
+      label: undefined,
+    };
     this[$internal] = {
       unwrap: () => {
         return baseTexture[$internal].materialize().createView({
@@ -788,5 +811,9 @@ export class TgpuTextureRenderViewImpl implements TgpuTextureRenderView {
       format: descriptor.format ?? baseTexture.props.format,
       aspect: descriptor.aspect,
     };
+  }
+
+  get descriptor(): TgpuTextureViewDescriptor {
+    return this[$soul].descriptor ?? {};
   }
 }

--- a/packages/typegpu/src/core/variable/tgpuVariable.ts
+++ b/packages/typegpu/src/core/variable/tgpuVariable.ts
@@ -8,13 +8,23 @@ import { makeResolvable } from '../../tgsl/makeResolvable.ts';
 import type { TgpuNamable } from '../../shared/meta.ts';
 import { getName, setName } from '../../shared/meta.ts';
 import type { InferGPU } from '../../shared/repr.ts';
-import { $gpuValueOf, $internal } from '../../shared/symbols.ts';
+import type { TgpuSoul } from '../../shared/soul.ts';
+import { $gpuValueOf, $internal, $soul } from '../../shared/symbols.ts';
 
 // ----------
 // Public API
 // ----------
 
 export type VariableScope = 'private' | 'workgroup';
+
+export interface TgpuVarSoul<
+  TScope extends VariableScope = VariableScope,
+  TDataType extends BaseData = BaseData,
+> extends TgpuSoul<'var'> {
+  readonly scope: TScope;
+  readonly dataType: TDataType;
+  readonly initialValue: InferGPU<TDataType> | undefined;
+}
 
 export interface TgpuVar<
   TScope extends VariableScope = VariableScope,
@@ -24,6 +34,7 @@ export interface TgpuVar<
   readonly [$gpuValueOf]: InferGPU<TDataType>;
   $: InferGPU<TDataType>;
 
+  readonly [$soul]: TgpuVarSoul<TScope, TDataType>;
   readonly [$internal]: {
     /** Makes it differentiable on the type level. Does not exist at runtime. */
     dataType?: TDataType;
@@ -69,9 +80,7 @@ class TgpuVarImpl<TScope extends VariableScope, TDataType extends BaseData> impl
   TScope,
   TDataType
 > {
-  readonly #scope: TScope;
-  readonly #dataType: TDataType;
-  readonly #initialValue: InferGPU<TDataType> | undefined;
+  readonly [$soul]: TgpuVarSoul<TScope, TDataType>;
 
   // prototype properties
   declare resourceType: 'var';
@@ -92,14 +101,14 @@ class TgpuVarImpl<TScope extends VariableScope, TDataType extends BaseData> impl
         },
         resolve(ctx) {
           const id = ctx.makeUniqueIdentifier(getName(this), 'global');
-          const init = this.#initialValue
-            ? snip(this.#initialValue, this.#dataType, 'constant')
+          const init = this[$soul].initialValue
+            ? snip(this[$soul].initialValue, this[$soul].dataType, 'constant')
             : undefined;
 
           return ctx.gen.declareGlobalVar({
-            scope: this.#scope,
+            scope: this[$soul].scope,
             id,
-            dataType: this.#dataType,
+            dataType: this[$soul].dataType,
             init,
           });
         },
@@ -109,22 +118,22 @@ class TgpuVarImpl<TScope extends VariableScope, TDataType extends BaseData> impl
           getBaseSnippet(trackingProxy) {
             return snip(
               trackingProxy,
-              this.#dataType,
-              this.#scope,
+              this[$soul].dataType,
+              this[$soul].scope,
               /* possibleSideEffects */ false,
             );
           },
         },
         simulateMode: {
           get(state) {
-            if (!state.vars[this.#scope].has(this)) {
+            if (!state.vars[this[$soul].scope].has(this)) {
               // Not initialized yet
-              state.vars[this.#scope].set(this, this.#initialValue);
+              state.vars[this[$soul].scope].set(this, this[$soul].initialValue);
             }
-            return state.vars[this.#scope].get(this);
+            return state.vars[this[$soul].scope].get(this);
           },
           set(state, value) {
-            state.vars[this.#scope].set(this, value);
+            state.vars[this[$soul].scope].set(this, value);
           },
         },
         normalMode: {
@@ -148,9 +157,13 @@ class TgpuVarImpl<TScope extends VariableScope, TDataType extends BaseData> impl
   }
 
   constructor(scope: TScope, dataType: TDataType, initialValue?: InferGPU<TDataType>) {
-    this.#scope = scope;
-    this.#dataType = dataType;
-    this.#initialValue = initialValue;
+    this[$soul] = {
+      type: 'var',
+      scope,
+      dataType,
+      initialValue,
+      label: undefined,
+    };
   }
 
   $name(label: string) {

--- a/packages/typegpu/src/core/vertexLayout/vertexLayout.ts
+++ b/packages/typegpu/src/core/vertexLayout/vertexLayout.ts
@@ -7,7 +7,8 @@ import { isDecorated, isWgslStruct } from '../../data/wgslTypes.ts';
 import { roundUp } from '../../mathUtils.ts';
 import type { TgpuNamable } from '../../shared/meta.ts';
 import { setName } from '../../shared/meta.ts';
-import { $internal } from '../../shared/symbols.ts';
+import type { TgpuSoul } from '../../shared/soul.ts';
+import { $internal, $soul } from '../../shared/symbols.ts';
 import {
   kindToDefaultFormatMap,
   type TgpuVertexAttrib,
@@ -20,10 +21,16 @@ import type { ArrayToContainedAttribs, DataToContainedAttribs } from './vertexAt
 // Public API
 // ----------
 
+export interface TgpuVertexLayoutSoul extends TgpuSoul<'vertex-layout'> {
+  readonly schema: WgslArray | Disarray;
+  readonly stepMode: 'vertex' | 'instance';
+}
+
 export interface TgpuVertexLayout<
   TData extends WgslArray | Disarray = WgslArray | Disarray,
 > extends TgpuNamable {
   readonly [$internal]: true;
+  readonly [$soul]: TgpuVertexLayoutSoul;
   readonly resourceType: 'vertex-layout';
   readonly stride: number;
   readonly stepMode: 'vertex' | 'instance';
@@ -135,22 +142,31 @@ function dataToContainedAttribs<TLayoutData extends WgslArray | Disarray, TData 
 
 class TgpuVertexLayoutImpl<TData extends WgslArray | Disarray> implements TgpuVertexLayout<TData> {
   readonly [$internal] = true;
+  readonly [$soul]: TgpuVertexLayoutSoul;
   readonly resourceType = 'vertex-layout';
   readonly stride: number;
   readonly attrib: ArrayToContainedAttribs<TData>;
   readonly schemaForCount: (count: number) => TData;
-  readonly stepMode: 'vertex' | 'instance';
   readonly #customLocationMap = {} as Record<string | symbol, number>;
 
   constructor(schemaForCount: (count: number) => TData, stepMode: 'vertex' | 'instance') {
     this.schemaForCount = schemaForCount;
-    this.stepMode = stepMode;
 
     // `0` signals that the data-type is runtime-sized, and should not be used to create buffers.
     const arraySchema = schemaForCount(0);
 
+    this[$soul] = {
+      type: 'vertex-layout',
+      schema: arraySchema,
+      stepMode,
+      label: undefined,
+    };
     this.stride = roundUp(sizeOf(arraySchema.elementType), alignmentOf(arraySchema));
     this.attrib = dataToContainedAttribs(this, arraySchema.elementType, 0, this.#customLocationMap);
+  }
+
+  get stepMode(): 'vertex' | 'instance' {
+    return this[$soul].stepMode;
   }
 
   get vertexLayout(): GPUVertexBufferLayout {

--- a/packages/typegpu/src/shared/meta.ts
+++ b/packages/typegpu/src/shared/meta.ts
@@ -1,6 +1,7 @@
 import { version } from 'typegpu/package.json';
 import { DEV, TEST } from './env.ts';
-import { $getNameForward, isMarkedInternal } from './symbols.ts';
+import type { TgpuSoul } from './soul.ts';
+import { $getNameForward, $soul, isMarkedInternal } from './symbols.ts';
 import { normalizeMetadata, type Metadata, type RawMetadata } from './normalizeMetadata.ts';
 
 // --- globalExt ---
@@ -51,12 +52,18 @@ function isForwarded(value: unknown): value is { [$getNameForward]: unknown } {
   return !!(value as { [$getNameForward]?: unknown })?.[$getNameForward];
 }
 
+function soulOf(value: unknown): TgpuSoul | undefined {
+  return (value as { [$soul]?: TgpuSoul })?.[$soul];
+}
+
 export function getName(definition: unknown): string | undefined {
   if (isForwarded(definition)) {
     return getName(definition[$getNameForward]);
   }
   return (
-    nameMap.get(definition as object) ?? globalExt.__TYPEGPU_META__?.get(definition as object)?.name
+    nameMap.get(definition as object) ??
+    soulOf(definition)?.label ??
+    globalExt.__TYPEGPU_META__?.get(definition as object)?.name
   );
 }
 
@@ -66,6 +73,10 @@ export function setName(definition: object, name: string): void {
     return;
   }
   nameMap.set(definition, name);
+  const soul = soulOf(definition);
+  if (soul) {
+    soul.label = name;
+  }
 }
 
 // --- METADATA ---

--- a/packages/typegpu/src/shared/meta.ts
+++ b/packages/typegpu/src/shared/meta.ts
@@ -62,6 +62,7 @@ export function getName(definition: unknown): string | undefined {
   }
   return (
     nameMap.get(definition as object) ??
+    // nameMap is runtime-local, soul labels travel with the resource between runtimes
     soulOf(definition)?.label ??
     globalExt.__TYPEGPU_META__?.get(definition as object)?.name
   );

--- a/packages/typegpu/src/shared/soul.ts
+++ b/packages/typegpu/src/shared/soul.ts
@@ -1,7 +1,7 @@
 /**
  * The base shape of a soul: a plain record of all definitional state of a resource,
- * holding everything that survives a device boundary. Souls carry own data properties
- * only, no methods, no prototype and no symbol keys
+ * holding everything that survives transfer between runtimes. Souls carry own data
+ * properties only, no methods, no prototype and no symbol keys
  */
 export interface TgpuSoul<TType extends string = string> {
   readonly type: TType;

--- a/packages/typegpu/src/shared/soul.ts
+++ b/packages/typegpu/src/shared/soul.ts
@@ -1,0 +1,18 @@
+/**
+ * The base shape of a soul: a plain record of all definitional state of a resource,
+ * holding everything that survives a device boundary. Souls carry own data properties
+ * only, no methods, no prototype and no symbol keys
+ */
+export interface TgpuSoul<TType extends string = string> {
+  readonly type: TType;
+  label?: string | undefined;
+}
+
+/** A soul of a resource that owns a device object, filled in by `[$internal].materialize()` */
+export interface TgpuDeviceOwningSoul<
+  TType extends string = string,
+  TRaw = unknown,
+> extends TgpuSoul<TType> {
+  readonly device: GPUDevice;
+  raw?: TRaw | undefined;
+}

--- a/packages/typegpu/src/shared/soul.ts
+++ b/packages/typegpu/src/shared/soul.ts
@@ -1,10 +1,13 @@
 /**
  * The base shape of a soul: a plain record of all definitional state of a resource,
  * holding everything that survives transfer between runtimes. Souls carry own data
- * properties only, no methods, no prototype and no symbol keys
+ * properties only, no methods, no prototype and no symbol keys. Raw GPU objects
+ * belong here too, they cross runtimes as shareable host objects pointing to the
+ * same underlying resource
  */
 export interface TgpuSoul<TType extends string = string> {
   readonly type: TType;
+  /** Only set/read through `setName` and `getName` - do not change manually */
   label?: string | undefined;
 }
 

--- a/packages/typegpu/src/shared/symbols.ts
+++ b/packages/typegpu/src/shared/symbols.ts
@@ -1,7 +1,7 @@
 import { version } from 'typegpu/package.json';
 
 export const $internal = Symbol(`typegpu:${version}:$internal`);
-/** A plain record of all definitional state of a resource, surviving a device boundary */
+/** A plain record of all definitional state of a resource, surviving transfer between runtimes */
 export const $soul = Symbol(`typegpu:${version}:$soul`);
 /**
  * The getter to the value of this resource, accessible on the GPU

--- a/packages/typegpu/src/shared/symbols.ts
+++ b/packages/typegpu/src/shared/symbols.ts
@@ -1,6 +1,8 @@
 import { version } from 'typegpu/package.json';
 
 export const $internal = Symbol(`typegpu:${version}:$internal`);
+/** A plain record of all definitional state of a resource, surviving a device boundary */
+export const $soul = Symbol(`typegpu:${version}:$soul`);
 /**
  * The getter to the value of this resource, accessible on the GPU
  */

--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -37,7 +37,8 @@ import type { TgpuNamable } from './shared/meta.ts';
 import { getName, setName } from './shared/meta.ts';
 import type { InferGPU, MemIdentity } from './shared/repr.ts';
 import { safeStringify } from './shared/stringify.ts';
-import { $gpuValueOf, $internal } from './shared/symbols.ts';
+import type { TgpuSoul } from './shared/soul.ts';
+import { $gpuValueOf, $internal, $soul } from './shared/symbols.ts';
 import type { NullableToOptional, Prettify } from './shared/utilityTypes.ts';
 import type { ResolvableObject, TgpuShaderStage } from './types.ts';
 import type { Unwrapper } from './unwrapper.ts';
@@ -126,10 +127,23 @@ type UnwrapRuntimeConstructorInner<T extends BaseData | ((_: number) => BaseData
 export type UnwrapRuntimeConstructor<T extends BaseData | ((_: number) => BaseData)> =
   T extends unknown ? UnwrapRuntimeConstructorInner<T> : never;
 
+export interface TgpuBindGroupLayoutSoul extends TgpuSoul<'bind-group-layout'> {
+  readonly entries: Record<string, TgpuLayoutEntry | null>;
+  index?: number | undefined;
+}
+
+export interface TgpuBindGroupSoul<
+  Entries extends Record<string, TgpuLayoutEntry | null> = Record<string, TgpuLayoutEntry | null>,
+> extends TgpuSoul<'bind-group'> {
+  readonly layout: TgpuBindGroupLayout<Entries>;
+  readonly entries: Record<string, unknown>;
+}
+
 export interface TgpuBindGroupLayout<
   Entries extends Record<string, TgpuLayoutEntry | null> = Record<string, TgpuLayoutEntry | null>,
 > extends TgpuNamable {
   readonly [$internal]: ResolvableObject[];
+  readonly [$soul]: TgpuBindGroupLayoutSoul;
   readonly resourceType: 'bind-group-layout';
   readonly entries: Entries;
   readonly [$gpuValueOf]: {
@@ -230,6 +244,7 @@ export type ExtractBindGroupInputFromLayout<T extends Record<string, TgpuLayoutE
 export type TgpuBindGroup<
   Entries extends Record<string, TgpuLayoutEntry | null> = Record<string, TgpuLayoutEntry | null>,
 > = {
+  readonly [$soul]: TgpuBindGroupSoul<Entries>;
   readonly resourceType: 'bind-group';
   readonly layout: TgpuBindGroupLayout<Entries>;
   unwrap(unwrapper: Unwrapper): GPUBindGroup;
@@ -271,9 +286,8 @@ const DEFAULT_READONLY_VISIBILITY: TgpuShaderStage[] = ['compute', 'vertex', 'fr
 class TgpuBindGroupLayoutImpl<
   Entries extends Record<string, TgpuLayoutEntry | null>,
 > implements TgpuBindGroupLayout<Entries> {
-  #index: number | undefined;
-
   readonly [$internal]: ResolvableObject[];
+  readonly [$soul]: TgpuBindGroupLayoutSoul;
   readonly resourceType = 'bind-group-layout' as const;
 
   readonly $ = {} as {
@@ -289,17 +303,26 @@ class TgpuBindGroupLayoutImpl<
   constructor(entries: Entries) {
     this.entries = entries;
     this[$internal] = [];
+    const normalizedEntries: Record<string, TgpuLayoutEntry | null> = {};
+    this[$soul] = {
+      type: 'bind-group-layout',
+      entries: normalizedEntries,
+      index: undefined,
+      label: undefined,
+    };
 
     let idx = 0;
 
     for (const [key, entry] of Object.entries(entries)) {
       if (entry === null) {
+        normalizedEntries[key] = null;
         idx++;
         continue;
       }
 
       const membership: LayoutMembership = { layout: this, key, idx };
       let item: undefined | (ResolvableObject & { $: unknown }) = undefined;
+      normalizedEntries[key] = entry;
 
       if ('uniform' in entry) {
         item = new TgpuLaidOutBufferImpl('uniform', entry.uniform, membership);
@@ -308,6 +331,7 @@ class TgpuBindGroupLayoutImpl<
       if ('storage' in entry) {
         const dataType = 'type' in entry.storage ? entry.storage : entry.storage(0);
         item = new TgpuLaidOutBufferImpl(entry.access ?? 'readonly', dataType, membership);
+        normalizedEntries[key] = { ...entry, storage: dataType };
       }
 
       if ('texture' in entry) {
@@ -346,7 +370,7 @@ class TgpuBindGroupLayoutImpl<
   }
 
   get index(): number | undefined {
-    return this.#index;
+    return this[$soul].index;
   }
 
   $name(label: string): this {
@@ -355,7 +379,7 @@ class TgpuBindGroupLayoutImpl<
   }
 
   $idx(index?: number): this {
-    this.#index = index;
+    this[$soul].index = index;
     return this;
   }
 
@@ -441,16 +465,19 @@ class TgpuBindGroupLayoutImpl<
 export class TgpuBindGroupImpl<
   Entries extends Record<string, TgpuLayoutEntry | null> = Record<string, TgpuLayoutEntry | null>,
 > implements TgpuBindGroup<Entries> {
+  readonly [$soul]: TgpuBindGroupSoul<Entries>;
   readonly resourceType = 'bind-group' as const;
-  readonly layout: TgpuBindGroupLayout<Entries>;
-  readonly entries: ExtractBindGroupInputFromLayout<Entries>;
 
   constructor(
     layout: TgpuBindGroupLayout<Entries>,
     entries: ExtractBindGroupInputFromLayout<Entries>,
   ) {
-    this.layout = layout;
-    this.entries = entries;
+    this[$soul] = {
+      type: 'bind-group',
+      layout,
+      entries: entries as Record<string, unknown>,
+      label: undefined,
+    };
 
     // Checking if all entries are present.
     for (const key of Object.keys(layout.entries)) {
@@ -458,6 +485,14 @@ export class TgpuBindGroupImpl<
         throw new MissingBindingError(getName(layout), key);
       }
     }
+  }
+
+  get layout(): TgpuBindGroupLayout<Entries> {
+    return this[$soul].layout;
+  }
+
+  get entries(): ExtractBindGroupInputFromLayout<Entries> {
+    return this[$soul].entries as ExtractBindGroupInputFromLayout<Entries>;
   }
 
   public unwrap(unwrapper: Unwrapper): GPUBindGroup {


### PR DESCRIPTION
Groundwork for the transfer protocol (PR on top of this one). To move a resource between runtimes we need its complete definitional state as a plain serializable record, and previously that state was scattered across private fields, closures and getters per resource. This PR gathers it into one place without changing any behavior.

- every resource now carries a `[$soul]` - a plain record of everything that survives a runtime boundary (own data properties only, no methods, no prototype, no symbol keys)
- `[$internal]` changed from `true` to an object exposing `materialize()`, which fills the soul's `raw` with the device object for resources that own one (buffer, texture, query set, pipelines, ...)
- resource impls read their state through the soul instead of private fields, so the soul is the single source of truth rather than a copy that could drift