### PR TITLE
feat: Support default parameter values in TGSL functions

### DIFF
--- a/packages/eslint-plugin/src/rules/noUnsupportedSyntax.ts
+++ b/packages/eslint-plugin/src/rules/noUnsupportedSyntax.ts
@@ -49,7 +49,16 @@ export const noUnsupportedSyntax = createRule({
         if (!directives.getEnclosingTypegpuFunction()) {
           return;
         }
-        report(node, 'assignment pattern (default parameter)');
+        // Default values for plain identifier parameters are supported;
+        // defaults inside destructuring patterns are not.
+        const isDefaultedIdentifierParam =
+          (node.parent.type === 'ArrowFunctionExpression' ||
+            node.parent.type === 'FunctionExpression' ||
+            node.parent.type === 'FunctionDeclaration') &&
+          node.left.type === 'Identifier';
+        if (!isDefaultedIdentifierParam) {
+          report(node, 'assignment pattern (destructuring default)');
+        }
       },
 
       AwaitExpression(node) {

--- a/packages/eslint-plugin/tests/rules/noUnsupportedSyntax.test.ts
+++ b/packages/eslint-plugin/tests/rules/noUnsupportedSyntax.test.ts
@@ -9,6 +9,9 @@ describe('noUnsupportedSyntax', () => {
       "const fn = () => { 'use gpu'; const x = Struct({ prop: 1}); }",
       "const fn = () => { 'use gpu'; let x = 1; }",
       "const cls = new (class { #priv = 1; fn = () => { 'use gpu'; const a = this.#priv; } } )()",
+      "const fn = (arg = 1) => { 'use gpu'; }",
+      "function fn(arg = 1) { 'use gpu'; }",
+      "const fn = function(arg = 1) { 'use gpu'; }",
     ],
     invalid: [
       {
@@ -42,29 +45,27 @@ describe('noUnsupportedSyntax', () => {
         ],
       },
       {
-        code: "const fn = (arg = 1) => { 'use gpu'; }",
+        code: "const fn = ({ arg = 1 }) => { 'use gpu'; }",
         errors: [
           {
             messageId: 'unexpected',
-            data: { snippet: 'arg = 1', syntax: 'assignment pattern (default parameter)' },
+            data: { snippet: 'arg = 1', syntax: 'assignment pattern (destructuring default)' },
           },
         ],
       },
       {
-        code: "function fn(arg = 1) { 'use gpu'; }",
+        code: "const fn = () => { 'use gpu'; const { a = 1 } = foo; }",
         errors: [
           {
             messageId: 'unexpected',
-            data: { snippet: 'arg = 1', syntax: 'assignment pattern (default parameter)' },
+            data: {
+              snippet: '{ a = 1 } = foo',
+              syntax: 'variable declaration using destructuring',
+            },
           },
-        ],
-      },
-      {
-        code: "const fn = function(arg = 1) { 'use gpu'; }",
-        errors: [
           {
             messageId: 'unexpected',
-            data: { snippet: 'arg = 1', syntax: 'assignment pattern (default parameter)' },
+            data: { snippet: 'a = 1', syntax: 'assignment pattern (destructuring default)' },
           },
         ],
       },

--- a/packages/tinyest-for-wgsl/src/parsers.ts
+++ b/packages/tinyest-for-wgsl/src/parsers.ts
@@ -312,6 +312,12 @@ function transpile(ctx: Context, node: JsNode): tinyest.AnyNode {
 
 export function extractFunctionParts(rootNode: JsNode): {
   params: tinyest.FuncParameter[];
+  /**
+   * Raw default value expressions (`(a, b = 2) => ...`), aligned by index
+   * with `params`. Transpiled and attached to the params by `transpileFn`,
+   * which owns the transpilation context.
+   */
+  paramDefaults: (babel.Expression | acorn.Expression | undefined)[];
   body: acorn.BlockStatement | acorn.Expression | babel.BlockStatement | babel.Expression;
 } {
   let functionNode:
@@ -372,22 +378,28 @@ export function extractFunctionParts(rootNode: JsNode): {
 
   const unsupportedTypes = new Set(
     functionNode.params.flatMap((param) =>
-      param.type === 'ObjectPattern' || param.type === 'Identifier' ? [] : [param.type],
+      param.type === 'ObjectPattern' ||
+      param.type === 'Identifier' ||
+      (param.type === 'AssignmentPattern' && param.left.type === 'Identifier')
+        ? []
+        : [param.type],
     ),
   );
   if (unsupportedTypes.size > 0) {
     throw new Error(`Unsupported function parameter type(s): ${[...unsupportedTypes].join(', ')}`);
   }
 
+  const params = functionNode.params as (
+    | babel.Identifier
+    | acorn.Identifier
+    | babel.ObjectPattern
+    | acorn.ObjectPattern
+    | babel.AssignmentPattern
+    | acorn.AssignmentPattern
+  )[];
+
   return {
-    params: (
-      functionNode.params as (
-        | babel.Identifier
-        | acorn.Identifier
-        | babel.ObjectPattern
-        | acorn.ObjectPattern
-      )[]
-    ).map((param) =>
+    params: params.map((param) =>
       param.type === 'ObjectPattern'
         ? {
             type: FuncParameterType.destructuredObject,
@@ -401,15 +413,23 @@ export function extractFunctionParts(rootNode: JsNode): {
           }
         : {
             type: FuncParameterType.identifier,
-            name: param.name,
+            name:
+              param.type === 'AssignmentPattern'
+                ? (param.left as babel.Identifier | acorn.Identifier).name
+                : param.name,
           },
+    ),
+    paramDefaults: params.map((param) =>
+      param.type === 'AssignmentPattern'
+        ? (param.right as babel.Expression | acorn.Expression)
+        : undefined,
     ),
     body: functionNode.body,
   };
 }
 
 export function transpileFn(rootNode: JsNode): TranspilationResult {
-  const { params, body } = extractFunctionParts(rootNode);
+  const { params, paramDefaults, body } = extractFunctionParts(rootNode);
 
   const ctx: Context = {
     externalNames: new Map(),
@@ -425,6 +445,15 @@ export function transpileFn(rootNode: JsNode): TranspilationResult {
       },
     ],
   };
+
+  // Transpiled with the param names already declared, so identifiers used in
+  // a default value only count as externals when they're not other params.
+  for (const [i, defaultNode] of paramDefaults.entries()) {
+    const param = params[i];
+    if (defaultNode && param?.type === FuncParameterType.identifier) {
+      param.default = transpile(ctx, defaultNode) as tinyest.Expression;
+    }
+  }
 
   const tinyestBody = transpile(ctx, body);
 

--- a/packages/tinyest-for-wgsl/tests/parsers.test.ts
+++ b/packages/tinyest-for-wgsl/tests/parsers.test.ts
@@ -81,6 +81,41 @@ describe('transpileFn', () => {
   );
 
   it(
+    'supports default parameter values',
+    dualTest((p) => {
+      const { params, body, externalNames } = transpileFn(p('(a, b = 2, c = e) => a + b + c'));
+
+      expect(params).toStrictEqual([
+        { type: 'i', name: 'a' },
+        { type: 'i', name: 'b', default: [5, '2'] },
+        { type: 'i', name: 'c', default: 'e' },
+      ]);
+      expect(JSON.stringify(body)).toMatchInlineSnapshot(
+        `"[0,[[10,[1,[1,"a","+","b"],"+","c"]]]]"`,
+      );
+      // 'e' is external, even though it only appears in a default value.
+      expect(externalNames).toMatchInlineSnapshot(`
+        Map {
+          "e" => "e",
+        }
+      `);
+    }),
+  );
+
+  it(
+    'does not treat params referenced in default values as external names',
+    dualTest((p) => {
+      const { params, externalNames } = transpileFn(p('(a, b = a) => a + b'));
+
+      expect(params).toStrictEqual([
+        { type: 'i', name: 'a' },
+        { type: 'i', name: 'b', default: 'a' },
+      ]);
+      expect(externalNames).toMatchInlineSnapshot(`Map {}`);
+    }),
+  );
+
+  it(
     'respects local declarations when gathering external names',
     dualTest((p) => {
       const { params, body, externalNames } = transpileFn(

--- a/packages/tinyest/src/nodes.ts
+++ b/packages/tinyest/src/nodes.ts
@@ -267,6 +267,11 @@ export type FuncParameter =
   | {
       type: typeof FuncParameterType.identifier;
       name: string;
+      /**
+       * The parameter's default value expression (`(a, b = 2) => ...`),
+       * used when a call site omits the argument.
+       */
+      default?: Expression | undefined;
     }
   | {
       type: typeof FuncParameterType.destructuredObject;

--- a/packages/typegpu/src/resolutionCtx.ts
+++ b/packages/typegpu/src/resolutionCtx.ts
@@ -57,7 +57,7 @@ import type {
 import { CodegenState, isSelfResolvable, NormalState, type FunctionArgument } from './types.ts';
 import type { WgslEnableExtension } from './wgslExtensions.ts';
 import { getName, hasTinyestMetadata, isNamable, setName } from './shared/meta.ts';
-import { FuncParameterType } from 'tinyest';
+import { FuncParameterType, NodeTypeCatalog, type Block, type Statement } from 'tinyest';
 import { accessProp } from './tgsl/accessProp.ts';
 import { createIoSchema } from './core/function/ioSchema.ts';
 import { isShelllessImpl } from './core/function/shelllessImpl.ts';
@@ -716,6 +716,22 @@ export class ResolutionCtxImpl implements ResolutionCtx {
         }
       }
 
+      // Parameters beyond the call site's arguments fall back to their
+      // default value expressions (`(a, b = 2) => ...`), prepended to the
+      // body as const statements so they generate in the function's scope.
+      let body = options.body;
+      if (!options.entryInput) {
+        const defaultStatements: Statement[] = [];
+        for (const param of options.params.slice(options.argTypes.length)) {
+          if (param.type === FuncParameterType.identifier && param.default !== undefined) {
+            defaultStatements.push([NodeTypeCatalog.const, param.name, param.default]);
+          }
+        }
+        if (defaultStatements.length > 0) {
+          body = [NodeTypeCatalog.block, [...defaultStatements, ...body[1]]] as Block;
+        }
+      }
+
       let returnType: BaseData | undefined;
 
       const code = this.gen.functionDefinition({
@@ -723,7 +739,7 @@ export class ResolutionCtxImpl implements ResolutionCtx {
         name: options.name,
         workgroupSize: options.workgroupSize,
         args,
-        body: options.body,
+        body,
         determineReturnType: () => {
           if (returnType) {
             // Already determined

--- a/packages/typegpu/tests/tgsl/shellless.test.ts
+++ b/packages/typegpu/tests/tgsl/shellless.test.ts
@@ -511,4 +511,113 @@ describe('shellless', () => {
       Remember, that arguments such as samplers, texture views, accessors, slots etc. should be dereferenced via '.$' first.]
     `);
   });
+
+  it('falls back to default parameter values when arguments are omitted', () => {
+    const scale = (v: d.v2f, factor: number = 2) => {
+      'use gpu';
+      return std.mul(v, d.f32(factor));
+    };
+
+    const foo = () => {
+      'use gpu';
+      return std.add(scale(d.vec2f(1, 2)), scale(d.vec2f(3, 4), 0.5));
+    };
+
+    expect(tgpu.resolve([foo])).toMatchInlineSnapshot(`
+      "fn scale(v: vec2f) -> vec2f {
+        const factor = 2;
+        return (v * f32(factor));
+      }
+
+      fn scale_1(v: vec2f, factor: f32) -> vec2f {
+        return (v * factor);
+      }
+
+      fn foo() -> vec2f {
+        return (scale(vec2f(1, 2)) + scale_1(vec2f(3, 4), 0.5f));
+      }"
+    `);
+  });
+
+  it('supports comptime-style mode flags with default values', () => {
+    const interpolate = (t: number, cyclic: boolean = false) => {
+      'use gpu';
+      if (cyclic) {
+        return std.fract(t);
+      }
+      return std.clamp(t, 0, 1);
+    };
+
+    const foo = () => {
+      'use gpu';
+      return interpolate(1.5) + interpolate(2.5, true);
+    };
+
+    expect(tgpu.resolve([foo])).toMatchInlineSnapshot(`
+      "fn interpolate(t: f32) -> f32 {
+        const cyclic = false;
+        if (cyclic) {
+          return fract(t);
+        }
+        return clamp(t, 0f, 1f);
+      }
+
+      fn interpolate_1(t: f32, cyclic: bool) -> f32 {
+        if (cyclic) {
+          return fract(t);
+        }
+        return clamp(t, 0f, 1f);
+      }
+
+      fn foo() -> f32 {
+        return (interpolate(1.5f) + interpolate_1(2.5f, true));
+      }"
+    `);
+  });
+
+  it('evaluates default values referencing earlier parameters', () => {
+    const madd = (a: d.v2f, b: d.v2f = a) => {
+      'use gpu';
+      return std.add(a, b);
+    };
+
+    const foo = () => {
+      'use gpu';
+      return madd(d.vec2f(1, 2));
+    };
+
+    expect(tgpu.resolve([foo])).toMatchInlineSnapshot(`
+      "fn madd(a: vec2f) -> vec2f {
+        let b = a;
+        return (a + b);
+      }
+
+      fn foo() -> vec2f {
+        return madd(vec2f(1, 2));
+      }"
+    `);
+  });
+
+  it('falls back to default parameter values in shelled functions', () => {
+    const addBias = tgpu.fn(
+      [d.f32],
+      d.f32,
+    )((x, bias: number = 10) => {
+      'use gpu';
+      return x + d.f32(bias);
+    });
+
+    const main = tgpu.fn([], d.f32)(() => addBias(1));
+
+    expect(tgpu.resolve([main])).toMatchInlineSnapshot(`
+      "fn addBias(x: f32) -> f32 {
+        const bias = 10;
+        return (x + f32(bias));
+      }
+
+      fn main() -> f32 {
+        return addBias(1f);
+      }"
+    `);
+  });
 });


### PR DESCRIPTION
Allows 'use gpu' functions to declare defaulted identifier parameters, e.g. (t: number, cyclic = false) => ...

- tinyest: FuncParameter identifier variant carries an optional default Expression.
- tinyest-for-wgsl: AssignmentPattern params (with an Identifier target) transpile their default expression; identifiers used only in defaults are gathered as externals, other params are not.
- typegpu: when a call site provides fewer arguments than declared params, the trailing defaults are prepended to the function body as const statements, so each arity resolves to its own concrete overload.
- eslint-plugin: no-unsupported-syntax no longer flags defaulted identifier params, still flags destructuring defaults.