### PR TITLE
impr: auto-interpolate integer varyings

### DIFF
--- a/packages/typegpu/src/core/function/autoIO.ts
+++ b/packages/typegpu/src/core/function/autoIO.ts
@@ -86,7 +86,12 @@ export class AutoFragmentFn implements SelfResolvable {
       setName(impl, 'fragmentFn');
     }
     this.#core = createFnCore(impl, 'fragment');
-    this.autoIn = new AutoStruct({ ...builtinFragmentIn, ...varyings }, undefined, locations);
+    this.autoIn = new AutoStruct(
+      { ...builtinFragmentIn, ...varyings },
+      undefined,
+      locations,
+      /* autoInterpolateIntegers */ true,
+    );
     setName(this.autoIn, 'FragmentIn');
     this.autoOut = new AutoStruct(builtinFragmentOut, vec4f);
     setName(this.autoOut, 'FragmentOut');
@@ -134,7 +139,12 @@ export class AutoVertexFn implements SelfResolvable {
     this.#core = createFnCore(impl, 'vertex');
     this.autoIn = new AutoStruct({ ...builtinVertexIn, ...attribs }, undefined, locations);
     setName(this.autoIn, 'VertexIn');
-    this.autoOut = new AutoStruct(builtinVertexOut, undefined);
+    this.autoOut = new AutoStruct(
+      builtinVertexOut,
+      undefined,
+      undefined,
+      /* autoInterpolateIntegers */ true,
+    );
     setName(this.autoOut, 'VertexOut');
   }
 

--- a/packages/typegpu/src/core/function/ioSchema.ts
+++ b/packages/typegpu/src/core/function/ioSchema.ts
@@ -2,12 +2,23 @@ import {
   type Decorate,
   type HasCustomLocation,
   type IsBuiltin,
+  interpolate,
   location,
 } from '../../data/attributes.ts';
 import { isBuiltin } from '../../data/attributes.ts';
 import { getCustomLocation, isData } from '../../data/dataTypes.ts';
 import { INTERNAL_createStruct } from '../../data/struct.ts';
-import { type BaseData, isVoid, type Location, type WgslStruct } from '../../data/wgslTypes.ts';
+import {
+  type BaseData,
+  type FlatInterpolatableData,
+  isDecorated,
+  isInteger,
+  isIntegerVec,
+  isInterpolateAttrib,
+  isVoid,
+  type Location,
+  type WgslStruct,
+} from '../../data/wgslTypes.ts';
 import type { SeparatedEntryArgs } from './fnTypes.ts';
 
 export type WithLocations<T extends Record<string, BaseData>> = {
@@ -31,6 +42,7 @@ export type IOLayoutToSchema<T> = T extends BaseData
 export function withLocations<T extends BaseData>(
   members: Record<string, T> | undefined,
   locations: Record<string, number> = {},
+  autoInterpolateIntegers = false,
 ): Record<string, BaseData> {
   let nextLocation = 0;
   const usedCustomLocations = new Set<number>();
@@ -47,7 +59,12 @@ export function withLocations<T extends BaseData>(
           usedCustomLocations.add(customLocation);
         }
 
-        return [key, member] as const;
+        return [
+          key,
+          autoInterpolateIntegers && !isBuiltin(member)
+            ? withFlatInterpolationForInteger(member)
+            : member,
+        ] as const;
       })
       .map(([key, member]) => {
         if (isBuiltin(member)) {
@@ -76,6 +93,7 @@ export function withLocations<T extends BaseData>(
 export function separateBuiltins(
   schema: Record<string, BaseData>,
   locations: Record<string, number> = {},
+  autoInterpolateIntegers = false,
 ): SeparatedEntryArgs {
   const positionalArgs: SeparatedEntryArgs['positionalArgs'] = [];
   const dataFields: Record<string, BaseData> = {};
@@ -90,7 +108,10 @@ export function separateBuiltins(
 
   const dataSchema =
     Object.keys(dataFields).length > 0
-      ? INTERNAL_createStruct(withLocations(dataFields, locations), /* isAbstruct */ false)
+      ? INTERNAL_createStruct(
+          withLocations(dataFields, locations, autoInterpolateIntegers),
+          /* isAbstruct */ false,
+        )
       : undefined;
 
   return { dataSchema, positionalArgs };
@@ -105,19 +126,32 @@ export function separateAllAsPositional(schema: Record<string, BaseData>): Separ
 export function createIoSchema<T extends BaseData | Record<string, BaseData>>(
   layout: T,
   locations: Record<string, number> = {},
+  autoInterpolateIntegers = false,
 ) {
-  return (
-    isData(layout)
-      ? isVoid(layout)
-        ? layout
-        : isBuiltin(layout)
-          ? layout
-          : getCustomLocation(layout) !== undefined
-            ? layout
-            : location(0, layout)
-      : INTERNAL_createStruct(
-          withLocations(layout as Record<string, BaseData>, locations),
-          /* isAbstruct */ false,
-        )
+  if (isData(layout)) {
+    if (isVoid(layout) || isBuiltin(layout)) {
+      return layout as unknown as IOLayoutToSchema<T>;
+    }
+
+    const data = autoInterpolateIntegers ? withFlatInterpolationForInteger(layout) : layout;
+    return (
+      getCustomLocation(data) !== undefined ? data : location(0, data)
+    ) as IOLayoutToSchema<T>;
+  }
+
+  return INTERNAL_createStruct(
+    withLocations(layout as Record<string, BaseData>, locations, autoInterpolateIntegers),
+    /* isAbstruct */ false,
   ) as IOLayoutToSchema<T>;
+}
+
+function withFlatInterpolationForInteger(data: BaseData): BaseData {
+  if (isDecorated(data) && data.attribs.some(isInterpolateAttrib)) {
+    return data;
+  }
+
+  const inner = isDecorated(data) ? data.inner : data;
+  return isInteger(inner) || isIntegerVec(inner)
+    ? interpolate('flat', data as FlatInterpolatableData)
+    : data;
 }

--- a/packages/typegpu/src/core/function/tgpuFragmentFn.ts
+++ b/packages/typegpu/src/core/function/tgpuFragmentFn.ts
@@ -209,7 +209,11 @@ function createFragmentFn(
     },
 
     [$resolve](ctx: ResolutionCtx): ResolvedSnippet {
-      const entryInput = separateBuiltins(shell.in ?? {}, ctx.varyingLocations ?? {});
+      const entryInput = separateBuiltins(
+        shell.in ?? {},
+        ctx.varyingLocations ?? {},
+        /* autoInterpolateIntegers */ true,
+      );
 
       if (entryInput.dataSchema && isNamable(entryInput.dataSchema)) {
         entryInput.dataSchema.$name(`${getName(this) ?? ''}_Input`);

--- a/packages/typegpu/src/core/function/tgpuVertexFn.ts
+++ b/packages/typegpu/src/core/function/tgpuVertexFn.ts
@@ -177,9 +177,11 @@ function createVertexFn(
     },
 
     [$resolve](ctx: ResolutionCtx): ResolvedSnippet {
-      const outputWithLocation = createIoSchema(shell.out, ctx.varyingLocations).$name(
-        `${getName(this) ?? ''}_Output`,
-      );
+      const outputWithLocation = createIoSchema(
+        shell.out,
+        ctx.varyingLocations,
+        /* autoInterpolateIntegers */ true,
+      ).$name(`${getName(this) ?? ''}_Output`);
 
       if (typeof implementation === 'string') {
         core.setExternals('out', { Out: outputWithLocation });

--- a/packages/typegpu/src/data/autoStruct.ts
+++ b/packages/typegpu/src/data/autoStruct.ts
@@ -34,16 +34,19 @@ export class AutoStruct implements BaseData, SelfResolvable {
   #locations: Record<string, number> | undefined;
   #cachedStruct: WgslStruct | undefined;
   #typeForExtraProps: BaseData | undefined;
+  readonly #autoInterpolateIntegers: boolean;
 
   constructor(
     validProps: Record<string, BaseData>,
     typeForExtraProps: BaseData | undefined,
     locations?: Record<string, number>,
+    autoInterpolateIntegers = false,
   ) {
     this.#validProps = validProps;
     this.#typeForExtraProps = typeForExtraProps;
     this.#allocated = {};
     this.#locations = locations;
+    this.#autoInterpolateIntegers = autoInterpolateIntegers;
     this.#usedWgslKeys = new Set();
   }
 
@@ -97,6 +100,7 @@ export class AutoStruct implements BaseData, SelfResolvable {
           }),
         ),
         this.#locations,
+        this.#autoInterpolateIntegers,
       );
       const ownName = getName(this);
       // Passing the given name forward

--- a/packages/typegpu/tests/renderPipeline.test.ts
+++ b/packages/typegpu/tests/renderPipeline.test.ts
@@ -212,6 +212,32 @@ describe('render pipeline behavior', () => {
       expect(resolved).not.toContain('@interpolate(flat) @builtin(primitive_index)');
     });
 
+    it('does not flat interpolate integer vertex inputs or fragment outputs', ({ root }) => {
+      const vertexMain = tgpu.vertexFn({
+        in: { index: d.u32 },
+        out: { position: d.builtin.position },
+      })(({ index }) => {
+        'use gpu';
+        return { position: d.vec4f(d.f32(index), 0, 0, 1) };
+      });
+
+      const fragmentMain = tgpu.fragmentFn({ out: d.vec4u })(() => d.vec4u(1));
+      const pipeline = root.createRenderPipeline({
+        vertex: vertexMain,
+        fragment: fragmentMain,
+        targets: { format: 'rgba8uint' },
+      });
+
+      const resolved = tgpu.resolve([pipeline]);
+
+      expect(resolved).toContain('@location(0) index: u32');
+      expect(resolved).not.toContain('@location(0) @interpolate(flat) index: u32');
+      expect(resolved).toContain('@fragment fn fragmentMain() -> @location(0) vec4u');
+      expect(resolved).not.toContain(
+        '@fragment fn fragmentMain() -> @location(0) @interpolate(flat) vec4u',
+      );
+    });
+
     it('resolves with correct locations when pairing up a vertex and a fragment function', ({
       root,
     }) => {

--- a/packages/typegpu/tests/renderPipeline.test.ts
+++ b/packages/typegpu/tests/renderPipeline.test.ts
@@ -153,6 +153,65 @@ describe('render pipeline behavior', () => {
   });
 
   describe('resolve', () => {
+    it('automatically uses flat interpolation for integer varyings', ({ root }) => {
+      const vertexMain = tgpu.vertexFn({
+        out: {
+          count: d.u32,
+          coordinates: d.location(4, d.vec2i),
+          tagged: d.interpolate('flat, either', d.u32),
+          position: d.builtin.position,
+        },
+      })`{ return Out(); }`;
+
+      const fragmentMain = tgpu.fragmentFn({
+        in: {
+          count: d.u32,
+          coordinates: d.location(4, d.vec2i),
+          tagged: d.interpolate('flat, either', d.u32),
+        },
+        out: d.vec4f,
+      })(({ count, coordinates, tagged }) => {
+        'use gpu';
+        return d.vec4f(d.f32(count), d.f32(coordinates.x), d.f32(tagged), 1);
+      });
+
+      const pipeline = root.createRenderPipeline({
+        vertex: vertexMain,
+        fragment: fragmentMain,
+        targets: { format: 'r8unorm' },
+      });
+
+      const resolved = tgpu.resolve([pipeline]);
+
+      expect(resolved.match(/@location\(0\) @interpolate\(flat\) count: u32/g)).toHaveLength(2);
+      expect(
+        resolved.match(/@interpolate\(flat\) @location\(4\) coordinates: vec2i/g),
+      ).toHaveLength(2);
+      expect(
+        resolved.match(/@location\(\d+\) @interpolate\(flat, either\) tagged: u32/g),
+      ).toHaveLength(2);
+    });
+
+    it('automatically uses flat interpolation for inferred integer varyings', ({ root }) => {
+      const pipeline = root.createRenderPipeline({
+        vertex: () => {
+          'use gpu';
+          return { $position: d.vec4f(), count: d.u32(1) };
+        },
+        fragment: ({ count, $primitiveIndex }) => {
+          'use gpu';
+          return d.vec4f(d.f32(count + $primitiveIndex));
+        },
+        targets: { format: 'r8unorm' },
+      });
+
+      const resolved = tgpu.resolve([pipeline]);
+
+      expect(resolved.match(/@location\(0\) @interpolate\(flat\) count: u32/g)).toHaveLength(2);
+      expect(resolved).toContain('@builtin(primitive_index) primitiveIndex: u32');
+      expect(resolved).not.toContain('@interpolate(flat) @builtin(primitive_index)');
+    });
+
     it('resolves with correct locations when pairing up a vertex and a fragment function', ({
       root,
     }) => {
@@ -196,7 +255,7 @@ describe('render pipeline behavior', () => {
           @location(1) bar: vec3f,
           @location(0) baz: vec3f,
           @location(5) baz2: f32,
-          @location(3) baz3: u32,
+          @location(3) @interpolate(flat) baz3: u32,
           @builtin(position) pos: vec4f,
         }
 
@@ -248,13 +307,13 @@ describe('render pipeline behavior', () => {
           @builtin(position) position: vec4f,
           @location(0) baz: vec3f,
           @location(5) baz2: f32,
-          @location(3) baz3: u32,
+          @location(3) @interpolate(flat) baz3: u32,
         }
 
         @vertex fn vertexMain() -> vertexMain_Output { return vertexMain_Output(); }
 
         struct fragmentMain_Input {
-          @location(3) baz3: u32,
+          @location(3) @interpolate(flat) baz3: u32,
           @location(1) bar: vec3f,
           @location(2) foo: vec3f,
           @location(5) baz2: f32,
@@ -868,7 +927,7 @@ describe('root.createRenderPipeline', () => {
     expect(tgpu.resolve([pipeline])).toMatchInlineSnapshot(`
       "struct VertexOut {
         @builtin(position) position: vec4f,
-        @location(0) prop: i32,
+        @location(0) @interpolate(flat) prop: i32,
       }
 
       @vertex fn vertex() -> VertexOut {
@@ -876,7 +935,7 @@ describe('root.createRenderPipeline', () => {
       }
 
       struct FragmentIn {
-        @location(0) prop: i32,
+        @location(0) @interpolate(flat) prop: i32,
       }
 
       @fragment fn fragment(_arg_0: FragmentIn) -> @location(0) vec4f {


### PR DESCRIPTION
## Summary

- automatically add `@interpolate(flat)` to integer scalar and vector varyings
- apply the behavior only to vertex outputs and fragment inputs, never integer builtins, vertex attributes, or fragment outputs
- preserve explicit interpolation and custom location attributes
- cover shelled and inferred render pipelines plus the integer-builtin boundary

Closes #2147.

## Verification

- RED: focused render-pipeline regressions failed because implicit integer varyings had no flat interpolation
- `pnpm test:fast-unit` — 216 files, 2,795 tests passed; 2 baseline skips
- `pnpm --filter typegpu test:types`
- `pnpm test:style` — zero warnings/errors
- `pnpm --filter typegpu build`
- `git diff --check`