### PR TITLE
feat: std.getShaderStage

### DIFF
--- a/apps/typegpu-docs/src/content/docs/apis/utils.mdx
+++ b/apps/typegpu-docs/src/content/docs/apis/utils.mdx
@@ -108,11 +108,13 @@ Use an `if` statement for those cases.
 
 ## Resolution environment
 
-TypeGPU exposes two standard-library probes for code that needs to adapt to its execution environment:
+TypeGPU exposes standard-library probes for code that needs to adapt to its execution environment:
 
 - `std.isBeingTranspiled()` tells a direct `'use gpu'` callee whether it is currently being transpiled.
 - `std.getTargetShaderLanguage()` returns the name of the shader language being generated (usually `'wgsl'`)
   if it's called during shader generation, and `undefined` otherwise.
+- `std.getShaderStage()` returns `'vertex'`, `'fragment'` or `'compute'` when the function was transitively
+  used in a vertex, fragment or compute entry function respectively, `undefined` otherwise.
 
 ```ts twoslash
 import { tgpu, d, std } from 'typegpu';
@@ -126,7 +128,7 @@ implementation(); // 0 during normal JavaScript execution
 // The resolved WGSL function returns 1.
 ```
 
-Their behavior in each environment is:
+The first two can be harder to understand. Their behavior in each environment is:
 
 | Environment | `isBeingTranspiled()` | `getTargetShaderLanguage()` |
 | --- | --- | --- |

--- a/packages/typegpu-gl/src/glslGenerator.ts
+++ b/packages/typegpu-gl/src/glslGenerator.ts
@@ -1,12 +1,11 @@
 import { NodeTypeCatalog as NODE } from 'tinyest';
 import type { Return } from 'tinyest';
-import { tgpu, d } from 'typegpu';
+import { tgpu, d, type ShaderStage } from 'typegpu';
 import {
   WgslGenerator,
   UnknownData,
   getName,
   type ResolutionCtx,
-  type TgpuShaderStage,
   type FunctionDefinitionOptions,
   type Snippet,
   snip,
@@ -98,7 +97,7 @@ interface EntryFnState {
  * and overrides variable declaration emission to use `type name = rhs` syntax.
  */
 export class GlslGenerator extends WgslGenerator {
-  #functionType: TgpuShaderStage | 'normal' | undefined;
+  #functionType: ShaderStage | 'normal' | undefined;
   #entryFnState: EntryFnState | undefined;
 
   static {

--- a/packages/typegpu/src/core/function/fnCore.ts
+++ b/packages/typegpu/src/core/function/fnCore.ts
@@ -5,7 +5,7 @@ import { type BaseData, isWgslData, isWgslStruct, Void } from '../../data/wgslTy
 import { validateIdentifier } from '../../nameUtils.ts';
 import { getFunctionMetadata, getName } from '../../shared/meta.ts';
 import { $getNameForward } from '../../shared/symbols.ts';
-import type { ResolutionCtx, TgpuShaderStage } from '../../types.ts';
+import type { ResolutionCtx, ShaderStage } from '../../types.ts';
 import {
   type ExternalMap,
   replaceExternalsInWgsl,
@@ -59,7 +59,7 @@ export interface FnCore {
 
 export function createFnCore(
   implementation: Implementation,
-  functionType: 'normal' | TgpuShaderStage,
+  functionType: 'normal' | ShaderStage,
   workgroupSize?: number[],
 ): FnCore {
   /**

--- a/packages/typegpu/src/core/slot/internalSlots.ts
+++ b/packages/typegpu/src/core/slot/internalSlots.ts
@@ -1,4 +1,4 @@
 import type { ShaderStage } from '../../types.ts';
 import { slot } from './slot.ts';
 
-export const shaderStageSlot = slot<ShaderStage>(undefined);
+export const shaderStageSlot = slot<ShaderStage | null>(null);

--- a/packages/typegpu/src/indexNamedExports.ts
+++ b/packages/typegpu/src/indexNamedExports.ts
@@ -50,7 +50,7 @@ export { warn } from './tgpuLogger.ts';
 
 // types
 
-export type { ResolvableObject } from './types.ts';
+export type { ResolvableObject, ShaderStage } from './types.ts';
 export type { ResolvedDeclaration } from './resolutionCtx.ts';
 export type {
   Configurable,

--- a/packages/typegpu/src/internal.ts
+++ b/packages/typegpu/src/internal.ts
@@ -24,7 +24,7 @@ export {
 } from './serial/schema.ts';
 
 // types
-export type { ResolutionCtx, FunctionArgument, TgpuShaderStage } from './types.ts';
+export type { ResolutionCtx, FunctionArgument } from './types.ts';
 export type { Snippet, ResolvedSnippet, Origin } from './data/snippet.ts';
 
 export type {

--- a/packages/typegpu/src/resolutionCtx.ts
+++ b/packages/typegpu/src/resolutionCtx.ts
@@ -51,7 +51,7 @@ import type {
   ItemStateStack,
   ResolutionCtx,
   StackLayer,
-  TgpuShaderStage,
+  ShaderStage,
   Wgsl,
 } from './types.ts';
 import { CodegenState, isSelfResolvable, NormalState, type FunctionArgument } from './types.ts';
@@ -128,7 +128,7 @@ class ItemStateStackImpl implements ItemStateStack {
   }
 
   pushFunctionScope(
-    functionType: 'normal' | TgpuShaderStage,
+    functionType: 'normal' | ShaderStage,
     argAccess: Record<string, FunctionArgumentAccess>,
     returnType: BaseData | undefined,
     externalMap: Record<string, unknown>,

--- a/packages/typegpu/src/std/environment.ts
+++ b/packages/typegpu/src/std/environment.ts
@@ -1,8 +1,9 @@
 import { comptime } from '../core/function/comptime.ts';
+import { shaderStageSlot } from '../core/slot/internalSlots.ts';
 import { getExecMode, getResolutionCtx } from '../execMode.ts';
 import { $gpuCallable } from '../shared/symbols.ts';
 import { coerceToSnippet } from '../tgsl/generationHelpers.ts';
-import type { DualFn } from '../types.ts';
+import type { DualFn, ShaderStage } from '../types.ts';
 
 const impl = (() => false) as DualFn<() => boolean>;
 impl.toString = () => 'isBeingTranspiled';
@@ -61,3 +62,21 @@ export const getTargetShaderLanguage = comptime((() => {
   }
   return getExecMode().type !== 'simulate' ? ctx.gen.languageKey : undefined;
 }) as () => string | undefined);
+
+/**
+ * Can be used to change behavior based on which shader stage the code is being
+ * used in. If used in a 'use gpu' function, its definition will be duplicated
+ * for each shader stage.
+ *
+ * @note
+ * When called outside of shader resolution, or when the shader stage cannot be
+ * determined, `undefined` is returned.
+ */
+export const getShaderStage = comptime((): ShaderStage | undefined => {
+  const ctx = getResolutionCtx();
+  if (!ctx) {
+    // Called outside of resolution
+    return undefined;
+  }
+  return shaderStageSlot.$ ?? undefined;
+});

--- a/packages/typegpu/src/std/index.ts
+++ b/packages/typegpu/src/std/index.ts
@@ -190,4 +190,4 @@ export { bitcastU32toF32, bitcastU32toI32, bitcastF32toU32, bitcast } from './bi
 
 export { range } from './range.ts';
 
-export { isBeingTranspiled, getTargetShaderLanguage } from './environment.ts';
+export { isBeingTranspiled, getTargetShaderLanguage, getShaderStage } from './environment.ts';

--- a/packages/typegpu/src/tgpuBindGroupLayout.ts
+++ b/packages/typegpu/src/tgpuBindGroupLayout.ts
@@ -42,7 +42,7 @@ import { safeStringify } from './shared/stringify.ts';
 import type { TgpuDeviceOwningSoul, TgpuSoul } from './shared/soul.ts';
 import { $gpuValueOf, $internal, $soul } from './shared/symbols.ts';
 import type { NullableToOptional, Prettify } from './shared/utilityTypes.ts';
-import type { ResolvableObject, TgpuShaderStage } from './types.ts';
+import type { ResolvableObject, ShaderStage } from './types.ts';
 import type { Unwrapper } from './unwrapper.ts';
 import type { WgslComparisonSampler, WgslSampler } from './data/sampler.ts';
 import { TgpuLaidOutBufferImpl } from './core/buffer/laidOutBuffer.ts';
@@ -76,7 +76,7 @@ export type TgpuLayoutEntryBase = {
    * @default ['compute','fragment'] for mutable resources
    * @default ['compute','vertex','fragment'] for everything else
    */
-  visibility?: TgpuShaderStage[];
+  visibility?: ShaderStage[];
 };
 
 export type TgpuLayoutUniform = TgpuLayoutEntryBase & {
@@ -301,8 +301,8 @@ export class MissingBindingError extends Error {
 // Implementation
 // --------------
 
-const DEFAULT_MUTABLE_VISIBILITY: TgpuShaderStage[] = ['compute', 'fragment'];
-const DEFAULT_READONLY_VISIBILITY: TgpuShaderStage[] = ['compute', 'vertex', 'fragment'];
+const DEFAULT_MUTABLE_VISIBILITY: ShaderStage[] = ['compute', 'fragment'];
+const DEFAULT_READONLY_VISIBILITY: ShaderStage[] = ['compute', 'vertex', 'fragment'];
 
 class TgpuBindGroupLayoutImpl<
   Entries extends Record<string, TgpuLayoutEntry | null>,

--- a/packages/typegpu/src/tgsl/shaderGenerator.ts
+++ b/packages/typegpu/src/tgsl/shaderGenerator.ts
@@ -6,11 +6,11 @@ import type {
   BindableBufferUsage,
   FunctionArgument,
   ResolutionCtx,
-  TgpuShaderStage,
+  ShaderStage,
 } from '../types.ts';
 
 export interface FunctionDefinitionOptions {
-  readonly functionType: 'normal' | TgpuShaderStage;
+  readonly functionType: 'normal' | ShaderStage;
   readonly name: string;
   readonly workgroupSize?: readonly number[] | undefined;
   readonly args: readonly FunctionArgument[];

--- a/packages/typegpu/src/types.ts
+++ b/packages/typegpu/src/types.ts
@@ -74,10 +74,10 @@ export type ResolvableObject =
 
 export type Wgsl = Eventual<number | boolean | ResolvableObject>;
 
-export type TgpuShaderStage = 'compute' | 'vertex' | 'fragment';
+export type ShaderStage = 'compute' | 'vertex' | 'fragment';
 
 export interface ResolveFunctionOptions {
-  functionType: 'normal' | TgpuShaderStage;
+  functionType: 'normal' | ShaderStage;
   workgroupSize?: readonly number[] | undefined;
   name: string;
   argTypes: BaseData[];
@@ -157,7 +157,7 @@ export interface ItemStateStack {
   pushItem(): void;
   pushSlotBindings(pairs: SlotValuePair[]): void;
   pushFunctionScope(
-    functionType: 'normal' | TgpuShaderStage,
+    functionType: 'normal' | ShaderStage,
     argAccess: Record<string, FunctionArgumentAccess>,
     /**
      * The return type of the function. If undefined, the type should be inferred
@@ -261,8 +261,6 @@ export class SimulationState {
 }
 
 export type ExecState = NormalState | CodegenState | SimulationState;
-
-export type ShaderStage = 'vertex' | 'fragment' | 'compute' | undefined;
 
 /**
  * Passed into each resolvable item. All items in a tree share a resolution ctx,

--- a/packages/typegpu/tests/std/environment.test.ts
+++ b/packages/typegpu/tests/std/environment.test.ts
@@ -1,7 +1,7 @@
 import { it } from 'typegpu-testing-utility';
-import { expect, describe } from 'vitest';
+import { expect, describe, expectTypeOf } from 'vitest';
 
-import { tgpu, d, std } from 'typegpu';
+import { tgpu, d, std, type ShaderStage } from 'typegpu';
 
 describe('isBeingTranspiled', () => {
   it('returns false top level', () => {
@@ -168,5 +168,105 @@ describe('getTargetShaderLanguage', () => {
     };
 
     expect(f()).toBe(-7);
+  });
+});
+
+describe('getShaderStage', () => {
+  it('returns undefined top level', () => {
+    expect(std.getShaderStage()).toBe(undefined);
+    expectTypeOf(std.getShaderStage()).toEqualTypeOf<ShaderStage | undefined>();
+  });
+
+  it('returns undefined during normal function resolution', () => {
+    const f = () => {
+      'use gpu';
+      return std.getShaderStage() === undefined ? 1 : -1;
+    };
+
+    expect(tgpu.resolve([f])).toMatchInlineSnapshot(`
+      "fn f() -> i32 {
+        return 1;
+      }"
+    `);
+  });
+
+  it('returns the entry point stage transitively and duplicates shared functions per stage', () => {
+    const stageValue = () => {
+      'use gpu';
+      if (std.getShaderStage() === 'vertex') {
+        return 1;
+      }
+      if (std.getShaderStage() === 'fragment') {
+        return 2;
+      }
+      if (std.getShaderStage() === 'compute') {
+        return 3;
+      }
+      return 0;
+    };
+
+    const vertex = tgpu.vertexFn({
+      out: { position: d.builtin.position },
+    })(() => ({ position: d.vec4f(stageValue()) }));
+
+    const fragment = tgpu.fragmentFn({ out: d.vec4f })(() => d.vec4f(stageValue()));
+
+    const compute = tgpu.computeFn({ workgroupSize: [1] })(() => {
+      const value = stageValue();
+    });
+
+    expect(tgpu.resolve([vertex, fragment, compute])).toMatchInlineSnapshot(`
+      "fn stageValue() -> i32 {
+        {
+          return 1;
+        }
+        return 0;
+      }
+
+      struct vertex_Output {
+        @builtin(position) position: vec4f,
+      }
+
+      @vertex fn vertex() -> vertex_Output {
+        return vertex_Output(vec4f(f32(stageValue())));
+      }
+
+      fn stageValue_1() -> i32 {
+        {
+          return 2;
+        }
+        return 0;
+      }
+
+      @fragment fn fragment() -> @location(0) vec4f {
+        return vec4f(f32(stageValue_1()));
+      }
+
+      fn stageValue_2() -> i32 {
+        {
+          return 3;
+        }
+        return 0;
+      }
+
+      @compute @workgroup_size(1) fn compute() {
+        let value = stageValue_2();
+      }"
+    `);
+  });
+
+  it('returns undefined during JS execution', () => {
+    const f = () => {
+      'use gpu';
+      return std.getShaderStage();
+    };
+
+    expect(f()).toBe(undefined);
+  });
+
+  it('returns undefined inside simulate', () => {
+    const result = tgpu['~unstable'].simulate(() => std.getShaderStage());
+
+    expect(result.value).toBe(undefined);
   });
 });


### PR DESCRIPTION
I additionally merged our `ShaderStage` and `TgpuShaderStage` into one type, then exported it from `typegpu` instead of `typegpu/~internal`.