### PR TITLE
Add JSON-LD and llms.txt for AI search

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -42,6 +42,19 @@ jobs:
       - name: Build all
         run: pnpm -r build
 
+      - name: Check docs llms.txt
+        run: |
+          file=apps/typegpu-docs/dist/llms.txt
+          if [ ! -s "$file" ]; then
+            echo "::error::$file is missing or empty"
+            exit 1
+          fi
+          count=$(grep -cE '^- \[[^]]+\]\(https://docs\.swmansion\.com/TypeGPU/[^)]+\)' "$file" || true)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::$file lists no pages"
+            exit 1
+          fi
+          echo "llms.txt lists $count pages"
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/apps/typegpu-docs/astro.config.mjs
+++ b/apps/typegpu-docs/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 
 import react from '@astrojs/react';
+import swmGeo, { structuredData } from './swm-geo.mjs';
 import sitemap from '@astrojs/sitemap';
 import starlight from '@astrojs/starlight';
 import tailwindVite from '@tailwindcss/vite';
@@ -71,7 +72,11 @@ export default defineConfig({
     },
   },
   integrations: [
+    swmGeo({ name: 'TypeGPU', description: 'Type-safe WebGPU toolkit', repository: 'TypeGPU' }),
     starlight({
+      head: [
+        { tag: 'script', attrs: { type: 'application/ld+json' }, content: JSON.stringify(structuredData({ name: 'TypeGPU', description: 'Type-safe WebGPU toolkit', repository: 'TypeGPU' })) },
+      ],
       title: 'TypeGPU',
       customCss: ['./src/tailwind.css', './src/fonts/font-face.css', './src/mathjax.css'],
       plugins: stripFalsy([

--- a/apps/typegpu-docs/astro.config.mjs
+++ b/apps/typegpu-docs/astro.config.mjs
@@ -75,7 +75,17 @@ export default defineConfig({
     swmGeo({ name: 'TypeGPU', description: 'Type-safe WebGPU toolkit', repository: 'TypeGPU' }),
     starlight({
       head: [
-        { tag: 'script', attrs: { type: 'application/ld+json' }, content: JSON.stringify(structuredData({ name: 'TypeGPU', description: 'Type-safe WebGPU toolkit', repository: 'TypeGPU' })) },
+        {
+          tag: 'script',
+          attrs: { type: 'application/ld+json' },
+          content: JSON.stringify(
+            structuredData({
+              name: 'TypeGPU',
+              description: 'Type-safe WebGPU toolkit',
+              repository: 'TypeGPU',
+            }),
+          ),
+        },
       ],
       title: 'TypeGPU',
       customCss: ['./src/tailwind.css', './src/fonts/font-face.css', './src/mathjax.css'],

--- a/apps/typegpu-docs/swm-geo.mjs
+++ b/apps/typegpu-docs/swm-geo.mjs
@@ -53,7 +53,7 @@ function collect(dir, root = dir, found = []) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) collect(full, root, found);
     else if (entry.name.endsWith('.html') && entry.name !== '404.html')
-      found.push(path.relative(root, full));
+      found.push(path.relative(root, full).split(path.sep).join('/'));
   }
   return found;
 }

--- a/apps/typegpu-docs/swm-geo.mjs
+++ b/apps/typegpu-docs/swm-geo.mjs
@@ -64,20 +64,14 @@ export function buildLlmsTxt({ description, files, name, prefix, readFile }) {
   for (const file of files) {
     const html = readFile(file);
     const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? '';
-    const title = decode(raw).replace(
-      new RegExp(`\\s*[|·]\\s*${escapeRegExp(name)}$`),
-      '',
-    );
+    const title = decode(raw).replace(new RegExp(`\\s*[|·]\\s*${escapeRegExp(name)}$`), '');
     if (!title) continue;
 
     const detail = decode(
-      /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(html)?.[1] ??
-        '',
+      /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(html)?.[1] ?? '',
     );
     const route = file.replace(/index\.html$/, '').replace(/\.html$/, '');
-    entries.push(
-      `- [${title}](${prefix}${route})${detail ? `: ${detail}` : ''}`,
-    );
+    entries.push(`- [${title}](${prefix}${route})${detail ? `: ${detail}` : ''}`);
   }
 
   const lines = [`# ${name}`];
@@ -94,7 +88,7 @@ export function buildLlmsTxt({ description, files, name, prefix, readFile }) {
   return lines.join('\n');
 }
 
-export default function swmGeo({ description, name, repository } = {}) {
+export default function swmGeo({ description, name } = {}) {
   let site = 'https://docs.swmansion.com';
   let base = '/';
 
@@ -103,11 +97,7 @@ export default function swmGeo({ description, name, repository } = {}) {
     hooks: {
       'astro:config:done': ({ config }) => {
         if (config.site) site = String(config.site).replace(/\/$/, '');
-        base =
-          `/${String(config.base ?? '/').replace(/^\/|\/$/g, '')}/`.replace(
-            '//',
-            '/',
-          );
+        base = `/${String(config.base ?? '/').replace(/^\/|\/$/g, '')}/`.replace('//', '/');
       },
       'astro:build:done': ({ dir }) => {
         const outDir = fileURLToPath(dir);
@@ -118,8 +108,7 @@ export default function swmGeo({ description, name, repository } = {}) {
             files: collect(outDir),
             name,
             prefix: `${site}${base}`,
-            readFile: (file) =>
-              fs.readFileSync(path.join(outDir, file), 'utf8'),
+            readFile: (file) => fs.readFileSync(path.join(outDir, file), 'utf8'),
           }),
           'utf8',
         );

--- a/apps/typegpu-docs/swm-geo.mjs
+++ b/apps/typegpu-docs/swm-geo.mjs
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ORGANIZATION_ID = "https://swmansion.com/#organization";
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const decode = (value) =>
+  value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(?:39|x27);/g, "'")
+    .trim();
+
+// Same @id as swmansion.com, so engines read one company across both domains.
+export function structuredData({ description, name, repository }) {
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": ORGANIZATION_ID,
+        name: "Software Mansion",
+        url: "https://swmansion.com",
+        sameAs: [
+          "https://github.com/software-mansion",
+          "https://www.linkedin.com/company/software-mansion/",
+          "https://twitter.com/swmansion",
+          "https://www.youtube.com/c/SoftwareMansion",
+        ],
+      },
+      {
+        "@type": "SoftwareSourceCode",
+        name,
+        ...(description ? { description } : {}),
+        ...(repository
+          ? { codeRepository: `https://github.com/software-mansion/${repository}` }
+          : {}),
+        author: { "@id": ORGANIZATION_ID },
+        maintainer: { "@id": ORGANIZATION_ID },
+      },
+    ],
+  };
+}
+
+function collect(dir, root = dir, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) collect(full, root, found);
+    else if (entry.name.endsWith(".html") && entry.name !== "404.html")
+      found.push(path.relative(root, full));
+  }
+  return found;
+}
+
+export function buildLlmsTxt({ description, files, name, prefix, readFile }) {
+  const entries = [];
+
+  for (const file of files) {
+    const html = readFile(file);
+    const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? "";
+    const title = decode(raw).replace(
+      new RegExp(`\\s*[|·]\\s*${escapeRegExp(name)}$`),
+      "",
+    );
+    if (!title) continue;
+
+    const detail = decode(
+      /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(html)?.[1] ?? "",
+    );
+    const route = file.replace(/index\.html$/, "").replace(/\.html$/, "");
+    entries.push(`- [${title}](${prefix}${route})${detail ? `: ${detail}` : ""}`);
+  }
+
+  const lines = [`# ${name}`];
+  if (description) lines.push("", `> ${description}`);
+  if (entries.length) lines.push("", "## Documentation", "", ...entries.sort());
+  lines.push(
+    "",
+    "## About",
+    "",
+    `- [Software Mansion](https://swmansion.com): maintainer of ${name}`,
+    "",
+  );
+
+  return lines.join("\n");
+}
+
+export default function swmGeo({ description, name, repository } = {}) {
+  let site = "https://docs.swmansion.com";
+  let base = "/";
+
+  return {
+    name: "swm-geo",
+    hooks: {
+      "astro:config:done": ({ config }) => {
+        if (config.site) site = String(config.site).replace(/\/$/, "");
+        base = `/${String(config.base ?? "/").replace(/^\/|\/$/g, "")}/`.replace("//", "/");
+      },
+      "astro:build:done": ({ dir }) => {
+        const outDir = fileURLToPath(dir);
+        fs.writeFileSync(
+          path.join(outDir, "llms.txt"),
+          buildLlmsTxt({
+            description,
+            files: collect(outDir),
+            name,
+            prefix: `${site}${base}`,
+            readFile: (file) => fs.readFileSync(path.join(outDir, file), "utf8"),
+          }),
+          "utf8",
+        );
+      },
+    },
+  };
+}

--- a/apps/typegpu-docs/swm-geo.mjs
+++ b/apps/typegpu-docs/swm-geo.mjs
@@ -1,16 +1,16 @@
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const ORGANIZATION_ID = "https://swmansion.com/#organization";
+const ORGANIZATION_ID = 'https://swmansion.com/#organization';
 
-const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const decode = (value) =>
   value
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#(?:39|x27);/g, "'")
     .trim();
@@ -18,29 +18,31 @@ const decode = (value) =>
 // Same @id as swmansion.com, so engines read one company across both domains.
 export function structuredData({ description, name, repository }) {
   return {
-    "@context": "https://schema.org",
-    "@graph": [
+    '@context': 'https://schema.org',
+    '@graph': [
       {
-        "@type": "Organization",
-        "@id": ORGANIZATION_ID,
-        name: "Software Mansion",
-        url: "https://swmansion.com",
+        '@type': 'Organization',
+        '@id': ORGANIZATION_ID,
+        name: 'Software Mansion',
+        url: 'https://swmansion.com',
         sameAs: [
-          "https://github.com/software-mansion",
-          "https://www.linkedin.com/company/software-mansion/",
-          "https://twitter.com/swmansion",
-          "https://www.youtube.com/c/SoftwareMansion",
+          'https://github.com/software-mansion',
+          'https://www.linkedin.com/company/software-mansion/',
+          'https://twitter.com/swmansion',
+          'https://www.youtube.com/c/SoftwareMansion',
         ],
       },
       {
-        "@type": "SoftwareSourceCode",
+        '@type': 'SoftwareSourceCode',
         name,
         ...(description ? { description } : {}),
         ...(repository
-          ? { codeRepository: `https://github.com/software-mansion/${repository}` }
+          ? {
+              codeRepository: `https://github.com/software-mansion/${repository}`,
+            }
           : {}),
-        author: { "@id": ORGANIZATION_ID },
-        maintainer: { "@id": ORGANIZATION_ID },
+        author: { '@id': ORGANIZATION_ID },
+        maintainer: { '@id': ORGANIZATION_ID },
       },
     ],
   };
@@ -50,7 +52,7 @@ function collect(dir, root = dir, found = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) collect(full, root, found);
-    else if (entry.name.endsWith(".html") && entry.name !== "404.html")
+    else if (entry.name.endsWith('.html') && entry.name !== '404.html')
       found.push(path.relative(root, full));
   }
   return found;
@@ -61,57 +63,65 @@ export function buildLlmsTxt({ description, files, name, prefix, readFile }) {
 
   for (const file of files) {
     const html = readFile(file);
-    const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? "";
+    const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? '';
     const title = decode(raw).replace(
       new RegExp(`\\s*[|·]\\s*${escapeRegExp(name)}$`),
-      "",
+      '',
     );
     if (!title) continue;
 
     const detail = decode(
-      /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(html)?.[1] ?? "",
+      /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(html)?.[1] ??
+        '',
     );
-    const route = file.replace(/index\.html$/, "").replace(/\.html$/, "");
-    entries.push(`- [${title}](${prefix}${route})${detail ? `: ${detail}` : ""}`);
+    const route = file.replace(/index\.html$/, '').replace(/\.html$/, '');
+    entries.push(
+      `- [${title}](${prefix}${route})${detail ? `: ${detail}` : ''}`,
+    );
   }
 
   const lines = [`# ${name}`];
-  if (description) lines.push("", `> ${description}`);
-  if (entries.length) lines.push("", "## Documentation", "", ...entries.sort());
+  if (description) lines.push('', `> ${description}`);
+  if (entries.length) lines.push('', '## Documentation', '', ...entries.sort());
   lines.push(
-    "",
-    "## About",
-    "",
+    '',
+    '## About',
+    '',
     `- [Software Mansion](https://swmansion.com): maintainer of ${name}`,
-    "",
+    '',
   );
 
-  return lines.join("\n");
+  return lines.join('\n');
 }
 
 export default function swmGeo({ description, name, repository } = {}) {
-  let site = "https://docs.swmansion.com";
-  let base = "/";
+  let site = 'https://docs.swmansion.com';
+  let base = '/';
 
   return {
-    name: "swm-geo",
+    name: 'swm-geo',
     hooks: {
-      "astro:config:done": ({ config }) => {
-        if (config.site) site = String(config.site).replace(/\/$/, "");
-        base = `/${String(config.base ?? "/").replace(/^\/|\/$/g, "")}/`.replace("//", "/");
+      'astro:config:done': ({ config }) => {
+        if (config.site) site = String(config.site).replace(/\/$/, '');
+        base =
+          `/${String(config.base ?? '/').replace(/^\/|\/$/g, '')}/`.replace(
+            '//',
+            '/',
+          );
       },
-      "astro:build:done": ({ dir }) => {
+      'astro:build:done': ({ dir }) => {
         const outDir = fileURLToPath(dir);
         fs.writeFileSync(
-          path.join(outDir, "llms.txt"),
+          path.join(outDir, 'llms.txt'),
           buildLlmsTxt({
             description,
             files: collect(outDir),
             name,
             prefix: `${site}${base}`,
-            readFile: (file) => fs.readFileSync(path.join(outDir, file), "utf8"),
+            readFile: (file) =>
+              fs.readFileSync(path.join(outDir, file), 'utf8'),
           }),
-          "utf8",
+          'utf8',
         );
       },
     },


### PR DESCRIPTION
Two SEO changes for the docs site. Nothing changes the rendered page.

- **JSON-LD**: `Organization` with the same `@id` as swmansion.com, plus `SoftwareSourceCode`. The identical `@id` is what makes engines read this site and swmansion.com as one entity instead of two unrelated ones.
- **`llms.txt`**, written by an Astro integration on `astro:build:done` — no new dependency. The workflow fails if the file is missing or lists nothing.

Both come from `swm-geo.mjs` next to the Astro config. The same change is going out across the docs repos; reference: software-mansion/react-native-reanimated#10332.

**Check:** the deploy workflow does not run on pull requests, so the new step could not run here. It sits before the publish step, so a broken `llms.txt` blocks the deploy rather than shipping silently. The equivalent step is green in the Docusaurus repos, listing 25 to 90 pages.