### PR TITLE
fix: Counteract sideeffect based code pruning

### DIFF
--- a/packages/typegpu/package.json
+++ b/packages/typegpu/package.json
@@ -24,9 +24,7 @@
   },
   "bin": "./bin.mjs",
   "type": "module",
-  "sideEffects": [
-    "./data/assignInfixOperators.js"
-  ],
+  "sideEffects": false,
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/packages/typegpu/src/data/assignInfixOperators.ts
+++ b/packages/typegpu/src/data/assignInfixOperators.ts
@@ -3,13 +3,22 @@ import { MatBase } from './matrix.ts';
 import { VecBase } from './vectorImpl.ts';
 import { assignInfixOperator } from '../tgsl/infixDispatch.ts';
 
-assignInfixOperator(VecBase, 'add', Operator.plus);
-assignInfixOperator(MatBase, 'add', Operator.plus);
-assignInfixOperator(VecBase, 'sub', Operator.minus);
-assignInfixOperator(MatBase, 'sub', Operator.minus);
-assignInfixOperator(VecBase, 'mul', Operator.star);
-assignInfixOperator(MatBase, 'mul', Operator.star);
-assignInfixOperator(VecBase, 'div', Operator.slash);
-assignInfixOperator(VecBase, 'mod', Operator.percent);
-assignInfixOperator(VecBase, 'bitShiftLeft', Symbol()); // bitShift does not yet have tsover operator symbol
-assignInfixOperator(VecBase, 'bitShiftRight', Symbol()); // bitShift does not yet have tsover operator symbol
+let infixOperatorsAssigned = false;
+
+export function assignInfixOperators(): void {
+  if (infixOperatorsAssigned) {
+    return;
+  }
+  infixOperatorsAssigned = true;
+
+  assignInfixOperator(VecBase, 'add', Operator.plus);
+  assignInfixOperator(MatBase, 'add', Operator.plus);
+  assignInfixOperator(VecBase, 'sub', Operator.minus);
+  assignInfixOperator(MatBase, 'sub', Operator.minus);
+  assignInfixOperator(VecBase, 'mul', Operator.star);
+  assignInfixOperator(MatBase, 'mul', Operator.star);
+  assignInfixOperator(VecBase, 'div', Operator.slash);
+  assignInfixOperator(VecBase, 'mod', Operator.percent);
+  assignInfixOperator(VecBase, 'bitShiftLeft', Symbol()); // bitShift does not yet have tsover operator symbol
+  assignInfixOperator(VecBase, 'bitShiftRight', Symbol()); // bitShift does not yet have tsover operator symbol
+}

--- a/packages/typegpu/src/data/index.ts
+++ b/packages/typegpu/src/data/index.ts
@@ -4,8 +4,47 @@
 
 // NOTE: This is a barrel file, internal files should not import things from this file
 
-// oxlint-disable-next-line import/no-unassigned-import -- this import has side effects
-import './assignInfixOperators.ts';
+import { assignInfixOperators } from './assignInfixOperators.ts';
+
+import {
+  vec2b as _vec2b,
+  vec2f as _vec2f,
+  vec2h as _vec2h,
+  vec2i as _vec2i,
+  vec2u as _vec2u,
+  vec3b as _vec3b,
+  vec3f as _vec3f,
+  vec3h as _vec3h,
+  vec3i as _vec3i,
+  vec3u as _vec3u,
+  vec4b as _vec4b,
+  vec4f as _vec4f,
+  vec4h as _vec4h,
+  vec4i as _vec4i,
+  vec4u as _vec4u,
+} from './vector.ts';
+
+export const vec2b = (() => (assignInfixOperators(), _vec2b))();
+export const vec2f = (() => (assignInfixOperators(), _vec2f))();
+export const vec2h = (() => (assignInfixOperators(), _vec2h))();
+export const vec2i = (() => (assignInfixOperators(), _vec2i))();
+export const vec2u = (() => (assignInfixOperators(), _vec2u))();
+export const vec3b = (() => (assignInfixOperators(), _vec3b))();
+export const vec3f = (() => (assignInfixOperators(), _vec3f))();
+export const vec3h = (() => (assignInfixOperators(), _vec3h))();
+export const vec3i = (() => (assignInfixOperators(), _vec3i))();
+export const vec3u = (() => (assignInfixOperators(), _vec3u))();
+export const vec4b = (() => (assignInfixOperators(), _vec4b))();
+export const vec4f = (() => (assignInfixOperators(), _vec4f))();
+export const vec4h = (() => (assignInfixOperators(), _vec4h))();
+export const vec4i = (() => (assignInfixOperators(), _vec4i))();
+export const vec4u = (() => (assignInfixOperators(), _vec4u))();
+
+import { mat2x2f as _mat2x2f, mat3x3f as _mat3x3f, mat4x4f as _mat4x4f } from './matrix.ts';
+
+export const mat2x2f = (() => (assignInfixOperators(), _mat2x2f))();
+export const mat3x3f = (() => (assignInfixOperators(), _mat3x3f))();
+export const mat4x4f = (() => (assignInfixOperators(), _mat4x4f))();
 
 export { bool, f16, f32, i32, u16, u32 } from './numeric.ts';
 export {
@@ -137,26 +176,9 @@ export {
   type WgslComparisonSampler,
   type WgslSampler,
 } from './sampler.ts';
-export {
-  vec2b,
-  vec2f,
-  vec2h,
-  vec2i,
-  vec2u,
-  vec3b,
-  vec3f,
-  vec3h,
-  vec3i,
-  vec3u,
-  vec4b,
-  vec4f,
-  vec4h,
-  vec4i,
-  vec4u,
-} from './vector.ts';
 export { disarrayOf } from './disarray.ts';
 export { unstruct } from './unstruct.ts';
-export { mat2x2f, mat3x3f, mat4x4f, matToArray } from './matrix.ts';
+export { matToArray } from './matrix.ts';
 export * from './vertexFormatData.ts';
 export { atomic } from './atomic.ts';
 export { _ref as ref } from './ref.ts';


### PR DESCRIPTION
This PR makes it so that infix operator assignment is a side-effect of using any of the vector or matrix schemas, not a side-effect of importing.

The increased bundle size for the vector and matrix schemas is the code that makes infix operators possible, the diff can be inspected here:
https://gist.github.com/iwoplaza/e562b896912c280a254787851b0a8a9b