### PR TITLE
fix: Simpler ShaderGenerator lifetime

### DIFF
--- a/apps/typegpu-docs/src/content/docs/advanced/explaining-the-magic.mdx
+++ b/apps/typegpu-docs/src/content/docs/advanced/explaining-the-magic.mdx
@@ -157,7 +157,7 @@ Only functions marked with `'use gpu'` are processed, as well as those immediate
 
 The plugin uses the [tinyest-for-wgsl](https://github.com/software-mansion/TypeGPU/blob/main/packages/tinyest-for-wgsl/README.md) 
 package to parse the function AST into our custom AST format called [tinyest](https://github.com/software-mansion/TypeGPU/blob/main/packages/tinyest/README.md).
-Our `wgslGenerator` traverses this AST and generates code snippets.
+Our `WgslGenerator` traverses this AST and generates code snippets.
 
 This could theoretically be done at runtime from the function's `toString`, but it would require bundling a JavaScript parser with TypeGPU, and make catching externals impossible.
 
@@ -245,9 +245,9 @@ const externals = {
 This iteration of externals is still shared between different resolutions of the same function, thus we cannot concretize the externals just yet.
 
 Also, during resolution, deciding whether a given object comes from externals is difficult. Getters let us forget about this problem.
-Without this change, the `wgslGenerator` would throw when encountering a function not marked with 'use gpu'.
+Without this change, the `WgslGenerator` would throw when encountering a function not marked with 'use gpu'.
 
-When the `wgslGenerator` cannot find an identifier in scope, 
+When the `WgslGenerator` cannot find an identifier in scope, 
 it accesses the externals, which return the correct code snippets and automatically add any used definitions to the context, 
 as this is the behavior of resource prop access during resolution.
 
@@ -314,4 +314,3 @@ Generated tinyest metadata is not modified.
 :::caution
 `unplugin-typegpu` only transforms operators inside of 'use gpu' functions.
 :::
-

--- a/packages/typegpu-gl/src/glOptions.ts
+++ b/packages/typegpu-gl/src/glOptions.ts
@@ -1,7 +1,7 @@
-import glslGenerator from './glslGenerator.ts';
+import { GlslGenerator } from './glslGenerator.ts';
 
 export function glOptions() {
   return {
-    unstable_shaderGenerator: glslGenerator,
+    unstable_shaderGenerator: new GlslGenerator(),
   };
 }

--- a/packages/typegpu-gl/src/glslGenerator.ts
+++ b/packages/typegpu-gl/src/glslGenerator.ts
@@ -246,6 +246,3 @@ export class GlslGenerator extends WgslGenerator {
     }
   }
 }
-
-const glslGenerator: GlslGenerator = new GlslGenerator();
-export default glslGenerator;

--- a/packages/typegpu-gl/src/tgpuRootWebGL.ts
+++ b/packages/typegpu-gl/src/tgpuRootWebGL.ts
@@ -7,8 +7,7 @@
  */
 
 import { tgpu, d, type TgpuFragmentFn, type TgpuVertexFn } from 'typegpu';
-import type { ShaderGenerator } from 'typegpu/~internal';
-import glslGenerator, { translateWgslTypeToGlsl } from './glslGenerator.ts';
+import { GlslGenerator, translateWgslTypeToGlsl } from './glslGenerator.ts';
 
 // ----------
 // Public API
@@ -440,8 +439,6 @@ export interface CreateRenderPipelineWebGLOptions {
 }
 
 export class TgpuRootWebGL {
-  readonly #shaderGenerator: ShaderGenerator = glslGenerator;
-
   #gl: WebGL2RenderingContext;
   #offscreen: OffscreenCanvas;
   #uniforms: Array<WebGLUniformImpl<d.AnyWgslData>> = [];
@@ -545,25 +542,25 @@ export class TgpuRootWebGL {
 
     // Resolve both functions using the GLSL generator
     const vertexCode = tgpu.resolve([vertex], {
-      unstable_shaderGenerator: this.#shaderGenerator,
+      unstable_shaderGenerator: new GlslGenerator(),
       names: vertexNamespace,
     });
 
     const fragmentCode = tgpu.resolve([fragment], {
-      unstable_shaderGenerator: this.#shaderGenerator,
+      unstable_shaderGenerator: new GlslGenerator(),
       names: fragmentNamespace,
     });
 
     // Get the function names from the resolved code
     const vertexFnName = tgpu.resolve({
       template: '$$name$$',
-      unstable_shaderGenerator: this.#shaderGenerator,
+      unstable_shaderGenerator: new GlslGenerator(),
       names: vertexNamespace,
       externals: { $$name$$: vertex },
     });
     const fragmentFnName = tgpu.resolve({
       template: '$$name$$',
-      unstable_shaderGenerator: this.#shaderGenerator,
+      unstable_shaderGenerator: new GlslGenerator(),
       names: fragmentNamespace,
       externals: { $$name$$: fragment },
     });

--- a/packages/typegpu/src/core/pipeline/computePipeline.ts
+++ b/packages/typegpu/src/core/pipeline/computePipeline.ts
@@ -484,7 +484,9 @@ class ComputePipelineCore implements SelfResolvable {
       resolve(this, {
         namespace: ns,
         enableExtensions,
-        shaderGenerator: this.root.shaderGenerator,
+        shaderGenerator: this.root.shaderGeneratorClass
+          ? new this.root.shaderGeneratorClass()
+          : undefined,
         root: this.root,
       }),
     );

--- a/packages/typegpu/src/core/pipeline/renderPipeline.ts
+++ b/packages/typegpu/src/core/pipeline/renderPipeline.ts
@@ -876,7 +876,7 @@ class RenderPipelineCore implements SelfResolvable {
       resolve(this, {
         namespace: ns,
         enableExtensions,
-        shaderGenerator: root.shaderGenerator,
+        shaderGenerator: root.shaderGeneratorClass ? new root.shaderGeneratorClass() : undefined,
         root,
       }),
     );

--- a/packages/typegpu/src/core/root/init.ts
+++ b/packages/typegpu/src/core/root/init.ts
@@ -14,7 +14,7 @@ import type {
 } from '../../tgpuBindGroupLayout.ts';
 import { isBindGroup, isBindGroupLayout, TgpuBindGroupImpl } from '../../tgpuBindGroupLayout.ts';
 import type { LogGeneratorOptions } from '../../tgsl/consoleLog/types.ts';
-import type { ShaderGenerator } from '../../tgsl/shaderGenerator.ts';
+import type { WgslGeneratorClass } from '../../tgsl/shaderGenerator.ts';
 import { INTERNAL_createBuffer, type TgpuBuffer } from '../buffer/buffer.ts';
 import {
   isBufferBinding,
@@ -328,7 +328,7 @@ class TgpuRootImpl extends WithBindingImpl implements TgpuRoot, ExperimentalTgpu
   readonly [$soul]: TgpuRootSoul;
   readonly device: GPUDevice;
   readonly nameRegistrySetting: 'random' | 'strict';
-  readonly shaderGenerator: ShaderGenerator | undefined;
+  readonly shaderGeneratorClass: WgslGeneratorClass | undefined;
 
   #unwrappedBindGroupLayouts = new WeakMemo((key: TgpuBindGroupLayout) => key.unwrap(this));
   #unwrappedBindGroups = new WeakMemo((key: TgpuBindGroup) => key.unwrap(this));
@@ -343,14 +343,14 @@ class TgpuRootImpl extends WithBindingImpl implements TgpuRoot, ExperimentalTgpu
     nameRegistrySetting: 'random' | 'strict',
     ownDevice: boolean,
     logOptions: LogGeneratorOptions,
-    shaderGenerator?: ShaderGenerator,
+    shaderGeneratorClass?: WgslGeneratorClass,
   ) {
     super(() => this, []);
 
     this.device = device;
     this.nameRegistrySetting = nameRegistrySetting;
     this.#ownDevice = ownDevice;
-    this.shaderGenerator = shaderGenerator;
+    this.shaderGeneratorClass = shaderGeneratorClass;
 
     this['~unstable'] = this;
     this[$soul] = {
@@ -358,7 +358,7 @@ class TgpuRootImpl extends WithBindingImpl implements TgpuRoot, ExperimentalTgpu
       device,
       nameRegistrySetting,
       logOptions,
-      nonTransferablePriors: shaderGenerator ? ['shaderGenerator'] : undefined,
+      nonTransferablePriors: shaderGeneratorClass ? ['shaderGeneratorClass'] : undefined,
       label: undefined,
     };
     this[$internal] = {
@@ -587,7 +587,7 @@ export type InitOptions = {
    * A custom shader code generator, used when resolving TypeGPU functions.
    * If not provided, the default WGSL generator will be used.
    */
-  unstable_shaderGenerator?: ShaderGenerator | undefined;
+  unstable_shaderGeneratorClass?: WgslGeneratorClass | undefined;
   unstable_logOptions?: LogGeneratorOptions;
 };
 
@@ -602,7 +602,7 @@ export type InitFromDeviceOptions = {
    * A custom shader code generator, used when resolving TypeGPU functions.
    * If not provided, the default WGSL generator will be used.
    */
-  unstable_shaderGenerator?: ShaderGenerator | undefined;
+  unstable_shaderGeneratorClass?: WgslGeneratorClass | undefined;
   unstable_logOptions?: LogGeneratorOptions;
 };
 
@@ -630,7 +630,7 @@ export async function init(options?: InitOptions): Promise<TgpuRoot> {
     device: deviceOpt,
     unstable_names: names = 'strict',
     unstable_logOptions: logOptions,
-    unstable_shaderGenerator: shaderGenerator,
+    unstable_shaderGeneratorClass: shaderGeneratorClass,
   } = options ?? {};
 
   if (!navigator.gpu) {
@@ -666,7 +666,7 @@ export async function init(options?: InitOptions): Promise<TgpuRoot> {
     requiredFeatures: availableFeatures,
   });
 
-  return new TgpuRootImpl(device, names, true, logOptions ?? {}, shaderGenerator);
+  return new TgpuRootImpl(device, names, true, logOptions ?? {}, shaderGeneratorClass);
 }
 
 /**
@@ -683,8 +683,8 @@ export function initFromDevice(options: InitFromDeviceOptions): TgpuRoot {
     device,
     unstable_names: names = 'strict',
     unstable_logOptions: logOptions,
-    unstable_shaderGenerator: shaderGenerator,
+    unstable_shaderGeneratorClass: shaderGeneratorClass,
   } = options ?? {};
 
-  return new TgpuRootImpl(device, names, false, logOptions ?? {}, shaderGenerator);
+  return new TgpuRootImpl(device, names, false, logOptions ?? {}, shaderGeneratorClass);
 }

--- a/packages/typegpu/src/core/root/rootTypes.ts
+++ b/packages/typegpu/src/core/root/rootTypes.ts
@@ -23,7 +23,7 @@ import type {
   TgpuLayoutEntry,
 } from '../../tgpuBindGroupLayout.ts';
 import type { LogGeneratorOptions } from '../../tgsl/consoleLog/types.ts';
-import type { ShaderGenerator } from '../../tgsl/shaderGenerator.ts';
+import type { ShaderGeneratorClass } from '../../tgsl/shaderGenerator.ts';
 import type { Unwrapper } from '../../unwrapper.ts';
 import type { TgpuBuffer } from '../buffer/buffer.ts';
 import type { TgpuMutable, TgpuReadonly, TgpuUniform } from '../buffer/bufferBinding.ts';
@@ -729,7 +729,7 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
     | 'createTexture'
     | 'flush'
     | 'nameRegistrySetting'
-    | 'shaderGenerator'
+    | 'shaderGeneratorClass'
     | 'pipe'
     | 'with'
   >;
@@ -738,7 +738,7 @@ export interface TgpuRoot extends Unwrapper, WithBinding {
 export interface ExperimentalTgpuRoot
   extends Omit<TgpuRoot, 'with'>, Withable_Deprecated<WithBinding> {
   readonly nameRegistrySetting: 'strict' | 'random';
-  readonly shaderGenerator?: ShaderGenerator | undefined;
+  readonly shaderGeneratorClass?: ShaderGeneratorClass | undefined;
 
   /** @deprecated Use `root.createTexture` instead. */
   createTexture<

--- a/packages/typegpu/src/core/simulate/tgpuSimulate.ts
+++ b/packages/typegpu/src/core/simulate/tgpuSimulate.ts
@@ -1,7 +1,6 @@
 import type { BaseData } from '../../data/wgslTypes.ts';
 import { getResolutionCtx, provideCtx } from '../../execMode.ts';
 import { ResolutionCtxImpl } from '../../resolutionCtx.ts';
-import wgslGenerator from '../../tgsl/wgslGenerator.ts';
 import { SimulationState } from '../../types.ts';
 import type { TgpuBuffer } from '../buffer/buffer.ts';
 import { namespace } from '../resolve/namespace.ts';
@@ -46,7 +45,6 @@ export function simulate<T>(callback: () => T): SimulationResult<T> {
     new ResolutionCtxImpl({
       // Not relevant
       namespace: namespace(),
-      shaderGenerator: wgslGenerator,
     });
 
   // Statically locked to one "thread" for now

--- a/packages/typegpu/src/internal.ts
+++ b/packages/typegpu/src/internal.ts
@@ -15,6 +15,7 @@ export type { Snippet, ResolvedSnippet, Origin } from './data/snippet.ts';
 
 export type {
   ShaderGenerator,
+  ShaderGeneratorClass,
   FunctionDefinitionOptions,
   ConstantDefinitionOptions,
   VariableDefinitionOptions,

--- a/packages/typegpu/src/resolutionCtx.ts
+++ b/packages/typegpu/src/resolutionCtx.ts
@@ -39,7 +39,7 @@ import type { LogGenerator, LogResources, SupportedLogOp } from './tgsl/consoleL
 import { getBestConversion } from './tgsl/conversion.ts';
 import { coerceToSnippet, concretize, numericLiteralToSnippet } from './tgsl/generationHelpers.ts';
 import type { ShaderGenerator } from './tgsl/shaderGenerator.ts';
-import wgslGenerator from './tgsl/wgslGenerator.ts';
+import { WgslGenerator } from './tgsl/wgslGenerator.ts';
 import type {
   BlockScopeLayer,
   ExecMode,
@@ -447,9 +447,10 @@ export class ResolutionCtxImpl implements ResolutionCtx {
 
   constructor(opts: ResolutionCtxImplOptions) {
     this.enableExtensions = opts.enableExtensions;
-    this.gen = opts.shaderGenerator ?? wgslGenerator;
     this.#logGenerator = opts.root ? new LogGeneratorImpl(opts.root) : new LogGeneratorNullImpl();
     this.#namespaceInternal = opts.namespace[$internal];
+    this.gen = opts.shaderGenerator ?? new WgslGenerator();
+    this.gen.initGenerator(this);
   }
 
   isIdentifierBanned(name: string): boolean {
@@ -1025,7 +1026,6 @@ export class ResolutionCtxImpl implements ResolutionCtx {
     if (isMarkedInternal(item) || hasTinyestMetadata(item)) {
       // Top-level resolve
       if (this._itemStateStack.itemDepth === 0) {
-        this.gen.initGenerator(this);
         try {
           this.pushMode(new CodegenState());
           const result = provideCtx(this, () => this._getOrInstantiate(item));

--- a/packages/typegpu/src/shared/normalizeMetadata.ts
+++ b/packages/typegpu/src/shared/normalizeMetadata.ts
@@ -32,7 +32,7 @@ export interface Metadata {
 
 /**
  * The values of ExternalsV2 are zero-argument functions for accessing the value.
- * Since they would be recognized by the wgslGenerator as regular, non 'use gpu' functions,
+ * Since they would be recognized by the WgslGenerator as regular, non 'use gpu' functions,
  * we turn them into getters.
  *
  * @example

--- a/packages/typegpu/src/tgsl/shaderGenerator.ts
+++ b/packages/typegpu/src/tgsl/shaderGenerator.ts
@@ -37,6 +37,20 @@ export interface VariableDefinitionOptions {
 /**
  * **NOTE: This is an unstable API and may change in the future.**
  *
+ * Used to instantiate generators, once per resolution context
+ */
+export interface ShaderGeneratorClass<T extends ShaderGenerator = ShaderGenerator> {
+  new (): T;
+}
+
+/**
+ * Represents generators that, once instantiated, will generate `wgsl` (as opposed to e.g. `glsl`)
+ */
+export type WgslGeneratorClass = ShaderGeneratorClass<ShaderGenerator & { languageKey: 'wgsl' }>;
+
+/**
+ * **NOTE: This is an unstable API and may change in the future.**
+ *
  * An interface meant to be used by other systems to generate snippets of
  * shader code in the target language (WGSL, GLSL, etc.).
  */

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -221,6 +221,11 @@ export class WgslGenerator implements ShaderGenerator {
   }
 
   public initGenerator(ctx: ResolutionCtx) {
+    if (this.#ctx !== undefined) {
+      throw new Error(
+        `Cannot initialize shader generators twice. Create one generator per resolution.`,
+      );
+    }
     this.#ctx = ctx;
   }
 
@@ -1673,6 +1678,3 @@ function extractObject(expr: tinyest.Expression): string | undefined {
     return object;
   }
 }
-
-const wgslGenerator: WgslGenerator = new WgslGenerator();
-export default wgslGenerator;

--- a/packages/typegpu/tests/tgsl/consoleLog.test.ts
+++ b/packages/typegpu/tests/tgsl/consoleLog.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, vi } from 'vitest';
 import { it } from 'typegpu-testing-utility';
 import { tgpu, d } from 'typegpu';
 
-describe('wgslGenerator with console.log', () => {
+describe('WgslGenerator with console.log', () => {
   it('Parses console.log in a stray function to a comment and warns', () => {
     using consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/packages/typegpu/tests/tgsl/infixOperators.test.ts
+++ b/packages/typegpu/tests/tgsl/infixOperators.test.ts
@@ -2,7 +2,7 @@ import { describe, expect } from 'vitest';
 import { tgpu, d } from 'typegpu';
 import { it } from 'typegpu-testing-utility';
 
-describe('wgslGenerator', () => {
+describe('WgslGenerator', () => {
   it('resolves add infix operator in comptime', () => {
     const testFn = tgpu.fn([])(() => {
       const v1 = d.vec4f().add(1);

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -7,7 +7,7 @@ const numberSlot = tgpu.slot(44);
 const lazyV4u = tgpu.lazy(() => d.vec4u(1, 2, 3, 4).mul(numberSlot.$));
 const lazyV2f = tgpu.lazy(() => d.vec2f(1, 2).mul(numberSlot.$));
 
-describe('wgslGenerator', () => {
+describe('WgslGenerator', () => {
   it('creates a simple return statement', () => {
     const main = () => {
       'use gpu';


### PR DESCRIPTION
The main idea behind this change is to create a generator per resolution pass (tgpu.resolve call, root.unwrap(pipeline), ...). This makes it very easy to not have to think about nested resolves (which we want to support because of @typegpu/three)