### PR TITLE
fix: Declare side effects in typegpu/package.json

### DIFF
--- a/packages/typegpu/package.json
+++ b/packages/typegpu/package.json
@@ -24,7 +24,7 @@
   },
   "bin": "./bin.mjs",
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": true,
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/packages/typegpu/package.json
+++ b/packages/typegpu/package.json
@@ -25,7 +25,7 @@
   "bin": "./bin.mjs",
   "type": "module",
   "sideEffects": [
-    "./data/index.js"
+    "./data/assignInfixOperators.js"
   ],
   "exports": {
     "./package.json": "./package.json",

--- a/packages/typegpu/package.json
+++ b/packages/typegpu/package.json
@@ -24,7 +24,9 @@
   },
   "bin": "./bin.mjs",
   "type": "module",
-  "sideEffects": true,
+  "sideEffects": [
+    "./data/index.js"
+  ],
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/packages/typegpu/src/data/assignInfixOperators.ts
+++ b/packages/typegpu/src/data/assignInfixOperators.ts
@@ -1,0 +1,15 @@
+import { Operator } from 'tsover-runtime';
+import { MatBase } from './matrix.ts';
+import { VecBase } from './vectorImpl.ts';
+import { assignInfixOperator } from '../tgsl/infixDispatch.ts';
+
+assignInfixOperator(VecBase, 'add', Operator.plus);
+assignInfixOperator(MatBase, 'add', Operator.plus);
+assignInfixOperator(VecBase, 'sub', Operator.minus);
+assignInfixOperator(MatBase, 'sub', Operator.minus);
+assignInfixOperator(VecBase, 'mul', Operator.star);
+assignInfixOperator(MatBase, 'mul', Operator.star);
+assignInfixOperator(VecBase, 'div', Operator.slash);
+assignInfixOperator(VecBase, 'mod', Operator.percent);
+assignInfixOperator(VecBase, 'bitShiftLeft', Symbol()); // bitShift does not yet have tsover operator symbol
+assignInfixOperator(VecBase, 'bitShiftRight', Symbol()); // bitShift does not yet have tsover operator symbol

--- a/packages/typegpu/src/data/index.ts
+++ b/packages/typegpu/src/data/index.ts
@@ -4,21 +4,8 @@
 
 // NOTE: This is a barrel file, internal files should not import things from this file
 
-import { Operator } from 'tsover-runtime';
-import { MatBase } from './matrix.ts';
-import { VecBase } from './vectorImpl.ts';
-import { assignInfixOperator } from '../tgsl/infixDispatch.ts';
-
-assignInfixOperator(VecBase, 'add', Operator.plus);
-assignInfixOperator(MatBase, 'add', Operator.plus);
-assignInfixOperator(VecBase, 'sub', Operator.minus);
-assignInfixOperator(MatBase, 'sub', Operator.minus);
-assignInfixOperator(VecBase, 'mul', Operator.star);
-assignInfixOperator(MatBase, 'mul', Operator.star);
-assignInfixOperator(VecBase, 'div', Operator.slash);
-assignInfixOperator(VecBase, 'mod', Operator.percent);
-assignInfixOperator(VecBase, 'bitShiftLeft', Symbol()); // bitShift does not yet have tsover operator symbol
-assignInfixOperator(VecBase, 'bitShiftRight', Symbol()); // bitShift does not yet have tsover operator symbol
+// oxlint-disable-next-line import/no-unassigned-import -- this import has side effects
+import './assignInfixOperators.ts';
 
 export { bool, f16, f32, i32, u16, u32 } from './numeric.ts';
 export {


### PR DESCRIPTION
Before, this wasn't an issue because our package wasn't really tree-shakable. Now, it started pruning code and broke infix operators, since they are assigned via a side effect:
```ts
assignInfixOperator(VecBase, 'mul', Operator.star);
```
This code is still present in the built package, but it may be stripped when building a project with typegpu as a dependency.
Infix operators still work when transpiling 'use gpu' functions since they don't actually ever execute, we just invoke correct operations in `wgslGenerator.ts` based on the AST.