### PR TITLE
chore: run publint before publishing packages

### DIFF
--- a/scripts/_utils.ts
+++ b/scripts/_utils.ts
@@ -4,9 +4,14 @@ import { join } from 'node:path';
 
 const PACKAGES_DIR = join(import.meta.dir, '../packages');
 
+export const PUBLINT_PACKAGE = 'publint@0.3.24';
+
 interface PackageJson {
   name: string;
   private?: boolean;
+  publishConfig?: {
+    directory?: string;
+  };
   version: string;
 }
 
@@ -27,11 +32,17 @@ export function getPackages() {
         dir,
         dirname,
         name: pkg.name,
+        publishDirectory: pkg.publishConfig?.directory,
+        publishPath: join(dir, pkg.publishConfig?.directory ?? '.'),
         version: pkg.version,
         private: pkg.private ?? false,
       };
     }),
   );
+}
+
+export function getPublintArgs({ publishDirectory, publishPath }: PackageInfo): string[] {
+  return [publishPath, ...(publishDirectory ? ['--pack=false'] : [])];
 }
 
 const packageNameRegex = /^packages\/([@\w-]+)\//;
@@ -72,5 +83,7 @@ export interface PackageInfo {
   dirname: string;
   private: boolean;
   name: string;
+  publishDirectory: string | undefined;
+  publishPath: string;
   version: string;
 }

--- a/scripts/publish-pkg-pr.ts
+++ b/scripts/publish-pkg-pr.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env bun
 
 import { $ } from 'bun';
-import { getPackagesChangedSinceRelease, getPackages, getTag } from './_utils.ts';
+import {
+  getPackagesChangedSinceRelease,
+  getPackages,
+  getPublintArgs,
+  getTag,
+  PUBLINT_PACKAGE,
+} from './_utils.ts';
 
 async function main() {
   const packages = await getPackages();
@@ -42,6 +48,10 @@ async function main() {
     ...process.env,
     SKIP_TESTS: 'true',
   });
+
+  for (const pkg of toPublish) {
+    await $`pnpm dlx ${PUBLINT_PACKAGE} ${getPublintArgs(pkg)}`;
+  }
 
   const publishArgs = toPublish.map((pkg) => `./packages/${pkg.dirname}`);
 

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,7 +1,14 @@
 #!/usr/bin/env bun
 
 import { $ } from 'bun';
-import { getPackages, getTag, isPublished, type PackageInfo } from './_utils.ts';
+import {
+  getPackages,
+  getPublintArgs,
+  getTag,
+  isPublished,
+  PUBLINT_PACKAGE,
+  type PackageInfo,
+} from './_utils.ts';
 
 const isDryRun = process.env.DISABLE_DRY_RUN !== 'true';
 
@@ -41,19 +48,28 @@ async function main() {
 
   console.log();
 
-  for (const { dir, name, version } of toPublish) {
+  for (const pkg of toPublish) {
+    const { dir, name, version } = pkg;
     const tag = getTag(version);
     console.log(`Publishing ${name}@${version} [tag: ${tag}]...`);
+
+    const env = { ...process.env, SKIP_TESTS: 'true' };
+
+    // Run the package lifecycle explicitly so publint can validate the final
+    // artifact before pnpm performs the irreversible publish step.
+    await $`pnpm run --if-present prepublishOnly`.cwd(dir).env(env);
+    await $`pnpm dlx ${PUBLINT_PACKAGE} ${getPublintArgs(pkg)}`;
 
     const args = [
       'publish',
       '--provenance',
       '--no-git-checks',
+      '--ignore-scripts',
       ...(tag === 'latest' ? [] : ['--tag', tag]),
       ...(isDryRun ? ['--dry-run'] : []),
     ];
 
-    await $`pnpm ${args}`.cwd(dir).env({ ...process.env, SKIP_TESTS: 'true' });
+    await $`pnpm ${args}`.cwd(dir).env(env);
 
     console.log();
   }

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -59,8 +59,9 @@ async function main() {
       ...(tag === 'latest' ? {} : { npm_config_tag: tag }),
     };
 
-    // Run the package lifecycle explicitly so publint can validate the final
-    // artifact before pnpm performs the irreversible publish step.
+    // prepublishOnly is the only publish-time transform used by public packages.
+    // Run it explicitly so publint can validate the final artifact before pnpm
+    // publishes with all lifecycle scripts disabled.
     await $`pnpm run --if-present prepublishOnly`.cwd(dir).env(env);
     await $`pnpm dlx ${PUBLINT_PACKAGE} ${getPublintArgs(pkg)}`;
 

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -53,7 +53,11 @@ async function main() {
     const tag = getTag(version);
     console.log(`Publishing ${name}@${version} [tag: ${tag}]...`);
 
-    const env = { ...process.env, SKIP_TESTS: 'true' };
+    const env = {
+      ...process.env,
+      SKIP_TESTS: 'true',
+      ...(tag === 'latest' ? {} : { npm_config_tag: tag }),
+    };
 
     // Run the package lifecycle explicitly so publint can validate the final
     // artifact before pnpm performs the irreversible publish step.


### PR DESCRIPTION
## Summary

- derive each package's actual publish path from `publishConfig.directory`
- run pinned Publint 0.3.24 before npm and pkg.pr.new publishing
- lint transformed `dist` artifacts directly while letting root-published packages use their normal pack file list
- execute package lifecycle scripts explicitly, then publish with `--ignore-scripts` so the gate sits before the irreversible publish step

Fixes #2866

## Verification

- `oxfmt --check scripts/_utils.ts scripts/publish.ts scripts/publish-pkg-pr.ts`
- `oxlint -c oxlint.config.ts --max-warnings=0 scripts/_utils.ts scripts/publish.ts scripts/publish-pkg-pr.ts`
- isolated strict TypeScript check for all three scripts
- `SKIP_TESTS=true pnpm --filter @typegpu/color run prepublishOnly --skip-publish-tag-check`
- Publint pass for `@typegpu/color/dist` (`--pack=false`)
- Publint pass for `create-typegpu` (normal `pnpm pack`)
- `pnpm publish --ignore-scripts --dry-run` for both publish-directory and package-root flows
- `git diff --check`