### PR TITLE
fix: Make the `makeResolvable` $internal marker writable

### DIFF
--- a/packages/typegpu/src/tgsl/makeResolvable.ts
+++ b/packages/typegpu/src/tgsl/makeResolvable.ts
@@ -21,6 +21,7 @@ export function makeResolvable<T extends object>(
   if (!isMarkedInternal(value)) {
     Object.defineProperty(value, $internal, {
       value: true,
+      writable: true,
     });
   }
 


### PR DESCRIPTION
Running current main on React Native crashes at module load with `TypeError: Cannot assign to read-only property Symbol(typegpu:$internal)` the moment anything creates a bind group layout.

`makeResolvable` marks class prototypes with `Object.defineProperty(proto, $internal, { value: true })` - `writable` defaults to false. Classes like `TgpuLaidOutBufferImpl` declare the field and assign it in the constructor:

```ts
class TgpuLaidOutBufferImpl {
  readonly [$internal]: { readonly dataType: TData };
  constructor(...) {
    this[$internal] = { dataType };
  }
}
```

Whether that assignment survives depends on who compiles it. Vitest (oxc) keeps the field declaration as a native class field:

```js
class TgpuLaidOutBufferImpl {
  [$internal];                        // defines an own writable property before the ctor body
  constructor(...) {
    this[$internal] = { dataType };   // writes to the own property, fine
  }
}
```

Babel (Metro) strips the uninitialized field entirely:

```js
class TgpuLaidOutBufferImpl {
  constructor(...) {
    this[$internal] = { dataType };   // assignment walks the prototype chain,
  }                                   // finds the read-only marker, throws
}
```
