### PR TITLE
impr: Optimize radiance cascade execution

### DIFF
--- a/packages/typegpu-radiance-cascades/package.json
+++ b/packages/typegpu-radiance-cascades/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "test:types": "pnpm tsc --p ./tsconfig.json --noEmit",
+    "test:types": "pnpm tsc --p ./tsconfig.json --noEmit && pnpm tsc --p ./tsconfig.test.json --noEmit",
     "prepublishOnly": "tgpu-dev-cli prepack"
   },
   "devDependencies": {
@@ -39,6 +39,7 @@
     "@webgpu/types": "catalog:types",
     "tsdown": "catalog:build",
     "typegpu": "workspace:*",
+    "typegpu-testing-utility": "workspace:*",
     "typescript": "catalog:types",
     "unplugin-typegpu": "workspace:*"
   },

--- a/packages/typegpu-radiance-cascades/src/cascades.ts
+++ b/packages/typegpu-radiance-cascades/src/cascades.ts
@@ -4,6 +4,7 @@ export const PREAVERAGE_RAY_DIM = 2;
 export const PREAVERAGE_RAY_COUNT = PREAVERAGE_RAY_DIM ** 2;
 
 const BILINEAR_TAP_COUNT = 4;
+export const CASCADE_WORKGROUP_DIM = 8;
 
 const F32_MAX = 3.40282346e38;
 
@@ -231,6 +232,7 @@ export const cascadePassBGL = tgpu.bindGroupLayout({
 export type CascadePassSpecialization = {
   hasUpperCascade: boolean;
   mergeMode: MergeMode;
+  useSharedRayDirections: boolean;
 };
 
 export type BuildRadianceFieldSpecialization = {
@@ -401,25 +403,45 @@ const rayDirection = (rayIndex: number, rayCountActual: number, aspect: number) 
   return std.select(d.vec2f(cosA, sinA * aspect), d.vec2f(cosA / aspect, sinA), aspect >= 1);
 };
 
-function createCascadePassCompute({ hasUpperCascade, mergeMode }: CascadePassSpecialization) {
+const sharedRayDirections = tgpu.workgroupVar(d.arrayOf(d.vec2f, PREAVERAGE_RAY_COUNT));
+
+function createCascadePassCompute({
+  hasUpperCascade,
+  mergeMode,
+  useSharedRayDirections,
+}: CascadePassSpecialization) {
   const isHardwareMerge = mergeMode === 'hardware';
 
   return tgpu.computeFn({
-    workgroupSize: [8, 8],
-    in: { gid: d.builtin.globalInvocationId },
-  })(({ gid }) => {
+    workgroupSize: [CASCADE_WORKGROUP_DIM, CASCADE_WORKGROUP_DIM],
+    in: {
+      gid: d.builtin.globalInvocationId,
+      localIndex: d.builtin.localInvocationIndex,
+    },
+  })(({ gid, localIndex }) => {
     'use gpu';
     const layerParams = cascadePassBGL.$.layerParams;
+    const probes = layerParams.probes;
+    const rayCountActual = d.f32(layerParams.raysDimActual) ** 2;
+    const dirStored = gid.xy / probes;
+    const aspect = layerParams.aspect;
+    if (useSharedRayDirections) {
+      if (localIndex < PREAVERAGE_RAY_COUNT) {
+        const dirActual =
+          dirStored * PREAVERAGE_RAY_DIM + d.vec2u(localIndex & 1, localIndex >>> 1);
+        const rayIndex = d.f32(morton2D(dirActual.x, dirActual.y)) + 0.5;
+        sharedRayDirections.$[localIndex] = rayDirection(rayIndex, rayCountActual, aspect);
+      }
+      std.workgroupBarrier();
+    }
+
+    // Every invocation must reach the barrier before out-of-bounds threads return.
     if (gid.x >= layerParams.validDim.x || gid.y >= layerParams.validDim.y) {
       return;
     }
 
-    const probes = layerParams.probes;
-    const rayCountActual = d.f32(layerParams.raysDimActual) ** 2;
-    const dirStored = gid.xy / probes;
     const probe = gid.xy % probes;
     const probePos = (d.vec2f(probe) + 0.5) / d.vec2f(probes);
-    const aspect = layerParams.aspect;
     const eps = layerParams.eps;
     const minStep = layerParams.minStep;
     const biasUv = layerParams.hitBias;
@@ -430,8 +452,9 @@ function createCascadePassCompute({ hasUpperCascade, mergeMode }: CascadePassSpe
 
     for (let i = d.u32(); i < PREAVERAGE_RAY_COUNT; i++) {
       const dirActual = dirStored * PREAVERAGE_RAY_DIM + d.vec2u(i & 1, i >>> 1);
-      const rayIndex = d.f32(morton2D(dirActual.x, dirActual.y)) + 0.5;
-      const rayDir = rayDirection(rayIndex, rayCountActual, aspect);
+      const rayDir = useSharedRayDirections
+        ? d.vec2f(sharedRayDirections.$[i] as d.v2f)
+        : rayDirection(d.f32(morton2D(dirActual.x, dirActual.y)) + 0.5, rayCountActual, aspect);
       const exitUv = rayBoxExitUv(probePos, rayDir);
       const clippedMarchEndUv = std.min(marchEndUv, exitUv);
 
@@ -491,7 +514,7 @@ function createCascadePassCompute({ hasUpperCascade, mergeMode }: CascadePassSpe
 const cascadePassComputeCache = new Map<string, ReturnType<typeof createCascadePassCompute>>();
 
 export function makeCascadePassCompute(specialization: CascadePassSpecialization) {
-  const key = `${specialization.mergeMode}:${specialization.hasUpperCascade}`;
+  const key = `${specialization.mergeMode}:${specialization.hasUpperCascade}:${specialization.useSharedRayDirections}`;
   let compute = cascadePassComputeCache.get(key);
   if (!compute) {
     compute = createCascadePassCompute(specialization);

--- a/packages/typegpu-radiance-cascades/src/cascades.ts
+++ b/packages/typegpu-radiance-cascades/src/cascades.ts
@@ -1,48 +1,163 @@
-import { tgpu, std, d } from 'typegpu';
+import { d, std, tgpu } from 'typegpu';
 
-const ERODE_BIAS = 2;
+export const PREAVERAGE_RAY_DIM = 2;
+export const PREAVERAGE_RAY_COUNT = PREAVERAGE_RAY_DIM ** 2;
 
-export function getCascadeDim(width: number, height: number) {
-  const aspect = width / height;
-  const diagonal = Math.sqrt(width ** 2 + height ** 2);
+const BILINEAR_TAP_COUNT = 4;
 
-  const minPow2 = 16;
-  const closestPowerOfTwo = Math.max(minPow2, 2 ** Math.floor(Math.log2(diagonal)));
+const F32_MAX = 3.40282346e38;
 
-  let cascadeWidth: number;
-  let cascadeHeight: number;
-  if (aspect >= 1) {
-    cascadeWidth = closestPowerOfTwo;
-    cascadeHeight = Math.max(minPow2, Math.round(closestPowerOfTwo / aspect));
-  } else {
-    cascadeWidth = Math.max(minPow2, Math.round(closestPowerOfTwo * aspect));
-    cascadeHeight = closestPowerOfTwo;
+export type MergeMode = 'hardware' | 'bilinear-fix';
+
+export type BaseStoredRayDim = 1 | 2 | 4;
+
+export type CascadeInfoOptions = {
+  baseStoredRayDim?: BaseStoredRayDim;
+  minCascades?: number;
+};
+
+export type CascadeLayerInfo = {
+  layer: number;
+  probes: [number, number];
+  probesU: [number, number];
+  validDim: [number, number];
+  raysDimStored: number;
+  raysDimActual: number;
+  startUv: number;
+  endUv: number;
+};
+
+export type CascadeInfo = {
+  baseProbes: [number, number];
+  cascadeDim: [number, number];
+  cascadeCount: number;
+  baseStoredRayDim: BaseStoredRayDim;
+  interval0: number;
+  maxRange: number;
+  layers: CascadeLayerInfo[];
+};
+
+const MIN_BASE_PROBES = 16;
+const DEFAULT_MIN_CASCADES = 5;
+
+function assertPositiveSize(width: number, height: number) {
+  if (!(width > 0) || !(height > 0)) {
+    throw new Error('Radiance cascade size must be positive.');
   }
+}
 
-  const cascadeDimX = cascadeWidth * 2;
-  const cascadeDimY = cascadeHeight * 2;
+function assertBaseStoredRayDim(value: number): asserts value is BaseStoredRayDim {
+  if (value !== 1 && value !== 2 && value !== 4) {
+    throw new Error('baseStoredRayDim must be 1, 2, or 4.');
+  }
+}
 
-  const interval = 1 / closestPowerOfTwo;
-  const maxIntervalStart = 2.0;
+function shrByPow2(value: number, shift: number) {
+  return Math.max(Math.floor(value / 2 ** shift), 1);
+}
 
-  const minCascades = 5;
-  const cascadeAmount = Math.max(
-    minCascades,
-    Math.ceil(Math.log2((maxIntervalStart * 3) / interval + 1) / 2),
+export function getCascadeInfo(
+  width: number,
+  height: number,
+  options: CascadeInfoOptions = {},
+): CascadeInfo {
+  assertPositiveSize(width, height);
+
+  const baseStoredRayDim = options.baseStoredRayDim ?? 2;
+  assertBaseStoredRayDim(baseStoredRayDim);
+
+  const aspect = width / height;
+  const diagonal = Math.hypot(width, height);
+
+  const closestPowerOfTwo = Math.max(MIN_BASE_PROBES, 2 ** Math.floor(Math.log2(diagonal)));
+
+  const [baseProbesX, baseProbesY] =
+    aspect >= 1
+      ? [closestPowerOfTwo, Math.max(MIN_BASE_PROBES, Math.round(closestPowerOfTwo / aspect))]
+      : [Math.max(MIN_BASE_PROBES, Math.round(closestPowerOfTwo * aspect)), closestPowerOfTwo];
+
+  const baseProbesMin = Math.min(baseProbesX, baseProbesY);
+  const interval0 = 1 / baseProbesMin;
+  const maxRange = diagonal / Math.min(width, height);
+
+  const cascadeCount = Math.max(
+    options.minCascades ?? DEFAULT_MIN_CASCADES,
+    Math.ceil(Math.log2((maxRange * 3) / interval0 + 1) / 2),
   );
 
-  return [cascadeDimX, cascadeDimY, cascadeAmount] as const;
+  const maxStoredRayDim = baseStoredRayDim * 2 ** (cascadeCount - 1);
+  const cascadeDimX = Math.max(baseProbesX * baseStoredRayDim, maxStoredRayDim);
+  const cascadeDimY = Math.max(baseProbesY * baseStoredRayDim, maxStoredRayDim);
+
+  const layers = Array.from({ length: cascadeCount }, (_, layer): CascadeLayerInfo => {
+    const probesX = shrByPow2(baseProbesX, layer);
+    const probesY = shrByPow2(baseProbesY, layer);
+    const probesUX = shrByPow2(baseProbesX, layer + 1);
+    const probesUY = shrByPow2(baseProbesY, layer + 1);
+    const raysDimStored = baseStoredRayDim * 2 ** layer;
+    const raysDimActual = raysDimStored * PREAVERAGE_RAY_DIM;
+    const pow4 = 4 ** layer;
+    const startUv = (interval0 * (pow4 - 1)) / 3;
+    const endUv = startUv + interval0 * pow4;
+
+    return {
+      layer,
+      probes: [probesX, probesY],
+      probesU: [probesUX, probesUY],
+      validDim: [
+        Math.min(cascadeDimX, probesX * raysDimStored),
+        Math.min(cascadeDimY, probesY * raysDimStored),
+      ],
+      raysDimStored,
+      raysDimActual,
+      startUv,
+      endUv,
+    };
+  });
+
+  return {
+    baseProbes: [baseProbesX, baseProbesY],
+    cascadeDim: [cascadeDimX, cascadeDimY],
+    cascadeCount,
+    baseStoredRayDim,
+    interval0,
+    maxRange,
+    layers,
+  };
+}
+
+export function getCascadeDim(width: number, height: number, options: CascadeInfoOptions = {}) {
+  const info = getCascadeInfo(width, height, options);
+  return [...info.cascadeDim, info.cascadeCount] as const;
 }
 
 export const sdfSlot = tgpu.slot<(uv: d.v2f) => number>();
 export const colorSlot = tgpu.slot<(uv: d.v2f) => d.v3f>();
-
-// Slot for SDF resolution to calculate proper texel-based eps/minStep (so we don't do redundant sub-texel steps)
-export const sdfResolutionSlot = tgpu.slot<d.v2u>();
+export const maxRayStepsAccess = tgpu.accessor(d.u32, 64);
+export const rayMarchStepSafetyAccess = tgpu.accessor(d.f32, 1);
 
 export const RayMarchResult = d.struct({
   color: d.vec3f,
   transmittance: d.f32, // 1.0 = no hit, 0.0 = fully opaque hit
+});
+
+const rayBoxExitUv = tgpu.fn(
+  [d.vec2f, d.vec2f],
+  d.f32,
+)((p, dir) => {
+  'use gpu';
+  let tx = d.f32(F32_MAX);
+  let ty = d.f32(F32_MAX);
+
+  if (std.abs(dir.x) > 1e-6) {
+    tx = std.select(-p.x / dir.x, (1 - p.x) / dir.x, dir.x > 0);
+  }
+
+  if (std.abs(dir.y) > 1e-6) {
+    ty = std.select(-p.y / dir.y, (1 - p.y) / dir.y, dir.y > 0);
+  }
+
+  return std.max(0, std.min(tx, ty));
 });
 
 export const defaultRayMarch = tgpu.fn(
@@ -50,146 +165,343 @@ export const defaultRayMarch = tgpu.fn(
   RayMarchResult,
 )((probePos, rayDir, startT, endT, eps, minStep, bias) => {
   'use gpu';
-  let rgb = d.vec3f();
-  let T = d.f32(1);
   let t = startT;
-  let hitPos = d.vec2f();
-  let didHit = false;
 
-  for (let step = 0; step < 64; step++) {
+  for (let step = d.u32(); step < maxRayStepsAccess.$; step++) {
     if (t > endT) {
       break;
     }
     const pos = probePos + rayDir * t;
-    if (std.any(std.lt(pos, d.vec2f(0))) || std.any(std.gt(pos, d.vec2f(1)))) {
-      break;
+    const hitDist = sdfSlot.$(pos) + bias;
+    if (hitDist <= eps) {
+      return RayMarchResult({ color: colorSlot.$(pos), transmittance: 0 });
     }
-
-    const dist = std.max(sdfSlot.$(pos) + bias, 0);
-    if (dist <= eps) {
-      hitPos = d.vec2f(pos);
-      didHit = true;
-      T = 0;
-      break;
-    }
-    t += std.max(dist, minStep);
+    t += std.max(hitDist * rayMarchStepSafetyAccess.$, minStep);
   }
 
-  if (didHit) {
-    rgb = colorSlot.$(hitPos);
-  }
-
-  return RayMarchResult({ color: rgb, transmittance: T });
+  return RayMarchResult({ color: d.vec3f(), transmittance: 1 });
 });
 
 export const rayMarchSlot = tgpu.slot(defaultRayMarch);
 
-export const CascadeStaticParams = d.struct({
-  baseProbes: d.vec2u,
-  cascadeDim: d.vec2u,
-  cascadeCount: d.u32,
+export const defaultTraceSegment = tgpu.fn(
+  [d.vec2f, d.vec2f, d.f32, d.f32, d.f32, d.f32],
+  RayMarchResult,
+)((p0, p1, aspect, eps, minStep, bias) => {
+  'use gpu';
+  const delta = p1 - p0;
+  const metricDelta = std.select(
+    d.vec2f(delta.x, delta.y / aspect),
+    d.vec2f(delta.x * aspect, delta.y),
+    aspect >= 1,
+  );
+  const endT = std.length(metricDelta);
+
+  if (endT <= 0) {
+    return RayMarchResult({ color: d.vec3f(), transmittance: 1 });
+  }
+
+  const rayDir = delta / endT;
+  return rayMarchSlot.$(p0, rayDir, 0, std.min(endT, rayBoxExitUv(p0, rayDir)), eps, minStep, bias);
+});
+
+export const traceSegmentSlot = tgpu.slot(defaultTraceSegment);
+
+export const CascadeLayerParams = d.struct({
+  probes: d.vec2u,
+  probesU: d.vec2u,
+  validDim: d.vec2u,
+  raysDimActual: d.u32,
+  startUv: d.f32,
+  endUv: d.f32,
+  intervalOverlapUv: d.f32,
+  aspect: d.f32,
+  eps: d.f32,
+  minStep: d.f32,
+  hitBias: d.f32,
 });
 
 export const cascadePassBGL = tgpu.bindGroupLayout({
-  staticParams: { uniform: CascadeStaticParams },
-  layer: { uniform: d.u32 },
+  layerParams: { uniform: CascadeLayerParams },
   upper: { texture: d.texture2d() },
   upperSampler: { sampler: 'filtering' },
   dst: { storageTexture: d.textureStorage2d('rgba16float') },
 });
 
-export const cascadePassCompute = tgpu.computeFn({
-  workgroupSize: [8, 8],
-  in: { gid: d.builtin.globalInvocationId },
-})(({ gid }) => {
+export type CascadePassSpecialization = {
+  hasUpperCascade: boolean;
+  mergeMode: MergeMode;
+};
+
+export type BuildRadianceFieldSpecialization = {
+  baseStoredRayDim: BaseStoredRayDim;
+};
+
+const part1By1 = tgpu.fn(
+  [d.u32],
+  d.u32,
+)((v) => {
   'use gpu';
-  const dim2 = std.textureDimensions(cascadePassBGL.$.dst);
-  if (gid.x >= dim2.x || gid.y >= dim2.y) {
-    return;
-  }
-
-  const params = cascadePassBGL.$.staticParams;
-  const layer = cascadePassBGL.$.layer;
-  const probes = std.max(
-    d.vec2u(params.baseProbes.x >>> layer, params.baseProbes.y >>> layer),
-    d.vec2u(1, 1),
-  );
-
-  const dirStored = gid.xy / probes;
-  const probe = gid.xy % probes;
-  const raysDimStored = d.u32(2) << layer;
-  const raysDimActual = raysDimStored * 2;
-  const rayCountActual = d.f32(raysDimActual) ** 2;
-
-  if (dirStored.x >= raysDimStored || dirStored.y >= raysDimStored) {
-    std.textureStore(cascadePassBGL.$.dst, gid.xy, d.vec4f(0, 0, 0, 1));
-    return;
-  }
-
-  // const probePos = d.vec2f(probe).add(0.5).div(d.vec2f(probes));
-  const probePos = (d.vec2f(probe) + 0.5) / d.vec2f(probes);
-  const aspect = params.baseProbes.x / params.baseProbes.y;
-  const cascadeProbesMinVal = d.f32(std.min(params.baseProbes.x, params.baseProbes.y));
-  const interval0 = 1 / cascadeProbesMinVal;
-  const pow4 = d.f32(d.u32(1) << (layer * 2));
-  const startUv = (interval0 * (pow4 - 1)) / 3;
-  const endUv = startUv + interval0 * pow4;
-
-  const sdfDim = sdfResolutionSlot.$;
-  const texelSizeMin = 1.0 / d.f32(std.max(std.min(sdfDim.x, sdfDim.y), 1));
-  // Use texel size as minimum threshold to avoid sub-texel stepping
-  const eps = std.max(texelSizeMin, 0.25 / cascadeProbesMinVal);
-  const minStep = std.max(texelSizeMin * 0.5, 0.125 / cascadeProbesMinVal);
-  const biasUv = d.f32(ERODE_BIAS) / cascadeProbesMinVal;
-
-  let accum = d.vec4f();
-
-  for (let i = d.u32(0); i < 4; i++) {
-    const dirActual = dirStored * 2 + d.vec2u(i & 1, i >>> 1);
-    const rayIndex = d.f32(dirActual.y * raysDimActual + dirActual.x) + 0.5;
-    const angle = (rayIndex / rayCountActual) * (Math.PI * 2) - Math.PI;
-    const cosA = std.cos(angle);
-    const sinA = -std.sin(angle);
-    let rayDir = d.vec2f(cosA, sinA);
-    if (aspect >= 1) {
-      rayDir = d.vec2f(cosA / aspect, sinA);
-    } else {
-      rayDir = d.vec2f(cosA, sinA * aspect);
-    }
-
-    const marchResult = rayMarchSlot.$(probePos, rayDir, startUv, endUv, eps, minStep, biasUv);
-    let rgb = d.vec3f(marchResult.color);
-    let T = d.f32(marchResult.transmittance);
-
-    if (layer < params.cascadeCount - 1 && T > 0.01) {
-      const probesU = std.max(d.vec2u(probes.x >>> 1, probes.y >>> 1), d.vec2u(1));
-      const tileOrigin = d.vec2f(dirActual) * d.vec2f(probesU);
-      const probePixel = std.clamp(
-        probePos * d.vec2f(probesU),
-        d.vec2f(0.5),
-        d.vec2f(probesU) - 0.5,
-      );
-      const uvU = (tileOrigin + probePixel) / d.vec2f(dim2);
-
-      const upper = std.textureSampleLevel(
-        cascadePassBGL.$.upper,
-        cascadePassBGL.$.upperSampler,
-        uvU,
-        0,
-      );
-      rgb = rgb + upper.xyz * T;
-      T *= upper.w;
-    }
-
-    accum += d.vec4f(rgb, T);
-  }
-
-  std.textureStore(cascadePassBGL.$.dst, gid.xy, accum * 0.25);
+  const x0 = v & 0x0000ffff;
+  const x1 = (x0 | (x0 << 8)) & 0x00ff00ff;
+  const x2 = (x1 | (x1 << 4)) & 0x0f0f0f0f;
+  const x3 = (x2 | (x2 << 2)) & 0x33333333;
+  return (x3 | (x3 << 1)) & 0x55555555;
 });
 
+const morton2D = tgpu.fn(
+  [d.u32, d.u32],
+  d.u32,
+)((x, y) => {
+  'use gpu';
+  return part1By1(x) | (part1By1(y) << 1);
+});
+
+const traceHardwareMergeRay = (
+  probePos: d.v2f,
+  rayDir: d.v2f,
+  dirActual: d.v2u,
+  probesU: d.v2u,
+  startUv: number,
+  clippedMarchEndUv: number,
+  marchEndUv: number,
+  exitUv: number,
+  eps: number,
+  minStep: number,
+  biasUv: number,
+) => {
+  'use gpu';
+  const marchResult = rayMarchSlot.$(
+    probePos,
+    rayDir,
+    startUv,
+    clippedMarchEndUv,
+    eps,
+    minStep,
+    biasUv,
+  );
+
+  if (marchResult.transmittance > 0.01 && exitUv > marchEndUv) {
+    const upperDim = std.textureDimensions(cascadePassBGL.$.upper);
+    const tileOrigin = d.vec2f(dirActual * probesU);
+    const probePixel = std.clamp(probePos * d.vec2f(probesU), d.vec2f(0.5), d.vec2f(probesU) - 0.5);
+    const uvU = (tileOrigin + probePixel) / d.vec2f(upperDim);
+
+    const upper = std.textureSampleLevel(
+      cascadePassBGL.$.upper,
+      cascadePassBGL.$.upperSampler,
+      uvU,
+      0,
+    );
+    return d.vec4f(
+      marchResult.color + upper.xyz * marchResult.transmittance,
+      marchResult.transmittance * upper.w,
+    );
+  }
+
+  return d.vec4f(marchResult.color, marchResult.transmittance);
+};
+
+const bilinearWeight = (forkOffset: d.v2u, bilinear: d.v2f) => {
+  'use gpu';
+  const weightX = std.select(bilinear.x, 1 - bilinear.x, forkOffset.x === 0);
+  const weightY = std.select(bilinear.y, 1 - bilinear.y, forkOffset.y === 0);
+  return weightX * weightY;
+};
+
+const traceBilinearFork = (
+  tileOriginU: d.v2u,
+  upperProbe: d.v2u,
+  probesU: d.v2u,
+  probePos: d.v2f,
+  rayDir: d.v2f,
+  startUv: number,
+  clippedMarchEndUv: number,
+  marchEndUv: number,
+  exitUv: number,
+  aspect: number,
+  eps: number,
+  minStep: number,
+  biasUv: number,
+) => {
+  'use gpu';
+  const upperProbePos = (d.vec2f(upperProbe) + 0.5) / d.vec2f(probesU);
+  const near = traceSegmentSlot.$(
+    probePos + rayDir * startUv,
+    upperProbePos + rayDir * clippedMarchEndUv,
+    aspect,
+    eps,
+    minStep,
+    biasUv,
+  );
+
+  if (near.transmittance > 0.01 && exitUv > marchEndUv) {
+    const upper = std.textureLoad(cascadePassBGL.$.upper, d.vec2i(tileOriginU + upperProbe), 0);
+    return d.vec4f(near.color + upper.xyz * near.transmittance, near.transmittance * upper.w);
+  }
+
+  return d.vec4f(near.color, near.transmittance);
+};
+
+const traceBilinearFixMergeRay = (
+  probePos: d.v2f,
+  rayDir: d.v2f,
+  dirActual: d.v2u,
+  probesU: d.v2u,
+  startUv: number,
+  clippedMarchEndUv: number,
+  marchEndUv: number,
+  exitUv: number,
+  aspect: number,
+  eps: number,
+  minStep: number,
+  biasUv: number,
+) => {
+  'use gpu';
+  const tileOriginU = dirActual * probesU;
+  const samplePos = std.clamp(probePos * d.vec2f(probesU) - 0.5, d.vec2f(0), d.vec2f(probesU) - 1);
+  const upperBaseProbe = d.vec2u(std.floor(samplePos));
+  const bilinear = samplePos - d.vec2f(upperBaseProbe);
+
+  let forkAccum = d.vec4f();
+
+  for (let fork = d.u32(); fork < BILINEAR_TAP_COUNT; fork++) {
+    const forkOffset = d.vec2u(fork & 1, fork >>> 1);
+    const upperProbe = std.min(upperBaseProbe + forkOffset, probesU - 1);
+    const weight = bilinearWeight(forkOffset, bilinear);
+
+    if (weight > 0) {
+      forkAccum +=
+        traceBilinearFork(
+          tileOriginU,
+          upperProbe,
+          probesU,
+          probePos,
+          rayDir,
+          startUv,
+          clippedMarchEndUv,
+          marchEndUv,
+          exitUv,
+          aspect,
+          eps,
+          minStep,
+          biasUv,
+        ) * weight;
+    }
+  }
+
+  return forkAccum;
+};
+
+const rayDirection = (rayIndex: number, rayCountActual: number, aspect: number) => {
+  'use gpu';
+  const angle = (rayIndex / rayCountActual) * (Math.PI * 2) - Math.PI;
+  const cosA = std.cos(angle);
+  const sinA = -std.sin(angle);
+  return std.select(d.vec2f(cosA, sinA * aspect), d.vec2f(cosA / aspect, sinA), aspect >= 1);
+};
+
+function createCascadePassCompute({ hasUpperCascade, mergeMode }: CascadePassSpecialization) {
+  const isHardwareMerge = mergeMode === 'hardware';
+
+  return tgpu.computeFn({
+    workgroupSize: [8, 8],
+    in: { gid: d.builtin.globalInvocationId },
+  })(({ gid }) => {
+    'use gpu';
+    const layerParams = cascadePassBGL.$.layerParams;
+    if (gid.x >= layerParams.validDim.x || gid.y >= layerParams.validDim.y) {
+      return;
+    }
+
+    const probes = layerParams.probes;
+    const rayCountActual = d.f32(layerParams.raysDimActual) ** 2;
+    const dirStored = gid.xy / probes;
+    const probe = gid.xy % probes;
+    const probePos = (d.vec2f(probe) + 0.5) / d.vec2f(probes);
+    const aspect = layerParams.aspect;
+    const eps = layerParams.eps;
+    const minStep = layerParams.minStep;
+    const biasUv = layerParams.hitBias;
+    const startUv = layerParams.startUv;
+    const marchEndUv = layerParams.endUv + layerParams.intervalOverlapUv;
+
+    let accum = d.vec4f();
+
+    for (let i = d.u32(); i < PREAVERAGE_RAY_COUNT; i++) {
+      const dirActual = dirStored * PREAVERAGE_RAY_DIM + d.vec2u(i & 1, i >>> 1);
+      const rayIndex = d.f32(morton2D(dirActual.x, dirActual.y)) + 0.5;
+      const rayDir = rayDirection(rayIndex, rayCountActual, aspect);
+      const exitUv = rayBoxExitUv(probePos, rayDir);
+      const clippedMarchEndUv = std.min(marchEndUv, exitUv);
+
+      if (exitUv <= startUv) {
+        accum += d.vec4f(0, 0, 0, 1);
+      } else if (hasUpperCascade) {
+        const probesU = layerParams.probesU;
+
+        if (isHardwareMerge) {
+          accum += traceHardwareMergeRay(
+            probePos,
+            rayDir,
+            dirActual,
+            probesU,
+            startUv,
+            clippedMarchEndUv,
+            marchEndUv,
+            exitUv,
+            eps,
+            minStep,
+            biasUv,
+          );
+        } else {
+          accum += traceBilinearFixMergeRay(
+            probePos,
+            rayDir,
+            dirActual,
+            probesU,
+            startUv,
+            clippedMarchEndUv,
+            marchEndUv,
+            exitUv,
+            aspect,
+            eps,
+            minStep,
+            biasUv,
+          );
+        }
+      } else {
+        const ray = rayMarchSlot.$(
+          probePos,
+          rayDir,
+          startUv,
+          clippedMarchEndUv,
+          eps,
+          minStep,
+          biasUv,
+        );
+        accum += d.vec4f(ray.color, ray.transmittance);
+      }
+    }
+
+    std.textureStore(cascadePassBGL.$.dst, gid.xy, accum / d.f32(PREAVERAGE_RAY_COUNT));
+  });
+}
+
+const cascadePassComputeCache = new Map<string, ReturnType<typeof createCascadePassCompute>>();
+
+export function makeCascadePassCompute(specialization: CascadePassSpecialization) {
+  const key = `${specialization.mergeMode}:${specialization.hasUpperCascade}`;
+  let compute = cascadePassComputeCache.get(key);
+  if (!compute) {
+    compute = createCascadePassCompute(specialization);
+    cascadePassComputeCache.set(key, compute);
+  }
+  return compute;
+}
+
 export const BuildRadianceFieldParams = d.struct({
-  outputProbes: d.vec2u,
-  cascadeProbes: d.vec2u,
+  probes: d.vec2f,
 });
 
 export const buildRadianceFieldBGL = tgpu.bindGroupLayout({
@@ -199,45 +511,58 @@ export const buildRadianceFieldBGL = tgpu.bindGroupLayout({
   dst: { storageTexture: d.textureStorage2d('rgba16float') },
 });
 
-export const buildRadianceFieldCompute = tgpu.computeFn({
-  workgroupSize: [8, 8],
-  in: { gid: d.builtin.globalInvocationId },
-})(({ gid }) => {
-  'use gpu';
-  const dim2 = std.textureDimensions(buildRadianceFieldBGL.$.dst);
-  if (gid.x >= dim2.x || gid.y >= dim2.y) {
-    return;
+function createBuildRadianceFieldCompute({ baseStoredRayDim }: BuildRadianceFieldSpecialization) {
+  const storedRayCount = baseStoredRayDim * baseStoredRayDim;
+  const rayMask = baseStoredRayDim - 1;
+  const rayShift = Math.log2(baseStoredRayDim);
+
+  return tgpu.computeFn({
+    workgroupSize: [8, 8],
+    in: { gid: d.builtin.globalInvocationId },
+  })(({ gid }) => {
+    'use gpu';
+    const dstDim = std.textureDimensions(buildRadianceFieldBGL.$.dst);
+    if (gid.x >= dstDim.x || gid.y >= dstDim.y) {
+      return;
+    }
+
+    const srcDim = std.textureDimensions(buildRadianceFieldBGL.$.src);
+    const cascadeProbeDim = buildRadianceFieldBGL.$.params.probes;
+    const invSrcDim = 1 / d.vec2f(srcDim);
+    const uv = (d.vec2f(gid.xy) + 0.5) / d.vec2f(dstDim);
+
+    const probePixel = std.clamp(uv * cascadeProbeDim, d.vec2f(0.5), cascadeProbeDim - 0.5);
+
+    const uvStride = cascadeProbeDim * invSrcDim;
+    const baseSampleUV = probePixel * invSrcDim;
+
+    let sum = d.vec3f();
+
+    for (const i of tgpu.unroll(std.range(storedRayCount))) {
+      const offset = d.vec2f(i & rayMask, i >> rayShift) * uvStride;
+      const sample = std.textureSampleLevel(
+        buildRadianceFieldBGL.$.src,
+        buildRadianceFieldBGL.$.srcSampler,
+        baseSampleUV + offset,
+        0,
+      );
+      sum += sample.xyz;
+    }
+
+    std.textureStore(buildRadianceFieldBGL.$.dst, gid.xy, d.vec4f(sum / d.f32(storedRayCount), 1));
+  });
+}
+
+const buildRadianceFieldComputeCache = new Map<
+  BaseStoredRayDim,
+  ReturnType<typeof createBuildRadianceFieldCompute>
+>();
+
+export function makeBuildRadianceFieldCompute(specialization: BuildRadianceFieldSpecialization) {
+  let compute = buildRadianceFieldComputeCache.get(specialization.baseStoredRayDim);
+  if (!compute) {
+    compute = createBuildRadianceFieldCompute(specialization);
+    buildRadianceFieldComputeCache.set(specialization.baseStoredRayDim, compute);
   }
-
-  const params = buildRadianceFieldBGL.$.params;
-  const cascadeDim = params.cascadeProbes * 2;
-
-  const invCascadeDim = 1 / d.vec2f(cascadeDim);
-  const uv = (d.vec2f(gid.xy) + 0.5) / d.vec2f(params.outputProbes);
-
-  const probePixel = std.clamp(
-    uv * d.vec2f(params.cascadeProbes),
-    d.vec2f(0.5),
-    d.vec2f(params.cascadeProbes) - 0.5,
-  );
-
-  const uvStride = d.vec2f(params.cascadeProbes) * invCascadeDim;
-  const baseSampleUV = probePixel * invCascadeDim;
-
-  let sum = d.vec3f();
-  for (let i = d.u32(0); i < 4; i++) {
-    const offset = d.vec2f(i & 1, i >>> 1) * uvStride;
-    const sample = std.textureSampleLevel(
-      buildRadianceFieldBGL.$.src,
-      buildRadianceFieldBGL.$.srcSampler,
-      baseSampleUV + offset,
-      0,
-    );
-    sum = sum + sample.xyz;
-  }
-
-  const avg = sum * 0.25;
-  const res = d.vec3f(avg);
-
-  std.textureStore(buildRadianceFieldBGL.$.dst, gid.xy, d.vec4f(res, 1));
-});
+  return compute;
+}

--- a/packages/typegpu-radiance-cascades/src/index.ts
+++ b/packages/typegpu-radiance-cascades/src/index.ts
@@ -1,11 +1,26 @@
 export { createRadianceCascades } from './runner.ts';
-export type { RadianceCascadesExecutor } from './runner.ts';
+export type {
+  CascadeTextureArray,
+  OwnedRadianceCascadesExecutor,
+  RadianceCascadesExecutor,
+} from './runner.ts';
 export {
   colorSlot,
+  defaultTraceSegment,
   defaultRayMarch,
   getCascadeDim,
+  getCascadeInfo,
+  maxRayStepsAccess,
+  rayMarchStepSafetyAccess,
   RayMarchResult,
   rayMarchSlot,
-  sdfResolutionSlot,
   sdfSlot,
+  traceSegmentSlot,
+} from './cascades.ts';
+export type {
+  BaseStoredRayDim,
+  CascadeInfo,
+  CascadeInfoOptions,
+  CascadeLayerInfo,
+  MergeMode,
 } from './cascades.ts';

--- a/packages/typegpu-radiance-cascades/src/runner.ts
+++ b/packages/typegpu-radiance-cascades/src/runner.ts
@@ -1,44 +1,58 @@
 import {
   d,
   isTexture,
+  isTextureView,
+  isUsableAsSampled,
   type SampledFlag,
   type StorageFlag,
   type TgpuBindGroup,
+  type TgpuCommandEncoder,
   type TgpuRoot,
   type TgpuTexture,
   type TgpuTextureView,
 } from 'typegpu';
 import {
+  type BaseStoredRayDim,
   buildRadianceFieldBGL,
-  buildRadianceFieldCompute,
   BuildRadianceFieldParams,
   cascadePassBGL,
-  cascadePassCompute,
-  CascadeStaticParams,
+  type CascadeLayerInfo,
+  CascadeLayerParams,
   colorSlot,
   defaultRayMarch,
-  getCascadeDim,
+  defaultTraceSegment,
+  getCascadeInfo,
+  makeBuildRadianceFieldCompute,
+  makeCascadePassCompute,
+  maxRayStepsAccess,
+  type MergeMode,
+  rayMarchStepSafetyAccess,
   type RayMarchResult,
   rayMarchSlot,
-  sdfResolutionSlot,
   sdfSlot,
+  traceSegmentSlot,
 } from './cascades.ts';
 
-type OutputTexture = TgpuTexture<{
-  size: [number, number];
+type RadianceTexture2D = TgpuTexture<{ size: [number, number]; format: 'rgba16float' }>;
+type RadianceTextureArray = TgpuTexture<{
+  size: [number, number, number];
   format: 'rgba16float';
-}> &
-  StorageFlag &
-  SampledFlag;
-type OutputTextureView = TgpuTextureView<d.WgslStorageTexture2d<'rgba16float', 'write-only'>>;
-type OutputResource = OutputTexture | OutputTextureView;
-type Size = { width: number; height: number };
+}>;
+type RadianceStorageView = TgpuTextureView<d.WgslStorageTexture2d<'rgba16float', 'write-only'>>;
 
-type CascadesOptions<TOutput extends OutputResource | undefined = OutputResource | undefined> = {
+type OutputTexture = (RadianceTexture2D & StorageFlag) | RadianceStorageView;
+
+type CascadeTexture2D = RadianceTexture2D & StorageFlag & SampledFlag;
+export type CascadeTextureArray = RadianceTextureArray & StorageFlag & SampledFlag;
+
+type CascadeTexture = CascadeTexture2D | CascadeTextureArray;
+type OutputSize = { width: number; height: number };
+
+type CascadesOptions = {
   root: TgpuRoot;
   sdf: (uv: d.v2f) => number;
   color: (uv: d.v2f) => d.v3f;
-  sdfResolution: Size;
+  sdfResolution: { width: number; height: number };
   rayMarch?: (
     probePos: d.v2f,
     rayDir: d.v2f,
@@ -48,15 +62,38 @@ type CascadesOptions<TOutput extends OutputResource | undefined = OutputResource
     minStep: number,
     bias: number,
   ) => d.InferGPU<typeof RayMarchResult>;
-  output?: TOutput;
-  size?: Size;
+  traceSegment?: (
+    p0: d.v2f,
+    p1: d.v2f,
+    aspect: number,
+    eps: number,
+    minStep: number,
+    bias: number,
+  ) => d.InferGPU<typeof RayMarchResult>;
+  output?: OutputTexture;
+  size?: OutputSize;
+  renderAspect?: number;
+  /** Tuning distances below are expressed in base-cascade probe spacings. */
+  erodeBiasProbes?: number | ((layer: CascadeLayerInfo) => number);
+  epsProbes?: number;
+  minStepProbes?: number;
+  maxRaySteps?: number;
+  /** Sphere-tracing step multiplier, in `(0, 1]`. Below 1 marches more conservatively. */
+  stepSafety?: number;
+  intervalOverlapProbes?: number | 'upperProbeSpacing';
+  baseStoredRayDim?: BaseStoredRayDim;
+  mergeMode?: MergeMode;
+  keepCascadeLayers?: boolean;
 };
 
-export type RadianceCascadesExecutor<TOutput extends OutputResource = OutputTexture> = {
-  run(): void;
+export type RadianceCascadesExecutor<TOutput extends OutputTexture = OutputTexture> = {
+  run(commandEncoder?: TgpuCommandEncoder): void;
   with(bindGroup: TgpuBindGroup): RadianceCascadesExecutor<TOutput>;
   destroy(): void;
   readonly output: TOutput;
+  readonly outputTexture: CascadeTexture2D | undefined;
+  readonly cascadeTexture: CascadeTextureArray | undefined;
+  readonly ownsOutput: boolean;
 
   /**
    * Eagerly initializes every pipeline by calling `initSync` on each.
@@ -70,29 +107,145 @@ export type RadianceCascadesExecutor<TOutput extends OutputResource = OutputText
   initAsync(): Promise<void>;
 };
 
-export function createRadianceCascades(
-  options: CascadesOptions<undefined> & { size: Size },
-): RadianceCascadesExecutor;
-export function createRadianceCascades<TOutput extends OutputResource>(
-  options: CascadesOptions<TOutput> & { output: TOutput },
-): RadianceCascadesExecutor<TOutput>;
-export function createRadianceCascades(
-  options: CascadesOptions,
-): RadianceCascadesExecutor<OutputResource> {
-  const { root, sdf, color, sdfResolution, output, size, rayMarch } = options;
+export type OwnedRadianceCascadesExecutor = RadianceCascadesExecutor<CascadeTexture2D> & {
+  readonly outputTexture: CascadeTexture2D;
+  readonly ownsOutput: true;
+};
 
-  const outputSize = output
-    ? isTexture(output)
-      ? output.props.size
-      : (output.size ?? (size && [size.width, size.height]))
-    : size && [size.width, size.height];
-  const outputWidth = outputSize?.[0];
-  const outputHeight = outputSize?.[1];
-  if (!outputWidth || !outputHeight) {
-    throw new Error('Size could not be inferred from output, pass explicit size in options.');
+function assertPositiveOption(name: string, value: number) {
+  if (!(value > 0)) {
+    throw new Error(`${name} must be positive.`);
+  }
+}
+
+function assertNonNegativeOption(name: string, value: number) {
+  if (value < 0) {
+    throw new Error(`${name} must be non-negative.`);
+  }
+}
+
+function assertStepSafety(value: number) {
+  if (!(value > 0) || value > 1) {
+    throw new Error('stepSafety must be within (0, 1], values above 1 overshoot the SDF bound.');
+  }
+}
+
+function getOutputSize(output: OutputTexture | undefined, size: OutputSize | undefined) {
+  if (output === undefined) {
+    if (!size) {
+      throw new Error('Size is required when output texture is not provided.');
+    }
+    return [size.width, size.height] as const;
   }
 
-  const dst: OutputResource =
+  if (isTexture(output)) {
+    return output.props.size;
+  }
+
+  const [width, height] = output.size ?? [size?.width, size?.height];
+  if (!width || !height) {
+    throw new Error('Size could not be inferred from texture view, pass explicit size in options.');
+  }
+  return [width, height] as const;
+}
+
+function createCascadeTexture(
+  root: TgpuRoot,
+  cascadeDimX: number,
+  cascadeDimY: number,
+  cascadeCount: number,
+  keepCascadeLayers: boolean,
+): CascadeTexture {
+  if (keepCascadeLayers) {
+    return root
+      .createTexture({
+        size: [cascadeDimX, cascadeDimY, cascadeCount],
+        format: 'rgba16float',
+      })
+      .$usage('storage', 'sampled');
+  }
+
+  return root
+    .createTexture({
+      size: [cascadeDimX, cascadeDimY],
+      format: 'rgba16float',
+    })
+    .$usage('storage', 'sampled');
+}
+
+function createCascadeSampleView(
+  texture: CascadeTexture,
+  layer: number,
+  keepCascadeLayers: boolean,
+) {
+  if (keepCascadeLayers) {
+    return (texture as CascadeTextureArray).createView(d.texture2d(d.f32), {
+      baseArrayLayer: layer,
+      arrayLayerCount: 1,
+    });
+  }
+
+  return (texture as CascadeTexture2D).createView(d.texture2d(d.f32));
+}
+
+function createCascadeStorageView(
+  texture: CascadeTexture,
+  layer: number,
+  keepCascadeLayers: boolean,
+) {
+  if (keepCascadeLayers) {
+    return (texture as CascadeTextureArray).createView(d.textureStorage2d('rgba16float'), {
+      baseArrayLayer: layer,
+      arrayLayerCount: 1,
+    });
+  }
+
+  return (texture as CascadeTexture2D).createView(d.textureStorage2d('rgba16float'));
+}
+
+export function createRadianceCascades(
+  options: CascadesOptions & { output?: undefined; size: OutputSize },
+): OwnedRadianceCascadesExecutor;
+export function createRadianceCascades<TOutput extends OutputTexture>(
+  options: CascadesOptions & { output: TOutput },
+): RadianceCascadesExecutor<TOutput>;
+export function createRadianceCascades(options: CascadesOptions): RadianceCascadesExecutor {
+  const { root, sdf, color, sdfResolution, output, size, rayMarch, traceSegment } = options;
+
+  if (output !== undefined && !isTexture(output) && !isTextureView(output)) {
+    throw new Error('output must be a TypeGPU texture or texture view.');
+  }
+
+  const [outputWidth, outputHeight] = getOutputSize(output, size);
+
+  if (!(sdfResolution.width > 0) || !(sdfResolution.height > 0)) {
+    throw new Error('sdfResolution must be positive.');
+  }
+
+  const mergeMode = options.mergeMode ?? 'hardware';
+  const keepCascadeLayers = options.keepCascadeLayers ?? false;
+  const baseStoredRayDim = options.baseStoredRayDim ?? 2;
+  const renderAspect = options.renderAspect ?? outputWidth / outputHeight;
+  const erodeBiasProbes = options.erodeBiasProbes ?? 1;
+  const epsProbes = options.epsProbes ?? 0.25;
+  const minStepProbes = options.minStepProbes ?? 0.125;
+  const maxRaySteps = Math.floor(options.maxRaySteps ?? 64);
+  const stepSafety = options.stepSafety ?? 1;
+  const intervalOverlapProbes = options.intervalOverlapProbes ?? 0;
+
+  assertPositiveOption('renderAspect', renderAspect);
+  if (typeof erodeBiasProbes === 'number') {
+    assertNonNegativeOption('erodeBiasProbes', erodeBiasProbes);
+  }
+  assertNonNegativeOption('epsProbes', epsProbes);
+  assertNonNegativeOption('minStepProbes', minStepProbes);
+  assertPositiveOption('maxRaySteps', maxRaySteps);
+  assertStepSafety(stepSafety);
+  if (typeof intervalOverlapProbes === 'number') {
+    assertNonNegativeOption('intervalOverlapProbes', intervalOverlapProbes);
+  }
+
+  const dst =
     output ??
     root
       .createTexture({
@@ -101,136 +254,190 @@ export function createRadianceCascades(
       })
       .$usage('storage', 'sampled');
 
-  const [cascadeDimX, cascadeDimY, cascadeAmount] = getCascadeDim(outputWidth, outputHeight);
+  const ownsOutput = output === undefined;
 
-  const cascadeProbesX = cascadeDimX / 2;
-  const cascadeProbesY = cascadeDimY / 2;
+  const {
+    baseProbes: [cascadeProbesX, cascadeProbesY],
+    cascadeDim: [cascadeDimX, cascadeDimY],
+    cascadeCount,
+    layers,
+  } = getCascadeInfo(outputWidth, outputHeight, { baseStoredRayDim });
+  const cascadeProbesMin = Math.min(cascadeProbesX, cascadeProbesY);
+  const sdfTexelSizeMin = 1 / Math.max(Math.min(sdfResolution.width, sdfResolution.height), 1);
+  const epsUv = Math.max(sdfTexelSizeMin, epsProbes / cascadeProbesMin);
+  const minStepUv = Math.max(sdfTexelSizeMin * 0.5, minStepProbes / cascadeProbesMin);
 
-  const cascadeTextureA = root
-    .createTexture({
-      size: [cascadeDimX, cascadeDimY, cascadeAmount],
-      format: 'rgba16float',
-    })
-    .$usage('storage', 'sampled');
+  const cascadeTextureA = createCascadeTexture(
+    root,
+    cascadeDimX,
+    cascadeDimY,
+    cascadeCount,
+    keepCascadeLayers,
+  );
 
-  const cascadeTextureB = root
-    .createTexture({
-      size: [cascadeDimX, cascadeDimY, cascadeAmount],
-      format: 'rgba16float',
-    })
-    .$usage('storage', 'sampled');
+  const cascadeTextureB = keepCascadeLayers
+    ? cascadeTextureA
+    : createCascadeTexture(root, cascadeDimX, cascadeDimY, cascadeCount, false);
+
+  const topUpperTexture = root
+    .createTexture({ size: [1, 1], format: 'rgba16float' })
+    .$usage('sampled');
+  const topUpperView = topUpperTexture.createView(d.texture2d(d.f32));
 
   const cascadeSampler = root.createSampler({
     magFilter: 'linear',
     minFilter: 'linear',
   });
 
-  const staticParamsBuffer = root
-    .createBuffer(CascadeStaticParams, {
-      baseProbes: [cascadeProbesX, cascadeProbesY],
-      cascadeDim: [cascadeDimX, cascadeDimY],
-      cascadeCount: cascadeAmount,
-    })
-    .$usage('uniform');
-
-  const layerBuffer = root.createBuffer(d.u32).$usage('uniform');
-
-  const cascadePassPipeline = root
-    .with(sdfResolutionSlot, d.vec2u(sdfResolution.width, sdfResolution.height))
-    .with(sdfSlot, sdf)
-    .with(colorSlot, color)
-    .with(rayMarchSlot, rayMarch ?? defaultRayMarch)
-    .createComputePipeline({ compute: cascadePassCompute });
-
-  const cascadePassBindGroups = Array.from({ length: cascadeAmount }, (_, layer) => {
-    const writeToA = (cascadeAmount - 1 - layer) % 2 === 0;
+  const cascadePasses = layers.map((layerInfo) => {
+    const { layer, validDim } = layerInfo;
+    const isTopCascade = layer === cascadeCount - 1;
+    const intervalOverlapUv = isTopCascade
+      ? 0
+      : typeof intervalOverlapProbes === 'number'
+        ? intervalOverlapProbes / cascadeProbesMin
+        : 1 / Math.min(layerInfo.probesU[0], layerInfo.probesU[1]);
+    const writeToA = (cascadeCount - 1 - layer) % 2 === 0;
     const dstTexture = writeToA ? cascadeTextureA : cascadeTextureB;
     const srcTexture = writeToA ? cascadeTextureB : cascadeTextureA;
-
-    return root.createBindGroup(cascadePassBGL, {
-      staticParams: staticParamsBuffer,
-      layer: layerBuffer,
-      upper: srcTexture.createView(d.texture2d(d.f32), {
-        baseArrayLayer: Math.min(layer + 1, cascadeAmount - 1),
-        arrayLayerCount: 1,
-      }),
-      upperSampler: cascadeSampler,
-      dst: dstTexture.createView(d.textureStorage2d('rgba16float'), {
-        baseArrayLayer: layer,
-        arrayLayerCount: 1,
-      }),
+    const layerErodeBiasProbes =
+      typeof erodeBiasProbes === 'number' ? erodeBiasProbes : erodeBiasProbes(layerInfo);
+    assertNonNegativeOption('erodeBiasProbes', layerErodeBiasProbes);
+    const layerParams = root.createUniform(CascadeLayerParams, {
+      probes: layerInfo.probes,
+      probesU: layerInfo.probesU,
+      validDim: layerInfo.validDim,
+      raysDimActual: layerInfo.raysDimActual,
+      startUv: layerInfo.startUv,
+      endUv: layerInfo.endUv,
+      intervalOverlapUv,
+      aspect: renderAspect,
+      eps: epsUv,
+      minStep: minStepUv,
+      hitBias: layerErodeBiasProbes / cascadeProbesMin,
     });
+
+    return {
+      layerParams,
+      bindGroup: root.createBindGroup(cascadePassBGL, {
+        layerParams,
+        upper: isTopCascade
+          ? topUpperView
+          : createCascadeSampleView(srcTexture, layer + 1, keepCascadeLayers),
+        upperSampler: cascadeSampler,
+        dst: createCascadeStorageView(dstTexture, layer, keepCascadeLayers),
+      }),
+      workgroups: [Math.ceil(validDim[0] / 8), Math.ceil(validDim[1] / 8)] as const,
+      isTopCascade,
+    };
+  });
+
+  const cascadePipelineBase = root
+    .with(sdfSlot, sdf)
+    .with(colorSlot, color)
+    .with(maxRayStepsAccess, maxRaySteps)
+    .with(rayMarchStepSafetyAccess, stepSafety)
+    .with(rayMarchSlot, rayMarch ?? defaultRayMarch)
+    .with(traceSegmentSlot, traceSegment ?? defaultTraceSegment);
+
+  const topCascadePipeline = cascadePipelineBase.createComputePipeline({
+    compute: makeCascadePassCompute({ mergeMode, hasUpperCascade: false }),
+  });
+
+  const mergeCascadePipeline = cascadePipelineBase.createComputePipeline({
+    compute: makeCascadePassCompute({ mergeMode, hasUpperCascade: true }),
   });
 
   const buildRadianceFieldPipeline = root.createComputePipeline({
-    compute: buildRadianceFieldCompute,
+    compute: makeBuildRadianceFieldCompute({ baseStoredRayDim }),
   });
 
-  const radianceFieldParamsBuffer = root
-    .createBuffer(BuildRadianceFieldParams, {
-      outputProbes: [outputWidth, outputHeight],
-      cascadeProbes: [cascadeProbesX, cascadeProbesY],
-    })
-    .$usage('uniform');
+  const buildRadianceFieldParams = root.createUniform(BuildRadianceFieldParams, {
+    probes: d.vec2f(cascadeProbesX, cascadeProbesY),
+  });
 
-  const cascade0InA = (cascadeAmount - 1) % 2 === 0;
+  const cascade0InA = (cascadeCount - 1) % 2 === 0;
   const srcCascadeTexture = cascade0InA ? cascadeTextureA : cascadeTextureB;
 
   const buildRadianceFieldBG = root.createBindGroup(buildRadianceFieldBGL, {
-    params: radianceFieldParamsBuffer,
-    src: srcCascadeTexture.createView(d.texture2d(d.f32), {
-      baseArrayLayer: 0,
-      arrayLayerCount: 1,
-    }),
+    params: buildRadianceFieldParams,
+    src: createCascadeSampleView(srcCascadeTexture, 0, keepCascadeLayers),
     srcSampler: cascadeSampler,
     dst,
   });
 
-  const cascadeWorkgroupsX = Math.ceil(cascadeDimX / 8);
-  const cascadeWorkgroupsY = Math.ceil(cascadeDimY / 8);
   const outputWorkgroupsX = Math.ceil(outputWidth / 8);
   const outputWorkgroupsY = Math.ceil(outputHeight / 8);
+  const outputTexture = isTexture(dst) && isUsableAsSampled(dst) ? dst : undefined;
+
+  let destroyed = false;
 
   function destroy() {
+    if (destroyed) {
+      return;
+    }
+    destroyed = true;
+
     cascadeTextureA.destroy();
-    cascadeTextureB.destroy();
-    if (!output && isTexture(dst)) {
+    if (cascadeTextureB !== cascadeTextureA) {
+      cascadeTextureB.destroy();
+    }
+    topUpperTexture.destroy();
+    buildRadianceFieldParams.buffer.destroy();
+    for (const { layerParams } of cascadePasses) {
+      layerParams.buffer.destroy();
+    }
+    if (ownsOutput && isTexture(dst)) {
       dst.destroy();
     }
   }
 
-  function createExecutor(
-    additionalBindGroups: TgpuBindGroup[] = [],
-  ): RadianceCascadesExecutor<OutputResource> {
-    const prebuiltCascadePipelines = cascadePassBindGroups.map((bg) => {
-      let p = cascadePassPipeline.with(bg);
-      for (const addBg of additionalBindGroups) {
-        p = p.with(addBg);
-      }
-      return p;
-    });
+  function createExecutor(additionalBindGroups: TgpuBindGroup[] = []): RadianceCascadesExecutor {
+    const prebuiltCascadePasses = cascadePasses
+      .map(({ bindGroup, workgroups, isTopCascade }) => {
+        const cascadePassPipeline = isTopCascade ? topCascadePipeline : mergeCascadePipeline;
+        let pipeline = cascadePassPipeline.with(bindGroup);
+        for (const addBg of additionalBindGroups) {
+          pipeline = pipeline.with(addBg);
+        }
+        return { pipeline, workgroups };
+      })
+      .toReversed();
 
     let prebuiltRadiancePipeline = buildRadianceFieldPipeline.with(buildRadianceFieldBG);
     for (const bg of additionalBindGroups) {
       prebuiltRadiancePipeline = prebuiltRadiancePipeline.with(bg);
     }
 
-    function run() {
-      for (let layer = cascadeAmount - 1; layer >= 0; layer--) {
-        layerBuffer.write(layer);
-        prebuiltCascadePipelines[layer]?.dispatchWorkgroups(cascadeWorkgroupsX, cascadeWorkgroupsY);
+    function run(commandEncoder?: TgpuCommandEncoder) {
+      const encoder = commandEncoder ?? root['~unstable'].createCommandEncoder();
+      const pass = encoder.beginComputePass();
+
+      for (const { pipeline, workgroups } of prebuiltCascadePasses) {
+        pipeline.with(pass).dispatchWorkgroups(...workgroups);
       }
 
-      prebuiltRadiancePipeline.dispatchWorkgroups(outputWorkgroupsX, outputWorkgroupsY);
+      prebuiltRadiancePipeline.with(pass).dispatchWorkgroups(outputWorkgroupsX, outputWorkgroupsY);
+      pass.end();
+
+      if (!commandEncoder) {
+        encoder.submit();
+      }
     }
 
-    const pipelines = [...prebuiltCascadePipelines, prebuiltRadiancePipeline];
+    const pipelines = [
+      ...prebuiltCascadePasses.map(({ pipeline }) => pipeline),
+      prebuiltRadiancePipeline,
+    ];
 
     return {
       run,
       with: (bg) => createExecutor([...additionalBindGroups, bg]),
       destroy,
       output: dst,
+      outputTexture,
+      cascadeTexture: keepCascadeLayers ? (cascadeTextureA as CascadeTextureArray) : undefined,
+      ownsOutput,
       initSync: () => pipelines.forEach((pipeline) => pipeline.initSync()),
       initAsync: () =>
         Promise.all(pipelines.map((pipeline) => pipeline.initAsync())).then(() => {}),

--- a/packages/typegpu-radiance-cascades/src/runner.ts
+++ b/packages/typegpu-radiance-cascades/src/runner.ts
@@ -15,6 +15,7 @@ import {
   type BaseStoredRayDim,
   buildRadianceFieldBGL,
   BuildRadianceFieldParams,
+  CASCADE_WORKGROUP_DIM,
   cascadePassBGL,
   type CascadeLayerInfo,
   CascadeLayerParams,
@@ -327,8 +328,14 @@ export function createRadianceCascades(options: CascadesOptions): RadianceCascad
         upperSampler: cascadeSampler,
         dst: createCascadeStorageView(dstTexture, layer, keepCascadeLayers),
       }),
-      workgroups: [Math.ceil(validDim[0] / 8), Math.ceil(validDim[1] / 8)] as const,
+      workgroups: [
+        Math.ceil(validDim[0] / CASCADE_WORKGROUP_DIM),
+        Math.ceil(validDim[1] / CASCADE_WORKGROUP_DIM),
+      ] as const,
       isTopCascade,
+      useSharedRayDirections: layerInfo.probes.every(
+        (probeDim) => probeDim >= CASCADE_WORKGROUP_DIM && probeDim % CASCADE_WORKGROUP_DIM === 0,
+      ),
     };
   });
 
@@ -340,13 +347,26 @@ export function createRadianceCascades(options: CascadesOptions): RadianceCascad
     .with(rayMarchSlot, rayMarch ?? defaultRayMarch)
     .with(traceSegmentSlot, traceSegment ?? defaultTraceSegment);
 
-  const topCascadePipeline = cascadePipelineBase.createComputePipeline({
-    compute: makeCascadePassCompute({ mergeMode, hasUpperCascade: false }),
-  });
+  const cascadePipelineCache = new Map<
+    string,
+    ReturnType<typeof cascadePipelineBase.createComputePipeline>
+  >();
 
-  const mergeCascadePipeline = cascadePipelineBase.createComputePipeline({
-    compute: makeCascadePassCompute({ mergeMode, hasUpperCascade: true }),
-  });
+  function getCascadePipeline(hasUpperCascade: boolean, useSharedRayDirections: boolean) {
+    const key = `${hasUpperCascade}:${useSharedRayDirections}`;
+    let pipeline = cascadePipelineCache.get(key);
+    if (!pipeline) {
+      pipeline = cascadePipelineBase.createComputePipeline({
+        compute: makeCascadePassCompute({
+          mergeMode,
+          hasUpperCascade,
+          useSharedRayDirections,
+        }),
+      });
+      cascadePipelineCache.set(key, pipeline);
+    }
+    return pipeline;
+  }
 
   const buildRadianceFieldPipeline = root.createComputePipeline({
     compute: makeBuildRadianceFieldCompute({ baseStoredRayDim }),
@@ -394,8 +414,8 @@ export function createRadianceCascades(options: CascadesOptions): RadianceCascad
 
   function createExecutor(additionalBindGroups: TgpuBindGroup[] = []): RadianceCascadesExecutor {
     const prebuiltCascadePasses = cascadePasses
-      .map(({ bindGroup, workgroups, isTopCascade }) => {
-        const cascadePassPipeline = isTopCascade ? topCascadePipeline : mergeCascadePipeline;
+      .map(({ bindGroup, workgroups, isTopCascade, useSharedRayDirections }) => {
+        const cascadePassPipeline = getCascadePipeline(!isTopCascade, useSharedRayDirections);
         let pipeline = cascadePassPipeline.with(bindGroup);
         for (const addBg of additionalBindGroups) {
           pipeline = pipeline.with(addBg);

--- a/packages/typegpu-radiance-cascades/tests/cascades.test.ts
+++ b/packages/typegpu-radiance-cascades/tests/cascades.test.ts
@@ -1,0 +1,738 @@
+import { describe, expect, it } from 'vitest';
+import { d, tgpu } from 'typegpu';
+import {
+  colorSlot,
+  getCascadeInfo,
+  makeBuildRadianceFieldCompute,
+  makeCascadePassCompute,
+  sdfSlot,
+} from '../src/cascades.ts';
+
+describe('getCascadeInfo', () => {
+  it('computes contiguous ray intervals across layers', () => {
+    const info = getCascadeInfo(1024, 768);
+    for (let i = 1; i < info.layers.length; i++) {
+      expect(info.layers[i]?.startUv).toBeCloseTo(info.layers[i - 1]?.endUv ?? Number.NaN, 6);
+    }
+    expect(info.layers[0]?.startUv).toBe(0);
+  });
+
+  it('covers the full diagonal range with the top cascade', () => {
+    const info = getCascadeInfo(1024, 768);
+    const topLayer = info.layers[info.layers.length - 1];
+    expect(topLayer?.endUv ?? 0).toBeGreaterThanOrEqual(info.maxRange);
+  });
+
+  it('halves probes and doubles stored rays per layer', () => {
+    const info = getCascadeInfo(512, 512, { baseStoredRayDim: 2 });
+    for (const layer of info.layers) {
+      expect(layer.probes[0]).toBe(Math.max(Math.floor(512 / 2 ** layer.layer), 1));
+      expect(layer.raysDimStored).toBe(2 * 2 ** layer.layer);
+      expect(layer.raysDimActual).toBe(layer.raysDimStored * 2);
+    }
+  });
+
+  it('keeps the valid region within the cascade texture', () => {
+    for (const [w, h] of [
+      [1024, 768],
+      [333, 777],
+      [1920, 1080],
+      [64, 64],
+    ] as const) {
+      const info = getCascadeInfo(w, h);
+      for (const layer of info.layers) {
+        expect(layer.validDim[0]).toBeLessThanOrEqual(info.cascadeDim[0]);
+        expect(layer.validDim[1]).toBeLessThanOrEqual(info.cascadeDim[1]);
+      }
+    }
+  });
+
+  it('scales probe grid to aspect ratio', () => {
+    const wide = getCascadeInfo(2048, 512);
+    expect(wide.baseProbes[0]).toBeGreaterThan(wide.baseProbes[1]);
+    const tall = getCascadeInfo(512, 2048);
+    expect(tall.baseProbes[1]).toBeGreaterThan(tall.baseProbes[0]);
+  });
+
+  it('rejects invalid sizes and ray dims', () => {
+    expect(() => getCascadeInfo(0, 512)).toThrow();
+    expect(() => getCascadeInfo(512, -1)).toThrow();
+    expect(() => getCascadeInfo(512, 512, { baseStoredRayDim: 3 as never })).toThrow();
+  });
+});
+
+const sdfImpl = tgpu.fn([d.vec2f], d.f32)`(uv: vec2f) -> f32 {
+  return length(uv - vec2f(0.5)) - 0.25;
+}`;
+const colorImpl = tgpu.fn([d.vec2f], d.vec3f)`(uv: vec2f) -> vec3f {
+  return vec3f(uv, 1.0);
+}`;
+
+function resolveCascadePass(mergeMode: 'hardware' | 'bilinear-fix', hasUpperCascade: boolean) {
+  return tgpu.resolve([makeCascadePassCompute({ mergeMode, hasUpperCascade })], {
+    config: (cfg) => cfg.with(sdfSlot, sdfImpl).with(colorSlot, colorImpl),
+  });
+}
+
+describe('makeCascadePassCompute', () => {
+  it('resolves the hardware merge variant', () => {
+    expect(resolveCascadePass('hardware', true)).toMatchInlineSnapshot(`
+      "struct CascadeLayerParams {
+        probes: vec2u,
+        probesU: vec2u,
+        validDim: vec2u,
+        raysDimActual: u32,
+        startUv: f32,
+        endUv: f32,
+        intervalOverlapUv: f32,
+        aspect: f32,
+        eps: f32,
+        minStep: f32,
+        hitBias: f32,
+      }
+
+      @group(0) @binding(0) var<uniform> layerParams_1: CascadeLayerParams;
+
+      fn part1By1(v: u32) -> u32 {
+        let x0 = (v & 65535u);
+        let x1 = ((x0 | (x0 << 8u)) & 16711935u);
+        let x2 = ((x1 | (x1 << 4u)) & 252645135u);
+        let x3 = ((x2 | (x2 << 2u)) & 858993459u);
+        return ((x3 | (x3 << 1u)) & 1431655765u);
+      }
+
+      fn morton2D(x: u32, y: u32) -> u32 {
+        return (part1By1(x) | (part1By1(y) << 1u));
+      }
+
+      fn rayDirection(rayIndex: f32, rayCountActual: f32, aspect: f32) -> vec2f {
+        let angle = (((rayIndex / rayCountActual) * 6.283185307179586f) - 3.141592653589793f);
+        let cosA = cos(angle);
+        let sinA = -(sin(angle));
+        return select(vec2f(cosA, (sinA * aspect)), vec2f((cosA / aspect), sinA), (aspect >= 1f));
+      }
+
+      fn rayBoxExitUv(p: vec2f, dir: vec2f) -> f32 {
+        var tx = 3.4028234663852886e+38f;
+        var ty = 3.4028234663852886e+38f;
+        if ((abs(dir.x) > 1e-6f)) {
+          tx = select((-(p.x) / dir.x), ((1f - p.x) / dir.x), (dir.x > 0f));
+        }
+        if ((abs(dir.y) > 1e-6f)) {
+          ty = select((-(p.y) / dir.y), ((1f - p.y) / dir.y), (dir.y > 0f));
+        }
+        return max(0f, min(tx, ty));
+      }
+
+      fn sdfImpl(uv: vec2f) -> f32 {
+        return length(uv - vec2f(0.5)) - 0.25;
+      }
+
+      fn colorImpl(uv: vec2f) -> vec3f {
+        return vec3f(uv, 1.0);
+      }
+
+      struct RayMarchResult {
+        color: vec3f,
+        transmittance: f32,
+      }
+
+      fn defaultRayMarch(probePos: vec2f, rayDir: vec2f, startT: f32, endT: f32, eps: f32, minStep: f32, bias: f32) -> RayMarchResult {
+        var t = startT;
+        for (var step_1 = 0u; (step_1 < 64u); step_1++) {
+          if ((t > endT)) {
+            break;
+          }
+          let pos = (probePos + (rayDir * t));
+          let hitDist = (sdfImpl(pos) + bias);
+          if ((hitDist <= eps)) {
+            return RayMarchResult(colorImpl(pos), 0f);
+          }
+          t += max((hitDist * 1f), minStep);
+        }
+        return RayMarchResult(vec3f(), 1f);
+      }
+
+      @group(0) @binding(1) var upper: texture_2d<f32>;
+
+      @group(0) @binding(2) var upperSampler: sampler;
+
+      fn traceHardwareMergeRay(probePos: vec2f, rayDir: vec2f, dirActual: vec2u, probesU: vec2u, startUv: f32, clippedMarchEndUv: f32, marchEndUv: f32, exitUv: f32, eps: f32, minStep: f32, biasUv: f32) -> vec4f {
+        let marchResult = defaultRayMarch(probePos, rayDir, startUv, clippedMarchEndUv, eps, minStep, biasUv);
+        if (((marchResult.transmittance > 0.01f) && (exitUv > marchEndUv))) {
+          let upperDim = textureDimensions(upper);
+          let tileOrigin = vec2f((dirActual * probesU));
+          let probePixel = clamp((probePos * vec2f(probesU)), vec2f(0.5), (vec2f(probesU) - 0.5f));
+          let uvU = ((tileOrigin + probePixel) / vec2f(upperDim));
+          let upper_1 = textureSampleLevel(upper, upperSampler, uvU, 0);
+          return vec4f((marchResult.color + (upper_1.xyz * marchResult.transmittance)), (marchResult.transmittance * upper_1.w));
+        }
+        return vec4f(marchResult.color, marchResult.transmittance);
+      }
+
+      @group(0) @binding(3) var dst: texture_storage_2d<rgba16float, write>;
+
+      @compute @workgroup_size(8, 8) fn item(@builtin(global_invocation_id) gid: vec3u) {
+        let layerParams = (&layerParams_1);
+        if (((gid.x >= (*layerParams).validDim.x) || (gid.y >= (*layerParams).validDim.y))) {
+          return;
+        }
+        let probes = (&(*layerParams).probes);
+        let rayCountActual = pow(f32((*layerParams).raysDimActual), 2f);
+        let dirStored = (gid.xy / (*probes));
+        let probe = (gid.xy % (*probes));
+        let probePos = ((vec2f(probe) + 0.5f) / vec2f((*probes)));
+        let aspect = (*layerParams).aspect;
+        let eps = (*layerParams).eps;
+        let minStep = (*layerParams).minStep;
+        let biasUv = (*layerParams).hitBias;
+        let startUv = (*layerParams).startUv;
+        let marchEndUv = ((*layerParams).endUv + (*layerParams).intervalOverlapUv);
+        var accum = vec4f();
+        for (var i = 0u; (i < 4u); i++) {
+          let dirActual = ((dirStored * 2u) + vec2u((i & 1u), (i >> 1u)));
+          let rayIndex = (f32(morton2D(dirActual.x, dirActual.y)) + 0.5f);
+          let rayDir = rayDirection(rayIndex, rayCountActual, aspect);
+          let exitUv = rayBoxExitUv(probePos, rayDir);
+          let clippedMarchEndUv = min(marchEndUv, exitUv);
+          if ((exitUv <= startUv)) {
+            accum += vec4f(0, 0, 0, 1);
+          }
+          else {
+            {
+              let probesU = (&(*layerParams).probesU);
+              accum += traceHardwareMergeRay(probePos, rayDir, dirActual, (*probesU), startUv, clippedMarchEndUv, marchEndUv, exitUv, eps, minStep, biasUv);
+            }
+          }
+        }
+        textureStore(dst, gid.xy, (accum / 4f));
+      }"
+    `);
+  });
+
+  it('resolves the bilinear-fix merge variant', () => {
+    expect(resolveCascadePass('bilinear-fix', true)).toMatchInlineSnapshot(`
+      "struct CascadeLayerParams {
+        probes: vec2u,
+        probesU: vec2u,
+        validDim: vec2u,
+        raysDimActual: u32,
+        startUv: f32,
+        endUv: f32,
+        intervalOverlapUv: f32,
+        aspect: f32,
+        eps: f32,
+        minStep: f32,
+        hitBias: f32,
+      }
+
+      @group(0) @binding(0) var<uniform> layerParams_1: CascadeLayerParams;
+
+      fn part1By1(v: u32) -> u32 {
+        let x0 = (v & 65535u);
+        let x1 = ((x0 | (x0 << 8u)) & 16711935u);
+        let x2 = ((x1 | (x1 << 4u)) & 252645135u);
+        let x3 = ((x2 | (x2 << 2u)) & 858993459u);
+        return ((x3 | (x3 << 1u)) & 1431655765u);
+      }
+
+      fn morton2D(x: u32, y: u32) -> u32 {
+        return (part1By1(x) | (part1By1(y) << 1u));
+      }
+
+      fn rayDirection(rayIndex: f32, rayCountActual: f32, aspect: f32) -> vec2f {
+        let angle = (((rayIndex / rayCountActual) * 6.283185307179586f) - 3.141592653589793f);
+        let cosA = cos(angle);
+        let sinA = -(sin(angle));
+        return select(vec2f(cosA, (sinA * aspect)), vec2f((cosA / aspect), sinA), (aspect >= 1f));
+      }
+
+      fn rayBoxExitUv(p: vec2f, dir: vec2f) -> f32 {
+        var tx = 3.4028234663852886e+38f;
+        var ty = 3.4028234663852886e+38f;
+        if ((abs(dir.x) > 1e-6f)) {
+          tx = select((-(p.x) / dir.x), ((1f - p.x) / dir.x), (dir.x > 0f));
+        }
+        if ((abs(dir.y) > 1e-6f)) {
+          ty = select((-(p.y) / dir.y), ((1f - p.y) / dir.y), (dir.y > 0f));
+        }
+        return max(0f, min(tx, ty));
+      }
+
+      fn bilinearWeight(forkOffset: vec2u, bilinear: vec2f) -> f32 {
+        let weightX = select(bilinear.x, (1f - bilinear.x), (forkOffset.x == 0u));
+        let weightY = select(bilinear.y, (1f - bilinear.y), (forkOffset.y == 0u));
+        return (weightX * weightY);
+      }
+
+      struct RayMarchResult {
+        color: vec3f,
+        transmittance: f32,
+      }
+
+      fn sdfImpl(uv: vec2f) -> f32 {
+        return length(uv - vec2f(0.5)) - 0.25;
+      }
+
+      fn colorImpl(uv: vec2f) -> vec3f {
+        return vec3f(uv, 1.0);
+      }
+
+      fn defaultRayMarch(probePos: vec2f, rayDir: vec2f, startT: f32, endT: f32, eps: f32, minStep: f32, bias: f32) -> RayMarchResult {
+        var t = startT;
+        for (var step_1 = 0u; (step_1 < 64u); step_1++) {
+          if ((t > endT)) {
+            break;
+          }
+          let pos = (probePos + (rayDir * t));
+          let hitDist = (sdfImpl(pos) + bias);
+          if ((hitDist <= eps)) {
+            return RayMarchResult(colorImpl(pos), 0f);
+          }
+          t += max((hitDist * 1f), minStep);
+        }
+        return RayMarchResult(vec3f(), 1f);
+      }
+
+      fn defaultTraceSegment(p0: vec2f, p1: vec2f, aspect: f32, eps: f32, minStep: f32, bias: f32) -> RayMarchResult {
+        let delta = (p1 - p0);
+        let metricDelta = select(vec2f(delta.x, (delta.y / aspect)), vec2f((delta.x * aspect), delta.y), (aspect >= 1f));
+        let endT = length(metricDelta);
+        if ((endT <= 0f)) {
+          return RayMarchResult(vec3f(), 1f);
+        }
+        let rayDir = (delta / endT);
+        return defaultRayMarch(p0, rayDir, 0f, min(endT, rayBoxExitUv(p0, rayDir)), eps, minStep, bias);
+      }
+
+      @group(0) @binding(1) var upper: texture_2d<f32>;
+
+      fn traceBilinearFork(tileOriginU: vec2u, upperProbe: vec2u, probesU: vec2u, probePos: vec2f, rayDir: vec2f, startUv: f32, clippedMarchEndUv: f32, marchEndUv: f32, exitUv: f32, aspect: f32, eps: f32, minStep: f32, biasUv: f32) -> vec4f {
+        let upperProbePos = ((vec2f(upperProbe) + 0.5f) / vec2f(probesU));
+        let near = defaultTraceSegment((probePos + (rayDir * startUv)), (upperProbePos + (rayDir * clippedMarchEndUv)), aspect, eps, minStep, biasUv);
+        if (((near.transmittance > 0.01f) && (exitUv > marchEndUv))) {
+          let upper_1 = textureLoad(upper, vec2i((tileOriginU + upperProbe)), 0);
+          return vec4f((near.color + (upper_1.xyz * near.transmittance)), (near.transmittance * upper_1.w));
+        }
+        return vec4f(near.color, near.transmittance);
+      }
+
+      fn traceBilinearFixMergeRay(probePos: vec2f, rayDir: vec2f, dirActual: vec2u, probesU: vec2u, startUv: f32, clippedMarchEndUv: f32, marchEndUv: f32, exitUv: f32, aspect: f32, eps: f32, minStep: f32, biasUv: f32) -> vec4f {
+        let tileOriginU = (dirActual * probesU);
+        let samplePos = clamp(((probePos * vec2f(probesU)) - 0.5f), vec2f(), (vec2f(probesU) - 1f));
+        let upperBaseProbe = vec2u(floor(samplePos));
+        let bilinear = (samplePos - vec2f(upperBaseProbe));
+        var forkAccum = vec4f();
+        for (var fork = 0u; (fork < 4u); fork++) {
+          let forkOffset = vec2u((fork & 1u), (fork >> 1u));
+          let upperProbe = min((upperBaseProbe + forkOffset), (probesU - 1u));
+          let weight = bilinearWeight(forkOffset, bilinear);
+          if ((weight > 0f)) {
+            forkAccum += (traceBilinearFork(tileOriginU, upperProbe, probesU, probePos, rayDir, startUv, clippedMarchEndUv, marchEndUv, exitUv, aspect, eps, minStep, biasUv) * weight);
+          }
+        }
+        return forkAccum;
+      }
+
+      @group(0) @binding(3) var dst: texture_storage_2d<rgba16float, write>;
+
+      @compute @workgroup_size(8, 8) fn item(@builtin(global_invocation_id) gid: vec3u) {
+        let layerParams = (&layerParams_1);
+        if (((gid.x >= (*layerParams).validDim.x) || (gid.y >= (*layerParams).validDim.y))) {
+          return;
+        }
+        let probes = (&(*layerParams).probes);
+        let rayCountActual = pow(f32((*layerParams).raysDimActual), 2f);
+        let dirStored = (gid.xy / (*probes));
+        let probe = (gid.xy % (*probes));
+        let probePos = ((vec2f(probe) + 0.5f) / vec2f((*probes)));
+        let aspect = (*layerParams).aspect;
+        let eps = (*layerParams).eps;
+        let minStep = (*layerParams).minStep;
+        let biasUv = (*layerParams).hitBias;
+        let startUv = (*layerParams).startUv;
+        let marchEndUv = ((*layerParams).endUv + (*layerParams).intervalOverlapUv);
+        var accum = vec4f();
+        for (var i = 0u; (i < 4u); i++) {
+          let dirActual = ((dirStored * 2u) + vec2u((i & 1u), (i >> 1u)));
+          let rayIndex = (f32(morton2D(dirActual.x, dirActual.y)) + 0.5f);
+          let rayDir = rayDirection(rayIndex, rayCountActual, aspect);
+          let exitUv = rayBoxExitUv(probePos, rayDir);
+          let clippedMarchEndUv = min(marchEndUv, exitUv);
+          if ((exitUv <= startUv)) {
+            accum += vec4f(0, 0, 0, 1);
+          }
+          else {
+            {
+              let probesU = (&(*layerParams).probesU);
+              accum += traceBilinearFixMergeRay(probePos, rayDir, dirActual, (*probesU), startUv, clippedMarchEndUv, marchEndUv, exitUv, aspect, eps, minStep, biasUv);
+            }
+          }
+        }
+        textureStore(dst, gid.xy, (accum / 4f));
+      }"
+    `);
+  });
+
+  it('resolves the top cascade variant without upper sampling', () => {
+    expect(resolveCascadePass('hardware', false)).toMatchInlineSnapshot(`
+      "struct CascadeLayerParams {
+        probes: vec2u,
+        probesU: vec2u,
+        validDim: vec2u,
+        raysDimActual: u32,
+        startUv: f32,
+        endUv: f32,
+        intervalOverlapUv: f32,
+        aspect: f32,
+        eps: f32,
+        minStep: f32,
+        hitBias: f32,
+      }
+
+      @group(0) @binding(0) var<uniform> layerParams_1: CascadeLayerParams;
+
+      fn part1By1(v: u32) -> u32 {
+        let x0 = (v & 65535u);
+        let x1 = ((x0 | (x0 << 8u)) & 16711935u);
+        let x2 = ((x1 | (x1 << 4u)) & 252645135u);
+        let x3 = ((x2 | (x2 << 2u)) & 858993459u);
+        return ((x3 | (x3 << 1u)) & 1431655765u);
+      }
+
+      fn morton2D(x: u32, y: u32) -> u32 {
+        return (part1By1(x) | (part1By1(y) << 1u));
+      }
+
+      fn rayDirection(rayIndex: f32, rayCountActual: f32, aspect: f32) -> vec2f {
+        let angle = (((rayIndex / rayCountActual) * 6.283185307179586f) - 3.141592653589793f);
+        let cosA = cos(angle);
+        let sinA = -(sin(angle));
+        return select(vec2f(cosA, (sinA * aspect)), vec2f((cosA / aspect), sinA), (aspect >= 1f));
+      }
+
+      fn rayBoxExitUv(p: vec2f, dir: vec2f) -> f32 {
+        var tx = 3.4028234663852886e+38f;
+        var ty = 3.4028234663852886e+38f;
+        if ((abs(dir.x) > 1e-6f)) {
+          tx = select((-(p.x) / dir.x), ((1f - p.x) / dir.x), (dir.x > 0f));
+        }
+        if ((abs(dir.y) > 1e-6f)) {
+          ty = select((-(p.y) / dir.y), ((1f - p.y) / dir.y), (dir.y > 0f));
+        }
+        return max(0f, min(tx, ty));
+      }
+
+      fn sdfImpl(uv: vec2f) -> f32 {
+        return length(uv - vec2f(0.5)) - 0.25;
+      }
+
+      fn colorImpl(uv: vec2f) -> vec3f {
+        return vec3f(uv, 1.0);
+      }
+
+      struct RayMarchResult {
+        color: vec3f,
+        transmittance: f32,
+      }
+
+      fn defaultRayMarch(probePos: vec2f, rayDir: vec2f, startT: f32, endT: f32, eps: f32, minStep: f32, bias: f32) -> RayMarchResult {
+        var t = startT;
+        for (var step_1 = 0u; (step_1 < 64u); step_1++) {
+          if ((t > endT)) {
+            break;
+          }
+          let pos = (probePos + (rayDir * t));
+          let hitDist = (sdfImpl(pos) + bias);
+          if ((hitDist <= eps)) {
+            return RayMarchResult(colorImpl(pos), 0f);
+          }
+          t += max((hitDist * 1f), minStep);
+        }
+        return RayMarchResult(vec3f(), 1f);
+      }
+
+      @group(0) @binding(3) var dst: texture_storage_2d<rgba16float, write>;
+
+      @compute @workgroup_size(8, 8) fn item(@builtin(global_invocation_id) gid: vec3u) {
+        let layerParams = (&layerParams_1);
+        if (((gid.x >= (*layerParams).validDim.x) || (gid.y >= (*layerParams).validDim.y))) {
+          return;
+        }
+        let probes = (&(*layerParams).probes);
+        let rayCountActual = pow(f32((*layerParams).raysDimActual), 2f);
+        let dirStored = (gid.xy / (*probes));
+        let probe = (gid.xy % (*probes));
+        let probePos = ((vec2f(probe) + 0.5f) / vec2f((*probes)));
+        let aspect = (*layerParams).aspect;
+        let eps = (*layerParams).eps;
+        let minStep = (*layerParams).minStep;
+        let biasUv = (*layerParams).hitBias;
+        let startUv = (*layerParams).startUv;
+        let marchEndUv = ((*layerParams).endUv + (*layerParams).intervalOverlapUv);
+        var accum = vec4f();
+        for (var i = 0u; (i < 4u); i++) {
+          let dirActual = ((dirStored * 2u) + vec2u((i & 1u), (i >> 1u)));
+          let rayIndex = (f32(morton2D(dirActual.x, dirActual.y)) + 0.5f);
+          let rayDir = rayDirection(rayIndex, rayCountActual, aspect);
+          let exitUv = rayBoxExitUv(probePos, rayDir);
+          let clippedMarchEndUv = min(marchEndUv, exitUv);
+          if ((exitUv <= startUv)) {
+            accum += vec4f(0, 0, 0, 1);
+          }
+          else {
+            {
+              let ray = defaultRayMarch(probePos, rayDir, startUv, clippedMarchEndUv, eps, minStep, biasUv);
+              accum += vec4f(ray.color, ray.transmittance);
+            }
+          }
+        }
+        textureStore(dst, gid.xy, (accum / 4f));
+      }"
+    `);
+  });
+
+  it('memoizes per specialization', () => {
+    const a = makeCascadePassCompute({ mergeMode: 'hardware', hasUpperCascade: true });
+    const b = makeCascadePassCompute({ mergeMode: 'hardware', hasUpperCascade: true });
+    expect(a).toBe(b);
+    const c = makeCascadePassCompute({ mergeMode: 'bilinear-fix', hasUpperCascade: true });
+    expect(a).not.toBe(c);
+  });
+});
+
+describe('makeBuildRadianceFieldCompute', () => {
+  it('resolves for stored ray dim 1', () => {
+    expect(tgpu.resolve([makeBuildRadianceFieldCompute({ baseStoredRayDim: 1 })]))
+      .toMatchInlineSnapshot(`
+        "@group(0) @binding(3) var dst: texture_storage_2d<rgba16float, write>;
+
+        @group(0) @binding(1) var src: texture_2d<f32>;
+
+        struct BuildRadianceFieldParams {
+          probes: vec2f,
+        }
+
+        @group(0) @binding(0) var<uniform> params: BuildRadianceFieldParams;
+
+        @group(0) @binding(2) var srcSampler: sampler;
+
+        @compute @workgroup_size(8, 8) fn item(@builtin(global_invocation_id) gid: vec3u) {
+          let dstDim = textureDimensions(dst);
+          if (((gid.x >= dstDim.x) || (gid.y >= dstDim.y))) {
+            return;
+          }
+          let srcDim = textureDimensions(src);
+          let cascadeProbeDim = (&params.probes);
+          let invSrcDim = (1f / vec2f(srcDim));
+          let uv = ((vec2f(gid.xy) + 0.5f) / vec2f(dstDim));
+          let probePixel = clamp((uv * (*cascadeProbeDim)), vec2f(0.5), ((*cascadeProbeDim) - 0.5f));
+          let uvStride = ((*cascadeProbeDim) * invSrcDim);
+          let baseSampleUV = (probePixel * invSrcDim);
+          var sum = vec3f();
+          // unrolled iteration #0
+          {
+            let offset = (vec2f((0 & 0), (0 >> 0u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // ---
+          textureStore(dst, gid.xy, vec4f((sum / 1f), 1f));
+        }"
+      `);
+  });
+
+  it('resolves for stored ray dim 2', () => {
+    expect(tgpu.resolve([makeBuildRadianceFieldCompute({ baseStoredRayDim: 2 })]))
+      .toMatchInlineSnapshot(`
+        "@group(0) @binding(3) var dst: texture_storage_2d<rgba16float, write>;
+
+        @group(0) @binding(1) var src: texture_2d<f32>;
+
+        struct BuildRadianceFieldParams {
+          probes: vec2f,
+        }
+
+        @group(0) @binding(0) var<uniform> params: BuildRadianceFieldParams;
+
+        @group(0) @binding(2) var srcSampler: sampler;
+
+        @compute @workgroup_size(8, 8) fn item(@builtin(global_invocation_id) gid: vec3u) {
+          let dstDim = textureDimensions(dst);
+          if (((gid.x >= dstDim.x) || (gid.y >= dstDim.y))) {
+            return;
+          }
+          let srcDim = textureDimensions(src);
+          let cascadeProbeDim = (&params.probes);
+          let invSrcDim = (1f / vec2f(srcDim));
+          let uv = ((vec2f(gid.xy) + 0.5f) / vec2f(dstDim));
+          let probePixel = clamp((uv * (*cascadeProbeDim)), vec2f(0.5), ((*cascadeProbeDim) - 0.5f));
+          let uvStride = ((*cascadeProbeDim) * invSrcDim);
+          let baseSampleUV = (probePixel * invSrcDim);
+          var sum = vec3f();
+          // unrolled iteration #0
+          {
+            let offset = (vec2f((0 & 1), (0 >> 1u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #1
+          {
+            let offset = (vec2f((1 & 1), (1 >> 1u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #2
+          {
+            let offset = (vec2f((2 & 1), (2 >> 1u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #3
+          {
+            let offset = (vec2f((3 & 1), (3 >> 1u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // ---
+          textureStore(dst, gid.xy, vec4f((sum / 4f), 1f));
+        }"
+      `);
+  });
+
+  it('resolves for stored ray dim 4', () => {
+    expect(tgpu.resolve([makeBuildRadianceFieldCompute({ baseStoredRayDim: 4 })]))
+      .toMatchInlineSnapshot(`
+        "@group(0) @binding(3) var dst: texture_storage_2d<rgba16float, write>;
+
+        @group(0) @binding(1) var src: texture_2d<f32>;
+
+        struct BuildRadianceFieldParams {
+          probes: vec2f,
+        }
+
+        @group(0) @binding(0) var<uniform> params: BuildRadianceFieldParams;
+
+        @group(0) @binding(2) var srcSampler: sampler;
+
+        @compute @workgroup_size(8, 8) fn item(@builtin(global_invocation_id) gid: vec3u) {
+          let dstDim = textureDimensions(dst);
+          if (((gid.x >= dstDim.x) || (gid.y >= dstDim.y))) {
+            return;
+          }
+          let srcDim = textureDimensions(src);
+          let cascadeProbeDim = (&params.probes);
+          let invSrcDim = (1f / vec2f(srcDim));
+          let uv = ((vec2f(gid.xy) + 0.5f) / vec2f(dstDim));
+          let probePixel = clamp((uv * (*cascadeProbeDim)), vec2f(0.5), ((*cascadeProbeDim) - 0.5f));
+          let uvStride = ((*cascadeProbeDim) * invSrcDim);
+          let baseSampleUV = (probePixel * invSrcDim);
+          var sum = vec3f();
+          // unrolled iteration #0
+          {
+            let offset = (vec2f((0 & 3), (0 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #1
+          {
+            let offset = (vec2f((1 & 3), (1 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #2
+          {
+            let offset = (vec2f((2 & 3), (2 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #3
+          {
+            let offset = (vec2f((3 & 3), (3 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #4
+          {
+            let offset = (vec2f((4 & 3), (4 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #5
+          {
+            let offset = (vec2f((5 & 3), (5 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #6
+          {
+            let offset = (vec2f((6 & 3), (6 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #7
+          {
+            let offset = (vec2f((7 & 3), (7 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #8
+          {
+            let offset = (vec2f((8 & 3), (8 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #9
+          {
+            let offset = (vec2f((9 & 3), (9 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #10
+          {
+            let offset = (vec2f((10 & 3), (10 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #11
+          {
+            let offset = (vec2f((11 & 3), (11 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #12
+          {
+            let offset = (vec2f((12 & 3), (12 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #13
+          {
+            let offset = (vec2f((13 & 3), (13 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #14
+          {
+            let offset = (vec2f((14 & 3), (14 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // unrolled iteration #15
+          {
+            let offset = (vec2f((15 & 3), (15 >> 2u)) * uvStride);
+            let sample = textureSampleLevel(src, srcSampler, (baseSampleUV + offset), 0);
+            sum += sample.xyz;
+          }
+          // ---
+          textureStore(dst, gid.xy, vec4f((sum / 16f), 1f));
+        }"
+      `);
+  });
+
+  it('memoizes per stored ray dim', () => {
+    expect(makeBuildRadianceFieldCompute({ baseStoredRayDim: 2 })).toBe(
+      makeBuildRadianceFieldCompute({ baseStoredRayDim: 2 }),
+    );
+  });
+});

--- a/packages/typegpu-radiance-cascades/tests/cascades.test.ts
+++ b/packages/typegpu-radiance-cascades/tests/cascades.test.ts
@@ -68,10 +68,17 @@ const colorImpl = tgpu.fn([d.vec2f], d.vec3f)`(uv: vec2f) -> vec3f {
   return vec3f(uv, 1.0);
 }`;
 
-function resolveCascadePass(mergeMode: 'hardware' | 'bilinear-fix', hasUpperCascade: boolean) {
-  return tgpu.resolve([makeCascadePassCompute({ mergeMode, hasUpperCascade })], {
-    config: (cfg) => cfg.with(sdfSlot, sdfImpl).with(colorSlot, colorImpl),
-  });
+function resolveCascadePass(
+  mergeMode: 'hardware' | 'bilinear-fix',
+  hasUpperCascade: boolean,
+  useSharedRayDirections = true,
+) {
+  return tgpu.resolve(
+    [makeCascadePassCompute({ mergeMode, hasUpperCascade, useSharedRayDirections })],
+    {
+      config: (cfg) => cfg.with(sdfSlot, sdfImpl).with(colorSlot, colorImpl),
+    },
+  );
 }
 
 describe('makeCascadePassCompute', () => {
@@ -104,6 +111,8 @@ describe('makeCascadePassCompute', () => {
       fn morton2D(x: u32, y: u32) -> u32 {
         return (part1By1(x) | (part1By1(y) << 1u));
       }
+
+      var<workgroup> sharedRayDirections: array<vec2f, 4>;
 
       fn rayDirection(rayIndex: f32, rayCountActual: f32, aspect: f32) -> vec2f {
         let angle = (((rayIndex / rayCountActual) * 6.283185307179586f) - 3.141592653589793f);
@@ -172,17 +181,23 @@ describe('makeCascadePassCompute', () => {
 
       @group(0) @binding(3) var dst: texture_storage_2d<rgba16float, write>;
 
-      @compute @workgroup_size(8, 8) fn item(@builtin(global_invocation_id) gid: vec3u) {
+      @compute @workgroup_size(8, 8) fn item(@builtin(global_invocation_id) gid: vec3u, @builtin(local_invocation_index) localIndex: u32) {
         let layerParams = (&layerParams_1);
-        if (((gid.x >= (*layerParams).validDim.x) || (gid.y >= (*layerParams).validDim.y))) {
-          return;
-        }
         let probes = (&(*layerParams).probes);
         let rayCountActual = pow(f32((*layerParams).raysDimActual), 2f);
         let dirStored = (gid.xy / (*probes));
+        let aspect = (*layerParams).aspect;
+        if ((localIndex < 4u)) {
+          let dirActual = ((dirStored * 2u) + vec2u((localIndex & 1u), (localIndex >> 1u)));
+          let rayIndex = (f32(morton2D(dirActual.x, dirActual.y)) + 0.5f);
+          sharedRayDirections[localIndex] = rayDirection(rayIndex, rayCountActual, aspect);
+        }
+        workgroupBarrier();
+        if (((gid.x >= (*layerParams).validDim.x) || (gid.y >= (*layerParams).validDim.y))) {
+          return;
+        }
         let probe = (gid.xy % (*probes));
         let probePos = ((vec2f(probe) + 0.5f) / vec2f((*probes)));
-        let aspect = (*layerParams).aspect;
         let eps = (*layerParams).eps;
         let minStep = (*layerParams).minStep;
         let biasUv = (*layerParams).hitBias;
@@ -191,8 +206,7 @@ describe('makeCascadePassCompute', () => {
         var accum = vec4f();
         for (var i = 0u; (i < 4u); i++) {
           let dirActual = ((dirStored * 2u) + vec2u((i & 1u), (i >> 1u)));
-          let rayIndex = (f32(morton2D(dirActual.x, dirActual.y)) + 0.5f);
-          let rayDir = rayDirection(rayIndex, rayCountActual, aspect);
+          let rayDir = sharedRayDirections[i];
           let exitUv = rayBoxExitUv(probePos, rayDir);
           let clippedMarchEndUv = min(marchEndUv, exitUv);
           if ((exitUv <= startUv)) {
@@ -239,6 +253,8 @@ describe('makeCascadePassCompute', () => {
       fn morton2D(x: u32, y: u32) -> u32 {
         return (part1By1(x) | (part1By1(y) << 1u));
       }
+
+      var<workgroup> sharedRayDirections: array<vec2f, 4>;
 
       fn rayDirection(rayIndex: f32, rayCountActual: f32, aspect: f32) -> vec2f {
         let angle = (((rayIndex / rayCountActual) * 6.283185307179586f) - 3.141592653589793f);
@@ -336,17 +352,23 @@ describe('makeCascadePassCompute', () => {
 
       @group(0) @binding(3) var dst: texture_storage_2d<rgba16float, write>;
 
-      @compute @workgroup_size(8, 8) fn item(@builtin(global_invocation_id) gid: vec3u) {
+      @compute @workgroup_size(8, 8) fn item(@builtin(global_invocation_id) gid: vec3u, @builtin(local_invocation_index) localIndex: u32) {
         let layerParams = (&layerParams_1);
-        if (((gid.x >= (*layerParams).validDim.x) || (gid.y >= (*layerParams).validDim.y))) {
-          return;
-        }
         let probes = (&(*layerParams).probes);
         let rayCountActual = pow(f32((*layerParams).raysDimActual), 2f);
         let dirStored = (gid.xy / (*probes));
+        let aspect = (*layerParams).aspect;
+        if ((localIndex < 4u)) {
+          let dirActual = ((dirStored * 2u) + vec2u((localIndex & 1u), (localIndex >> 1u)));
+          let rayIndex = (f32(morton2D(dirActual.x, dirActual.y)) + 0.5f);
+          sharedRayDirections[localIndex] = rayDirection(rayIndex, rayCountActual, aspect);
+        }
+        workgroupBarrier();
+        if (((gid.x >= (*layerParams).validDim.x) || (gid.y >= (*layerParams).validDim.y))) {
+          return;
+        }
         let probe = (gid.xy % (*probes));
         let probePos = ((vec2f(probe) + 0.5f) / vec2f((*probes)));
-        let aspect = (*layerParams).aspect;
         let eps = (*layerParams).eps;
         let minStep = (*layerParams).minStep;
         let biasUv = (*layerParams).hitBias;
@@ -355,8 +377,7 @@ describe('makeCascadePassCompute', () => {
         var accum = vec4f();
         for (var i = 0u; (i < 4u); i++) {
           let dirActual = ((dirStored * 2u) + vec2u((i & 1u), (i >> 1u)));
-          let rayIndex = (f32(morton2D(dirActual.x, dirActual.y)) + 0.5f);
-          let rayDir = rayDirection(rayIndex, rayCountActual, aspect);
+          let rayDir = sharedRayDirections[i];
           let exitUv = rayBoxExitUv(probePos, rayDir);
           let clippedMarchEndUv = min(marchEndUv, exitUv);
           if ((exitUv <= startUv)) {
@@ -376,6 +397,157 @@ describe('makeCascadePassCompute', () => {
 
   it('resolves the top cascade variant without upper sampling', () => {
     expect(resolveCascadePass('hardware', false)).toMatchInlineSnapshot(`
+      "struct CascadeLayerParams {
+        probes: vec2u,
+        probesU: vec2u,
+        validDim: vec2u,
+        raysDimActual: u32,
+        startUv: f32,
+        endUv: f32,
+        intervalOverlapUv: f32,
+        aspect: f32,
+        eps: f32,
+        minStep: f32,
+        hitBias: f32,
+      }
+
+      @group(0) @binding(0) var<uniform> layerParams_1: CascadeLayerParams;
+
+      fn part1By1(v: u32) -> u32 {
+        let x0 = (v & 65535u);
+        let x1 = ((x0 | (x0 << 8u)) & 16711935u);
+        let x2 = ((x1 | (x1 << 4u)) & 252645135u);
+        let x3 = ((x2 | (x2 << 2u)) & 858993459u);
+        return ((x3 | (x3 << 1u)) & 1431655765u);
+      }
+
+      fn morton2D(x: u32, y: u32) -> u32 {
+        return (part1By1(x) | (part1By1(y) << 1u));
+      }
+
+      var<workgroup> sharedRayDirections: array<vec2f, 4>;
+
+      fn rayDirection(rayIndex: f32, rayCountActual: f32, aspect: f32) -> vec2f {
+        let angle = (((rayIndex / rayCountActual) * 6.283185307179586f) - 3.141592653589793f);
+        let cosA = cos(angle);
+        let sinA = -(sin(angle));
+        return select(vec2f(cosA, (sinA * aspect)), vec2f((cosA / aspect), sinA), (aspect >= 1f));
+      }
+
+      fn rayBoxExitUv(p: vec2f, dir: vec2f) -> f32 {
+        var tx = 3.4028234663852886e+38f;
+        var ty = 3.4028234663852886e+38f;
+        if ((abs(dir.x) > 1e-6f)) {
+          tx = select((-(p.x) / dir.x), ((1f - p.x) / dir.x), (dir.x > 0f));
+        }
+        if ((abs(dir.y) > 1e-6f)) {
+          ty = select((-(p.y) / dir.y), ((1f - p.y) / dir.y), (dir.y > 0f));
+        }
+        return max(0f, min(tx, ty));
+      }
+
+      fn sdfImpl(uv: vec2f) -> f32 {
+        return length(uv - vec2f(0.5)) - 0.25;
+      }
+
+      fn colorImpl(uv: vec2f) -> vec3f {
+        return vec3f(uv, 1.0);
+      }
+
+      struct RayMarchResult {
+        color: vec3f,
+        transmittance: f32,
+      }
+
+      fn defaultRayMarch(probePos: vec2f, rayDir: vec2f, startT: f32, endT: f32, eps: f32, minStep: f32, bias: f32) -> RayMarchResult {
+        var t = startT;
+        for (var step_1 = 0u; (step_1 < 64u); step_1++) {
+          if ((t > endT)) {
+            break;
+          }
+          let pos = (probePos + (rayDir * t));
+          let hitDist = (sdfImpl(pos) + bias);
+          if ((hitDist <= eps)) {
+            return RayMarchResult(colorImpl(pos), 0f);
+          }
+          t += max((hitDist * 1f), minStep);
+        }
+        return RayMarchResult(vec3f(), 1f);
+      }
+
+      @group(0) @binding(3) var dst: texture_storage_2d<rgba16float, write>;
+
+      @compute @workgroup_size(8, 8) fn item(@builtin(global_invocation_id) gid: vec3u, @builtin(local_invocation_index) localIndex: u32) {
+        let layerParams = (&layerParams_1);
+        let probes = (&(*layerParams).probes);
+        let rayCountActual = pow(f32((*layerParams).raysDimActual), 2f);
+        let dirStored = (gid.xy / (*probes));
+        let aspect = (*layerParams).aspect;
+        if ((localIndex < 4u)) {
+          let dirActual = ((dirStored * 2u) + vec2u((localIndex & 1u), (localIndex >> 1u)));
+          let rayIndex = (f32(morton2D(dirActual.x, dirActual.y)) + 0.5f);
+          sharedRayDirections[localIndex] = rayDirection(rayIndex, rayCountActual, aspect);
+        }
+        workgroupBarrier();
+        if (((gid.x >= (*layerParams).validDim.x) || (gid.y >= (*layerParams).validDim.y))) {
+          return;
+        }
+        let probe = (gid.xy % (*probes));
+        let probePos = ((vec2f(probe) + 0.5f) / vec2f((*probes)));
+        let eps = (*layerParams).eps;
+        let minStep = (*layerParams).minStep;
+        let biasUv = (*layerParams).hitBias;
+        let startUv = (*layerParams).startUv;
+        let marchEndUv = ((*layerParams).endUv + (*layerParams).intervalOverlapUv);
+        var accum = vec4f();
+        for (var i = 0u; (i < 4u); i++) {
+          let dirActual = ((dirStored * 2u) + vec2u((i & 1u), (i >> 1u)));
+          let rayDir = sharedRayDirections[i];
+          let exitUv = rayBoxExitUv(probePos, rayDir);
+          let clippedMarchEndUv = min(marchEndUv, exitUv);
+          if ((exitUv <= startUv)) {
+            accum += vec4f(0, 0, 0, 1);
+          }
+          else {
+            {
+              let ray = defaultRayMarch(probePos, rayDir, startUv, clippedMarchEndUv, eps, minStep, biasUv);
+              accum += vec4f(ray.color, ray.transmittance);
+            }
+          }
+        }
+        textureStore(dst, gid.xy, (accum / 4f));
+      }"
+    `);
+  });
+
+  it('memoizes per specialization', () => {
+    const a = makeCascadePassCompute({
+      mergeMode: 'hardware',
+      hasUpperCascade: true,
+      useSharedRayDirections: true,
+    });
+    const b = makeCascadePassCompute({
+      mergeMode: 'hardware',
+      hasUpperCascade: true,
+      useSharedRayDirections: true,
+    });
+    expect(a).toBe(b);
+    const c = makeCascadePassCompute({
+      mergeMode: 'bilinear-fix',
+      hasUpperCascade: true,
+      useSharedRayDirections: true,
+    });
+    expect(a).not.toBe(c);
+    const fallback = makeCascadePassCompute({
+      mergeMode: 'hardware',
+      hasUpperCascade: true,
+      useSharedRayDirections: false,
+    });
+    expect(fallback).not.toBe(a);
+  });
+
+  it('keeps per-invocation direction calculation as a fallback', () => {
+    expect(resolveCascadePass('hardware', true, false)).toMatchInlineSnapshot(`
       "struct CascadeLayerParams {
         probes: vec2u,
         probesU: vec2u,
@@ -452,19 +624,36 @@ describe('makeCascadePassCompute', () => {
         return RayMarchResult(vec3f(), 1f);
       }
 
+      @group(0) @binding(1) var upper: texture_2d<f32>;
+
+      @group(0) @binding(2) var upperSampler: sampler;
+
+      fn traceHardwareMergeRay(probePos: vec2f, rayDir: vec2f, dirActual: vec2u, probesU: vec2u, startUv: f32, clippedMarchEndUv: f32, marchEndUv: f32, exitUv: f32, eps: f32, minStep: f32, biasUv: f32) -> vec4f {
+        let marchResult = defaultRayMarch(probePos, rayDir, startUv, clippedMarchEndUv, eps, minStep, biasUv);
+        if (((marchResult.transmittance > 0.01f) && (exitUv > marchEndUv))) {
+          let upperDim = textureDimensions(upper);
+          let tileOrigin = vec2f((dirActual * probesU));
+          let probePixel = clamp((probePos * vec2f(probesU)), vec2f(0.5), (vec2f(probesU) - 0.5f));
+          let uvU = ((tileOrigin + probePixel) / vec2f(upperDim));
+          let upper_1 = textureSampleLevel(upper, upperSampler, uvU, 0);
+          return vec4f((marchResult.color + (upper_1.xyz * marchResult.transmittance)), (marchResult.transmittance * upper_1.w));
+        }
+        return vec4f(marchResult.color, marchResult.transmittance);
+      }
+
       @group(0) @binding(3) var dst: texture_storage_2d<rgba16float, write>;
 
       @compute @workgroup_size(8, 8) fn item(@builtin(global_invocation_id) gid: vec3u) {
         let layerParams = (&layerParams_1);
-        if (((gid.x >= (*layerParams).validDim.x) || (gid.y >= (*layerParams).validDim.y))) {
-          return;
-        }
         let probes = (&(*layerParams).probes);
         let rayCountActual = pow(f32((*layerParams).raysDimActual), 2f);
         let dirStored = (gid.xy / (*probes));
+        let aspect = (*layerParams).aspect;
+        if (((gid.x >= (*layerParams).validDim.x) || (gid.y >= (*layerParams).validDim.y))) {
+          return;
+        }
         let probe = (gid.xy % (*probes));
         let probePos = ((vec2f(probe) + 0.5f) / vec2f((*probes)));
-        let aspect = (*layerParams).aspect;
         let eps = (*layerParams).eps;
         let minStep = (*layerParams).minStep;
         let biasUv = (*layerParams).hitBias;
@@ -473,8 +662,7 @@ describe('makeCascadePassCompute', () => {
         var accum = vec4f();
         for (var i = 0u; (i < 4u); i++) {
           let dirActual = ((dirStored * 2u) + vec2u((i & 1u), (i >> 1u)));
-          let rayIndex = (f32(morton2D(dirActual.x, dirActual.y)) + 0.5f);
-          let rayDir = rayDirection(rayIndex, rayCountActual, aspect);
+          let rayDir = rayDirection((f32(morton2D(dirActual.x, dirActual.y)) + 0.5f), rayCountActual, aspect);
           let exitUv = rayBoxExitUv(probePos, rayDir);
           let clippedMarchEndUv = min(marchEndUv, exitUv);
           if ((exitUv <= startUv)) {
@@ -482,22 +670,14 @@ describe('makeCascadePassCompute', () => {
           }
           else {
             {
-              let ray = defaultRayMarch(probePos, rayDir, startUv, clippedMarchEndUv, eps, minStep, biasUv);
-              accum += vec4f(ray.color, ray.transmittance);
+              let probesU = (&(*layerParams).probesU);
+              accum += traceHardwareMergeRay(probePos, rayDir, dirActual, (*probesU), startUv, clippedMarchEndUv, marchEndUv, exitUv, eps, minStep, biasUv);
             }
           }
         }
         textureStore(dst, gid.xy, (accum / 4f));
       }"
     `);
-  });
-
-  it('memoizes per specialization', () => {
-    const a = makeCascadePassCompute({ mergeMode: 'hardware', hasUpperCascade: true });
-    const b = makeCascadePassCompute({ mergeMode: 'hardware', hasUpperCascade: true });
-    expect(a).toBe(b);
-    const c = makeCascadePassCompute({ mergeMode: 'bilinear-fix', hasUpperCascade: true });
-    expect(a).not.toBe(c);
   });
 });
 

--- a/packages/typegpu-radiance-cascades/tsconfig.test.json
+++ b/packages/typegpu-radiance-cascades/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["tests/**/*"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "declaration": false,
+    "noEmit": true,
+    "emitDeclarationOnly": false
+  }
+}

--- a/packages/typegpu-radiance-cascades/vitest.config.mts
+++ b/packages/typegpu-radiance-cascades/vitest.config.mts
@@ -1,0 +1,14 @@
+import { createJiti } from 'jiti';
+import type TypeGPUPlugin from 'unplugin-typegpu/vite';
+import { defineConfig } from 'vitest/config';
+import { typegpuBuiltAliases } from 'typegpu-testing-utility/config';
+
+const jiti = createJiti(import.meta.url);
+const typegpu = await jiti.import<typeof TypeGPUPlugin>('unplugin-typegpu/vite', { default: true });
+
+export default defineConfig({
+  plugins: [typegpu({ forceTgpuAlias: 'tgpu', earlyPruning: false })],
+  resolve: {
+    alias: typegpuBuiltAliases(),
+  },
+});

--- a/packages/typegpu-sdf/src/jumpFlood.ts
+++ b/packages/typegpu-sdf/src/jumpFlood.ts
@@ -3,6 +3,7 @@ import {
   type SampledFlag,
   type StorageFlag,
   type TgpuBindGroup,
+  type TgpuCommandEncoder,
   type TgpuRoot,
   type TgpuTexture,
 } from 'typegpu';
@@ -244,7 +245,7 @@ export type ColorTexture = TgpuTexture<{
 
 export type Executor = {
   /** Run the jump flood algorithm. */
-  run(): void;
+  run(commandEncoder?: TgpuCommandEncoder): void;
   /** The SDF output texture (rgba16float). */
   readonly sdfOutput: SdfTexture;
   /** The color output texture (rgba8unorm). */
@@ -336,15 +337,9 @@ export function createJumpFlood(options: JumpFloodOptions): Executor {
     })
     .$usage('storage');
 
-  const offsetUniform = root.createUniform(d.i32);
-
   const initFromSeedPipeline = root
     .with(classifySlot, classify)
     .createComputePipeline({ compute: initFromSeedCompute });
-
-  const jumpFloodPipeline = root
-    .with(offsetAccessor, offsetUniform)
-    .createComputePipeline({ compute: jumpFloodCompute });
 
   const finalizePipeline = root
     .with(sdfSlot, getSdf)
@@ -365,7 +360,7 @@ export function createJumpFlood(options: JumpFloodOptions): Executor {
       readView: floodTextureB.createView(d.textureStorage2d('rgba16uint', 'read-only')),
       writeView: floodTextureA.createView(d.textureStorage2d('rgba16uint', 'write-only')),
     }),
-  ];
+  ] as const;
 
   const distWriteBG = root.createBindGroup(distWriteLayout, {
     sdfTexture: sdfTexture.createView(d.textureStorage2d('rgba16float', 'write-only')),
@@ -379,7 +374,7 @@ export function createJumpFlood(options: JumpFloodOptions): Executor {
     root.createBindGroup(finalizeReadLayout, {
       readView: floodTextureB.createView(d.textureStorage2d('rgba16uint', 'read-only')),
     }),
-  ];
+  ] as const;
 
   const workgroupsX = Math.ceil(width / 8);
   const workgroupsY = Math.ceil(height / 8);
@@ -387,12 +382,24 @@ export function createJumpFlood(options: JumpFloodOptions): Executor {
 
   // Largest power-of-two strictly less than maxDim.
   const maxRange = 2 ** Math.floor(Math.log2(Math.max(maxDim - 1, 1)));
+  const offsets: number[] = [];
+  for (let offset = maxRange; offset >= 1; offset = Math.floor(offset / 2)) {
+    offsets.push(offset);
+  }
+  const offsetUniforms = offsets.map((offset) => root.createUniform(d.i32, offset));
+  const jumpFloodPipelines = offsetUniforms.map((offsetUniform) =>
+    root.with(offsetAccessor, offsetUniform).createComputePipeline({ compute: jumpFloodCompute }),
+  );
+  const finalizeReadBG = offsets.length % 2 === 0 ? finalizeReadBGs[0] : finalizeReadBGs[1];
 
   function destroy() {
     floodTextureA.destroy();
     floodTextureB.destroy();
     sdfTexture.destroy();
     colorTexture.destroy();
+    for (const offsetUniform of offsetUniforms) {
+      offsetUniform.buffer.destroy();
+    }
   }
 
   function createExecutor(additionalBindGroups: TgpuBindGroup[] = []): Executor {
@@ -402,44 +409,39 @@ export function createJumpFlood(options: JumpFloodOptions): Executor {
       prebuiltInitPipeline = prebuiltInitPipeline.with(bg);
     }
 
-    const prebuiltFloodPipelines = pingPongBGs.map((bg) => {
-      let p = jumpFloodPipeline.with(bg);
+    const prebuiltFloodPipelines = jumpFloodPipelines.map((pipeline, passIndex) => {
+      const bg = passIndex % 2 === 0 ? pingPongBGs[0] : pingPongBGs[1];
+      let p = pipeline.with(bg);
       for (const addBg of additionalBindGroups) {
         p = p.with(addBg);
       }
       return p;
     });
 
-    const prebuiltFinalizePipelines = finalizeReadBGs.map((bg) => {
-      let p = finalizePipeline.with(bg).with(distWriteBG);
-      for (const addBg of additionalBindGroups) {
-        p = p.with(addBg);
-      }
-      return p;
-    });
-
-    function run() {
-      prebuiltInitPipeline.dispatchWorkgroups(workgroupsX, workgroupsY);
-
-      let sourceIdx = 0;
-      let offset = maxRange;
-
-      while (offset >= 1) {
-        offsetUniform.write(offset);
-        prebuiltFloodPipelines[sourceIdx]?.dispatchWorkgroups(workgroupsX, workgroupsY);
-        sourceIdx ^= 1;
-        offset = Math.floor(offset / 2);
-      }
-
-      // Finalize: JFA+1 at offset=1 fused with distance field output
-      prebuiltFinalizePipelines[sourceIdx]?.dispatchWorkgroups(workgroupsX, workgroupsY);
+    let prebuiltFinalizePipeline = finalizePipeline.with(finalizeReadBG).with(distWriteBG);
+    for (const addBg of additionalBindGroups) {
+      prebuiltFinalizePipeline = prebuiltFinalizePipeline.with(addBg);
     }
 
-    const pipelines = [
-      prebuiltInitPipeline,
-      ...prebuiltFloodPipelines,
-      ...prebuiltFinalizePipelines,
-    ];
+    function run(commandEncoder?: TgpuCommandEncoder) {
+      const encoder = commandEncoder ?? root['~unstable'].createCommandEncoder();
+      const pass = encoder.beginComputePass();
+
+      prebuiltInitPipeline.with(pass).dispatchWorkgroups(workgroupsX, workgroupsY);
+
+      for (const floodPipeline of prebuiltFloodPipelines) {
+        floodPipeline.with(pass).dispatchWorkgroups(workgroupsX, workgroupsY);
+      }
+
+      prebuiltFinalizePipeline.with(pass).dispatchWorkgroups(workgroupsX, workgroupsY);
+      pass.end();
+
+      if (!commandEncoder) {
+        encoder.submit();
+      }
+    }
+
+    const pipelines = [prebuiltInitPipeline, ...prebuiltFloodPipelines, prebuiltFinalizePipeline];
 
     return {
       run,

--- a/packages/typegpu/src/indexNamedExports.ts
+++ b/packages/typegpu/src/indexNamedExports.ts
@@ -13,7 +13,7 @@ export {
 } from './errors.ts';
 export { isAccessor, isLazy, isMutableAccessor, isSlot } from './core/slot/slotTypes.ts';
 export { isComparisonSampler, isSampler } from './core/sampler/sampler.ts';
-export { isTexture } from './core/texture/texture.ts';
+export { isTexture, isTextureView } from './core/texture/texture.ts';
 export { isUsableAsRender, isUsableAsSampled } from './core/texture/usageExtension.ts';
 export {
   isBuffer,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -854,6 +854,9 @@ importers:
       typegpu:
         specifier: workspace:*
         version: link:../typegpu
+      typegpu-testing-utility:
+        specifier: workspace:*
+        version: link:../typegpu-testing-utility
       typescript:
         specifier: npm:tsover@^6.0.2
         version: tsover@6.0.2


### PR DESCRIPTION
Built on top of #2617.

- shares ray directions through workgroup memory when the cascade layout allows it
- prebuilds jump-flood pipelines instead of updating the offset uniform between dispatches
- records the entire jump-flood run into one compute pass
- allows jump flooding to participate in a caller-owned command encoder