### PR TITLE
chore: Refactor GPU function call mechanism

### DIFF
--- a/packages/typegpu-gl/src/glslGenerator.ts
+++ b/packages/typegpu-gl/src/glslGenerator.ts
@@ -704,7 +704,7 @@ export class GlslGenerator extends WgslGenerator {
 
     // Non-literal return: inspect type to decide how to assign.
     const expr = expectedReturnType
-      ? this._typedExpression(exprNode, expectedReturnType)
+      ? this._expressionWithTypeConversion(exprNode, expectedReturnType)
       : this._expression(exprNode);
 
     if (expr.dataType === UnknownData) {

--- a/packages/typegpu/src/core/function/comptime.ts
+++ b/packages/typegpu/src/core/function/comptime.ts
@@ -8,8 +8,9 @@ type AnyFn = (...args: never[]) => unknown;
 
 export type TgpuComptime<T extends AnyFn = AnyFn> = DualFn<T> &
   TgpuNamable & {
+    toString(): string;
     [$getNameForward]: unknown;
-    [$internal]: { isComptime: true };
+    [$internal]: { isComptime: true; func: T };
   };
 
 export function isComptimeFn(value: unknown): value is TgpuComptime {
@@ -45,34 +46,41 @@ export function comptime<T extends (...args: never[]) => unknown>(func: T): Tgpu
     return func(...args);
   }) as TgpuComptime<T>;
 
-  impl.toString = () => 'comptime';
-  impl[$getNameForward] = func;
-  impl[$gpuCallable] = {
-    call(ctx, args) {
-      if (!args.every((s) => isKnownAtComptime(s))) {
-        throw new WgslTypeError(
-          `Called comptime function with runtime-known values: ${args
-            .filter((s) => !isKnownAtComptime(s))
-            .map((s) => `'${s.value}'`)
-            .join(', ')}`,
-        );
-      }
+  Object.setPrototypeOf(impl, ComptimePrototype);
 
-      ctx.pushMode(new NormalState());
-      try {
-        return coerceToSnippet(func(...(args.map((s) => s.value) as never[])));
-      } finally {
-        ctx.popMode();
-      }
-    },
-  };
-  impl.$name = (label: string) => {
-    setName(func, label);
-    return impl;
-  };
+  impl[$getNameForward] = func;
   Object.defineProperty(impl, $internal, {
-    value: { isComptime: true },
+    value: { isComptime: true, func },
   });
 
   return impl;
 }
+
+const ComptimePrototype = {
+  toString() {
+    return 'comptime';
+  },
+
+  $name(label: string) {
+    setName(this[$internal].func, label);
+    return this;
+  },
+
+  [$gpuCallable](ctx, args) {
+    if (!args.every((s) => isKnownAtComptime(s))) {
+      throw new WgslTypeError(
+        `Called comptime function with runtime-known values: ${args
+          .filter((s) => !isKnownAtComptime(s))
+          .map((s) => `'${s.value}'`)
+          .join(', ')}`,
+      );
+    }
+
+    ctx.pushMode(new NormalState());
+    try {
+      return coerceToSnippet(this[$internal].func(...(args.map((s) => s.value) as never[])));
+    } finally {
+      ctx.popMode();
+    }
+  },
+} as TgpuComptime;

--- a/packages/typegpu/src/core/function/createCallableSchema.ts
+++ b/packages/typegpu/src/core/function/createCallableSchema.ts
@@ -34,51 +34,46 @@ export function callableSchema<T extends AnyFn>(options: CallableSchemaOptions<T
 
   setName(impl, options.name);
   impl.toString = () => options.name;
-  impl[$gpuCallable] = {
-    get strictSignature() {
-      return undefined;
-    },
-    call(ctx, args) {
-      const argTypes = options.argTypes(
-        ...(args.map((s) => {
-          // Dereference implicit pointers
-          if (isPtr(s.dataType) && s.dataType.implicit) {
-            return s.dataType.inner;
-          }
-          return s.dataType;
-        }) as MapValueToDataType<Parameters<T>>),
-      );
-
-      const converted = args.map((s, idx) => {
-        const argType = argTypes[idx];
-        if (!argType) {
-          throw new Error('Function called with invalid arguments');
+  impl[$gpuCallable] = (ctx, args) => {
+    const argTypes = options.argTypes(
+      ...(args.map((s) => {
+        // Dereference implicit pointers
+        if (isPtr(s.dataType) && s.dataType.implicit) {
+          return s.dataType.inner;
         }
-        return tryConvertSnippet(ctx, s, argType, false);
-      }) as MapValueToSnippet<Parameters<T>>;
+        return s.dataType;
+      }) as MapValueToDataType<Parameters<T>>),
+    );
 
-      let result: Snippet;
-      if (converted.every((s) => isKnownAtComptime(s))) {
-        ctx.pushMode(new NormalState());
-        try {
-          result = snip(
-            options.normalImpl(...(converted.map((s) => s.value) as never[])),
-            options.schema(),
-            // Functions give up ownership of their return value
-            /* origin */ 'constant',
-          );
-        } finally {
-          ctx.popMode('normal');
-        }
-      } else {
-        result = options.codegenImpl(ctx, converted);
+    const converted = args.map((s, idx) => {
+      const argType = argTypes[idx];
+      if (!argType) {
+        throw new Error('Function called with invalid arguments');
       }
+      return tryConvertSnippet(ctx, s, argType, false);
+    }) as MapValueToSnippet<Parameters<T>>;
 
-      if (!args.some((a) => a.possibleSideEffects)) {
-        return noSideEffects(result);
+    let result: Snippet;
+    if (converted.every((s) => isKnownAtComptime(s))) {
+      ctx.pushMode(new NormalState());
+      try {
+        result = snip(
+          options.normalImpl(...(converted.map((s) => s.value) as never[])),
+          options.schema(),
+          // Functions give up ownership of their return value
+          /* origin */ 'constant',
+        );
+      } finally {
+        ctx.popMode('normal');
       }
-      return result;
-    },
+    } else {
+      result = options.codegenImpl(ctx, converted);
+    }
+
+    if (!args.some((a) => a.possibleSideEffects)) {
+      return noSideEffects(result);
+    }
+    return result;
   };
 
   return impl;

--- a/packages/typegpu/src/core/function/dualImpl.ts
+++ b/packages/typegpu/src/core/function/dualImpl.ts
@@ -1,6 +1,6 @@
 import { type MapValueToSnippet, snip } from '../../data/snippet.ts';
 import { setName } from '../../shared/meta.ts';
-import { $gpuCallable } from '../../shared/symbols.ts';
+import { $gpuCallable, $gpuCallableStrictSignature } from '../../shared/symbols.ts';
 import { tryConvertSnippet } from '../../tgsl/conversion.ts';
 import { concretize } from '../../tgsl/generationHelpers.ts';
 import { type DualFn, isKnownAtComptime, NormalState, type ResolutionCtx } from '../../types.ts';
@@ -67,69 +67,69 @@ export function dualImpl<T extends AnyFn>(options: DualImplOptions<T>): DualFn<T
     setName(impl, options.name);
   }
   impl.toString = () => options.name ?? '<unknown>';
-  impl[$gpuCallable] = {
-    get strictSignature() {
+  Object.defineProperty(impl, $gpuCallableStrictSignature, {
+    get() {
       return typeof options.signature !== 'function' ? options.signature : undefined;
     },
-    call(ctx, args) {
-      const { argTypes, returnType } =
-        typeof options.signature === 'function'
-          ? options.signature(
-              ...(args.map((s) => {
-                // Dereference implicit pointers
-                if (isPtr(s.dataType) && s.dataType.implicit) {
-                  return s.dataType.inner;
-                }
-                return s.dataType;
-              }) as MapValueToDataType<Parameters<T>>),
-            )
-          : options.signature;
+  });
+  impl[$gpuCallable] = (ctx, args) => {
+    const { argTypes, returnType } =
+      typeof options.signature === 'function'
+        ? options.signature(
+            ...(args.map((s) => {
+              // Dereference implicit pointers
+              if (isPtr(s.dataType) && s.dataType.implicit) {
+                return s.dataType.inner;
+              }
+              return s.dataType;
+            }) as MapValueToDataType<Parameters<T>>),
+          )
+        : options.signature;
 
-      const converted = args.map((s, idx) => {
-        const argType = argTypes[idx];
-        if (!argType) {
-          throw new Error('Function called with invalid arguments');
-        }
-        return tryConvertSnippet(ctx, s, argType, !options.ignoreImplicitCastWarning);
-      }) as MapValueToSnippet<Parameters<T>>;
-
-      if (
-        !options.noComptime &&
-        converted.every((s) => isKnownAtComptime(s)) &&
-        typeof options.normalImpl === 'function'
-      ) {
-        ctx.pushMode(new NormalState());
-        try {
-          return snip(
-            options.normalImpl(...(converted.map((s) => s.value) as never[])),
-            returnType,
-            // Functions give up ownership of their return value
-            /* origin */ 'constant',
-            options.sideEffects,
-          );
-        } catch (e) {
-          // cpuImpl may in some cases be present but implemented only partially.
-          // In that case, if the MissingCpuImplError is thrown, we fallback to codegenImpl.
-          // If it is any other error, we just rethrow.
-          if (!(e instanceof MissingCpuImplError)) {
-            throw e;
-          }
-        } finally {
-          ctx.popMode('normal');
-        }
+    const converted = args.map((s, idx) => {
+      const argType = argTypes[idx];
+      if (!argType) {
+        throw new Error('Function called with invalid arguments');
       }
+      return tryConvertSnippet(ctx, s, argType, !options.ignoreImplicitCastWarning);
+    }) as MapValueToSnippet<Parameters<T>>;
 
-      const possibleSideEffects = options.sideEffects || args.some((a) => a.possibleSideEffects);
+    if (
+      !options.noComptime &&
+      converted.every((s) => isKnownAtComptime(s)) &&
+      typeof options.normalImpl === 'function'
+    ) {
+      ctx.pushMode(new NormalState());
+      try {
+        return snip(
+          options.normalImpl(...(converted.map((s) => s.value) as never[])),
+          returnType,
+          // Functions give up ownership of their return value
+          /* origin */ 'constant',
+          options.sideEffects,
+        );
+      } catch (e) {
+        // cpuImpl may in some cases be present but implemented only partially.
+        // In that case, if the MissingCpuImplError is thrown, we fallback to codegenImpl.
+        // If it is any other error, we just rethrow.
+        if (!(e instanceof MissingCpuImplError)) {
+          throw e;
+        }
+      } finally {
+        ctx.popMode('normal');
+      }
+    }
 
-      const concreteReturnType = concretize(returnType);
-      return snip(
-        options.codegenImpl(ctx, converted, concreteReturnType),
-        concreteReturnType,
-        // Functions give up ownership of their return value
-        /* origin */ 'runtime',
-        possibleSideEffects,
-      );
-    },
+    const possibleSideEffects = options.sideEffects || args.some((a) => a.possibleSideEffects);
+
+    const concreteReturnType = concretize(returnType);
+    return snip(
+      options.codegenImpl(ctx, converted, concreteReturnType),
+      concreteReturnType,
+      // Functions give up ownership of their return value
+      /* origin */ 'runtime',
+      possibleSideEffects,
+    );
   };
 
   return impl;

--- a/packages/typegpu/src/core/slot/accessor.ts
+++ b/packages/typegpu/src/core/slot/accessor.ts
@@ -92,7 +92,7 @@ function createAccessorSnippet(accessor: AccessorBase<BaseData, unknown>) {
   }
 
   if (isGPUCallable(value)) {
-    return value[$gpuCallable].call(ctx, []);
+    return value[$gpuCallable](ctx, []);
   }
 
   if (isTgpuFn(value) || hasTinyestMetadata(value)) {

--- a/packages/typegpu/src/core/unroll/tgpuUnroll.ts
+++ b/packages/typegpu/src/core/unroll/tgpuUnroll.ts
@@ -86,10 +86,8 @@ export const unroll = (() => {
   setName(impl, 'unroll');
   impl.toString = () => 'unroll';
   impl[$internal] = true;
-  impl[$gpuCallable] = {
-    call(_ctx, [value]) {
-      return withValue(new UnrollableIterable(value), value);
-    },
+  impl[$gpuCallable] = (_ctx, [value]) => {
+    return withValue(new UnrollableIterable(value), value);
   };
 
   return impl;

--- a/packages/typegpu/src/data/array.ts
+++ b/packages/typegpu/src/data/array.ts
@@ -1,7 +1,11 @@
 import { comptime, type TgpuComptime } from '../core/function/comptime.ts';
-import { $internal } from '../shared/symbols.ts';
+import { WgslTypeError } from '../errors.ts';
+import { $gpuCallable, $gpuCallableStrictSignature, $internal } from '../shared/symbols.ts';
+import { tryConvertSnippet } from '../tgsl/conversion.ts';
+import { ArrayExpression } from '../tgsl/generationHelpers.ts';
 import { schemaCallWrapper } from './schemaCallWrapper.ts';
 import { sizeOf } from './sizeOf.ts';
+import { snip } from './snippet.ts';
 import type { AnyWgslData, Decorated, Location, WgslArray } from './wgslTypes.ts';
 import { isDecorated, isLocationAttrib } from './wgslTypes.ts';
 
@@ -107,10 +111,46 @@ function cpu_arrayOf<TElement extends AnyWgslData>(
 }
 
 const WgslArrayImpl = {
-  [$internal]: true,
+  [$internal]: {},
   type: 'array',
 
   toString(this: WgslArray): string {
     return `arrayOf(${String(this.elementType)}, ${this.elementCount})`;
   },
-};
+
+  get [$gpuCallableStrictSignature]() {
+    return { argTypes: [this as WgslArray], returnType: this as WgslArray };
+  },
+
+  [$gpuCallable](ctx, args) {
+    // Array schema call.
+    if (args.length > 1) {
+      throw new WgslTypeError('Array schemas should always be called with at most 1 argument');
+    }
+
+    // No arguments `array<...>()`, resolve array type and return.
+    if (!args[0]) {
+      // The schema becomes the data type.
+      return ctx.gen.typeInstantiation(this as WgslArray, []);
+    }
+
+    const arg = tryConvertSnippet(ctx, args[0], this as WgslArray);
+
+    // `d.arrayOf(...)([...])`.
+    // We don't resolve the ArrayExpression object itself to
+    // avoid reference checks (we're copying so it's fine)
+    if (arg.value instanceof ArrayExpression) {
+      return ctx.gen.typeInstantiation(this as WgslArray, arg.value.elements);
+    }
+
+    // `d.arrayOf(...)(otherArr)`.
+    // We just let the argument resolve everything.
+    return snip(
+      ctx.resolveSnippet(arg).value,
+      this as WgslArray,
+      // A new array, so not a reference.
+      /* origin */ 'runtime',
+      arg.possibleSideEffects,
+    );
+  },
+} satisfies Partial<WgslArray>;

--- a/packages/typegpu/src/data/ref.ts
+++ b/packages/typegpu/src/data/ref.ts
@@ -46,57 +46,55 @@ export const _ref = (() => {
   setName(impl, 'ref');
   impl.toString = () => 'ref';
   impl[$internal] = true;
-  impl[$gpuCallable] = {
-    call(ctx, [value]) {
-      if (value.origin === 'argument') {
-        throw new WgslTypeError(
-          stitch`d.ref(${value}) is illegal, cannot take a reference of an argument. Copy the value first, and take a reference of the copy.`,
-        );
-      }
+  impl[$gpuCallable] = (ctx, [value]) => {
+    if (value.origin === 'argument') {
+      throw new WgslTypeError(
+        stitch`d.ref(${value}) is illegal, cannot take a reference of an argument. Copy the value first, and take a reference of the copy.`,
+      );
+    }
 
-      if (value.origin === 'constant-immutable-def' || value.origin === 'runtime-immutable-def') {
-        const typeStr = ctx.resolve(value.dataType).value;
-        throw new WgslTypeError(
-          stitch`d.ref(${value}) is illegal, cannot take a reference to a constant.
+    if (value.origin === 'constant-immutable-def' || value.origin === 'runtime-immutable-def') {
+      const typeStr = ctx.resolve(value.dataType).value;
+      throw new WgslTypeError(
+        stitch`d.ref(${value}) is illegal, cannot take a reference to a constant.
 -----
 - Try 'd.ref(${typeStr}(${value}));' instead to create a new referencable value.
 -----`,
-        );
-      }
+      );
+    }
 
-      if (isAlias(value) && isNaturallyEphemeral(value.dataType)) {
-        const typeStr = ctx.resolve(value.dataType).value;
-        throw new WgslTypeError(
-          stitch`d.ref(${value}) is illegal, cannot take a reference to a scalar value.
+    if (isAlias(value) && isNaturallyEphemeral(value.dataType)) {
+      const typeStr = ctx.resolve(value.dataType).value;
+      throw new WgslTypeError(
+        stitch`d.ref(${value}) is illegal, cannot take a reference to a scalar value.
 -----
 - Try 'd.ref(${typeStr}(${value}));' instead to create a new referencable scalar.
 -----`,
-        );
-      }
-
-      if (isPtr(value.dataType)) {
-        // This can happen if we take a reference of an *implicit* pointer, one
-        // made by assigning a reference to a `const`.
-        return withDataType(explicitFrom(value.dataType), value);
-      }
-
-      /**
-       * Pointer type only exists if the ref was created from a reference (buttery-butter).
-       *
-       * @example
-       * ```ts
-       * const life = ref(42); // created from a value
-       * const boid = ref(layout.$.boids[0]); // created from a reference
-       * ```
-       */
-      const ptrType = createPtrFromOrigin(value.origin, value.dataType as StorableData);
-      return snip(
-        new RefOperator(value, ptrType),
-        ptrType ?? UnknownData,
-        /* origin */ 'runtime',
-        value.possibleSideEffects,
       );
-    },
+    }
+
+    if (isPtr(value.dataType)) {
+      // This can happen if we take a reference of an *implicit* pointer, one
+      // made by assigning a reference to a `const`.
+      return withDataType(explicitFrom(value.dataType), value);
+    }
+
+    /**
+     * Pointer type only exists if the ref was created from a reference (buttery-butter).
+     *
+     * @example
+     * ```ts
+     * const life = ref(42); // created from a value
+     * const boid = ref(layout.$.boids[0]); // created from a reference
+     * ```
+     */
+    const ptrType = createPtrFromOrigin(value.origin, value.dataType as StorableData);
+    return snip(
+      new RefOperator(value, ptrType),
+      ptrType ?? UnknownData,
+      /* origin */ 'runtime',
+      value.possibleSideEffects,
+    );
   };
 
   return impl;

--- a/packages/typegpu/src/data/schemaCallWrapper.ts
+++ b/packages/typegpu/src/data/schemaCallWrapper.ts
@@ -44,6 +44,6 @@ export function schemaCallWrapperGPU(
 
   const callSchema = schema as GPUCallable<[unknown?]>;
   return item === undefined || item.value === undefined
-    ? callSchema[$gpuCallable].call(ctx, [])
-    : callSchema[$gpuCallable].call(ctx, [item]);
+    ? callSchema[$gpuCallable](ctx, [])
+    : callSchema[$gpuCallable](ctx, [item]);
 }

--- a/packages/typegpu/src/data/snippet.ts
+++ b/packages/typegpu/src/data/snippet.ts
@@ -110,7 +110,7 @@ export interface ResolvedSnippet extends Snippet {
   readonly dataType: BaseData;
 }
 
-export type MapValueToSnippet<T> = { [K in keyof T]: Snippet };
+export type MapValueToSnippet<T> = { readonly [K in keyof T]: Snippet };
 
 class SnippetImpl implements Snippet {
   readonly value: unknown;

--- a/packages/typegpu/src/data/struct.ts
+++ b/packages/typegpu/src/data/struct.ts
@@ -1,7 +1,10 @@
+import { WgslTypeError } from '../errors.ts';
 import { validateProp } from '../nameUtils.ts';
 import { getName, setName } from '../shared/meta.ts';
-import { $internal } from '../shared/symbols.ts';
+import { $gpuCallable, $gpuCallableStrictSignature, $internal } from '../shared/symbols.ts';
+import { tryConvertSnippet } from '../tgsl/conversion.ts';
 import { schemaCallWrapper } from './schemaCallWrapper.ts';
+import { snip } from './snippet.ts';
 import type { AnyWgslData, BaseData, WgslStruct } from './wgslTypes.ts';
 
 // ----------
@@ -72,10 +75,38 @@ const WgslStructImpl = {
 
   $name(label: string) {
     setName(this, label);
-    return this;
+    return this as WgslStruct;
   },
 
   toString(): string {
     return `struct:${getName(this) ?? '<unnamed>'}`;
   },
-};
+
+  get [$gpuCallableStrictSignature]() {
+    return { argTypes: [this as WgslStruct], returnType: this as WgslStruct };
+  },
+
+  [$gpuCallable](ctx, args) {
+    if (args.length > 1) {
+      throw new WgslTypeError('Struct schemas should always be called with at most 1 argument');
+    }
+
+    // No arguments `Struct()`, resolve struct name and return.
+    if (!args[0]) {
+      // The schema becomes the data type.
+      return ctx.gen.typeInstantiation(this as WgslStruct, []);
+    }
+
+    const arg = tryConvertSnippet(ctx, args[0], this as WgslStruct);
+
+    // Either `Struct({ x: 1, y: 2 })`, or `Struct(otherStruct)`.
+    // In both cases, we just let the argument resolve everything.
+    return snip(
+      ctx.resolveSnippet(arg).value,
+      this as WgslStruct,
+      // A new struct, so not a reference.
+      /* origin */ 'runtime',
+      arg.possibleSideEffects,
+    );
+  },
+} satisfies Partial<WgslStruct>;

--- a/packages/typegpu/src/data/vertexFormatData.ts
+++ b/packages/typegpu/src/data/vertexFormatData.ts
@@ -53,10 +53,8 @@ class TgpuVertexFormatDataImpl<T extends VertexFormat> implements TgpuVertexForm
 
   constructor(type: T) {
     this.type = type;
-    this[$gpuCallable] = {
-      call: (ctx, [v]): Snippet => {
-        return schemaCallWrapperGPU(ctx, formatToWGSLType[this.type], v);
-      },
+    this[$gpuCallable] = (ctx, [v]): Snippet => {
+      return schemaCallWrapperGPU(ctx, formatToWGSLType[this.type], v);
     };
   }
 

--- a/packages/typegpu/src/data/wgslTypes.ts
+++ b/packages/typegpu/src/data/wgslTypes.ts
@@ -1169,9 +1169,8 @@ export interface Mat4x4f extends BaseData {
 // We restrict the element type to being BaseData, which is the widest type
 // we can use internally to work with generic arrays. The default type of
 // `AnyWgslData` is the best choice for end-users.
-export interface WgslArray<out TElement extends BaseData = BaseData> extends BaseData {
-  <T extends TElement>(elements: Infer<T>[]): Infer<T>[];
-  (): Infer<TElement>[];
+export interface WgslArray<out TElement extends BaseData = BaseData>
+  extends DualFn<<T extends Infer<TElement>[]>(elements?: T) => T>, BaseData {
   readonly type: 'array';
   readonly elementCount: number;
   readonly elementType: TElement;
@@ -1207,15 +1206,15 @@ export interface WgslStruct<
   // @ts-expect-error: Override variance, as we want structs to behave like objects
   out TProps extends Record<string, BaseData> = Record<string, BaseData>,
 >
-  extends BaseData, TgpuNamable {
+  extends
+    DualFn<(props?: Prettify<InferRecord<TProps>>) => Prettify<InferRecord<TProps>>>,
+    BaseData,
+    TgpuNamable {
   readonly [$internal]: {
     isAbstruct: boolean;
   };
   readonly type: 'struct';
   readonly propTypes: TProps;
-
-  (props: Prettify<InferRecord<TProps>>): Prettify<InferRecord<TProps>>;
-  (): Prettify<InferRecord<TProps>>;
 
   // Type-tokens, not available at runtime
   readonly [$repr]: Prettify<InferRecord<TProps>>;

--- a/packages/typegpu/src/resolutionCtx.ts
+++ b/packages/typegpu/src/resolutionCtx.ts
@@ -589,7 +589,7 @@ export class ResolutionCtxImpl implements ResolutionCtx {
     this._itemStateStack.clearBlockExternals();
   }
 
-  generateLog(op: SupportedLogOp, args: Snippet[]): Snippet {
+  generateLog(op: SupportedLogOp, args: readonly Snippet[]): Snippet {
     return this.#logGenerator.generateLog(this, op, args);
   }
 

--- a/packages/typegpu/src/shared/symbols.ts
+++ b/packages/typegpu/src/shared/symbols.ts
@@ -33,6 +33,11 @@ export const $cast = Symbol(`typegpu:${version}:$cast`);
  * Can be called on the GPU
  */
 export const $gpuCallable = Symbol(`typegpu:${version}:$gpuCallable`);
+/**
+ * Optional strict signature metadata for GPU-callable values, used for argument
+ * type hints and validation.
+ */
+export const $gpuCallableStrictSignature = Symbol(`typegpu:${version}:$gpuCallableStrictSignature`);
 
 //
 // Type tokens

--- a/packages/typegpu/src/std/environment.ts
+++ b/packages/typegpu/src/std/environment.ts
@@ -7,10 +7,8 @@ import type { DualFn, ShaderStage } from '../types.ts';
 
 const impl = (() => false) as DualFn<() => boolean>;
 impl.toString = () => 'isBeingTranspiled';
-impl[$gpuCallable] = {
-  call(_ctx, _args) {
-    return coerceToSnippet(true);
-  },
+impl[$gpuCallable] = (_ctx, _args) => {
+  return coerceToSnippet(true);
 };
 
 /**

--- a/packages/typegpu/src/std/matrix.ts
+++ b/packages/typegpu/src/std/matrix.ts
@@ -14,11 +14,11 @@ import { $gpuCallable } from '../shared/symbols.ts';
 import { vec3f } from '../data/vector.ts';
 import { f32 } from '../data/numeric.ts';
 
-const gpuTranslation4 = translation4[$gpuCallable].call.bind(translation4);
-const gpuScaling4 = scaling4[$gpuCallable].call.bind(scaling4);
-const gpuRotationX4 = rotationX4[$gpuCallable].call.bind(rotationX4);
-const gpuRotationY4 = rotationY4[$gpuCallable].call.bind(rotationY4);
-const gpuRotationZ4 = rotationZ4[$gpuCallable].call.bind(rotationZ4);
+const gpuTranslation4 = translation4[$gpuCallable].bind(translation4);
+const gpuScaling4 = scaling4[$gpuCallable].bind(scaling4);
+const gpuRotationX4 = rotationX4[$gpuCallable].bind(rotationX4);
+const gpuRotationY4 = rotationY4[$gpuCallable].bind(rotationY4);
+const gpuRotationZ4 = rotationZ4[$gpuCallable].bind(rotationZ4);
 
 /**
  * Translates the given 4-by-4 matrix by the given vector.

--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -93,7 +93,10 @@ function variadicReduce<T>(fn: (a: T, b: T) => T) {
 }
 
 function variadicStitch(wrapper: string) {
-  return (_ctx: ResolutionCtx, [fst, ...rest]: [fst: Snippet, ...rest: Snippet[]]): string => {
+  return (
+    _ctx: ResolutionCtx,
+    [fst, ...rest]: readonly [fst: Snippet, ...rest: Snippet[]],
+  ): string => {
     let acc = stitch`${fst}`;
     for (const r of rest) {
       acc = stitch`${wrapper}(${acc}, ${r})`;

--- a/packages/typegpu/src/tgsl/consoleLog/types.ts
+++ b/packages/typegpu/src/tgsl/consoleLog/types.ts
@@ -56,6 +56,6 @@ export interface LogResources {
 }
 
 export interface LogGenerator {
-  generateLog(ctx: ResolutionCtx, op: SupportedLogOp, args: Snippet[]): Snippet;
+  generateLog(ctx: ResolutionCtx, op: SupportedLogOp, args: readonly Snippet[]): Snippet;
   get logResources(): LogResources | undefined;
 }

--- a/packages/typegpu/src/tgsl/forOfUtils.ts
+++ b/packages/typegpu/src/tgsl/forOfUtils.ts
@@ -101,7 +101,7 @@ You can wrap iterable with \`tgpu.unroll(...)\`. If iterable is known at comptim
       end:
         dataType.elementCount > 0
           ? snip(dataType.elementCount, u32, 'constant', false)
-          : arrayLength[$gpuCallable].call(ctx, [iterableSnippet]),
+          : arrayLength[$gpuCallable](ctx, [iterableSnippet]),
     };
   }
 

--- a/packages/typegpu/src/tgsl/shaderGenerator.ts
+++ b/packages/typegpu/src/tgsl/shaderGenerator.ts
@@ -8,6 +8,7 @@ import type {
   ResolutionCtx,
   ShaderStage,
 } from '../types.ts';
+import type { AnyFn } from '../core/function/fnTypes.ts';
 
 export interface FunctionDefinitionOptions {
   readonly functionType: 'normal' | ShaderStage;
@@ -122,7 +123,12 @@ export interface ShaderGenerator {
 
   typeInstantiation(schema: BaseData, args: readonly Snippet[]): ResolvedSnippet;
   numericLiteral(value: number, schema: BaseData): ResolvedSnippet;
+  /**
+   * Can be used to call arbitrary helper functions during shader generation, e.g. for polifylls.
+   */
+  call(callee: AnyFn, args: readonly Snippet[]): Snippet;
 
+  // `emit*` methods, responsible only for combining pieces into valid shader code.
   emitTypeAnnotation(schema: BaseData): string;
   emitCall(name: string, templateParams: readonly Snippet[], args: readonly Snippet[]): string;
   emitBinaryOp(lhs: Snippet, op: BinaryOperator, rhs: Snippet): string;

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -15,7 +15,13 @@ import {
 import * as wgsl from '../data/wgslTypes.ts';
 import { invariant, ResolutionError, WgslTypeError } from '../errors.ts';
 import { getName } from '../shared/meta.ts';
-import { $gpuCallable, $internal, $providing, isMarkedInternal } from '../shared/symbols.ts';
+import {
+  $gpuCallable,
+  $gpuCallableStrictSignature,
+  $internal,
+  $providing,
+  isMarkedInternal,
+} from '../shared/symbols.ts';
 import { safeStringify } from '../shared/stringify.ts';
 import { pow } from '../std/numeric.ts';
 import { add, div, mul, neg, sub } from '../std/operators.ts';
@@ -25,7 +31,6 @@ import {
   isGPUCallable,
   isKnownAtComptime,
   type BindableBufferUsage,
-  type DualFn,
   type ResolutionCtx,
 } from '../types.ts';
 import { convertStructValues, convertToCommonType, tryConvertSnippet } from './conversion.ts';
@@ -170,7 +175,7 @@ function operatorToType<
 }
 
 const unaryOpCodeToCodegen = {
-  '-': neg[$gpuCallable].call.bind(neg),
+  '-': neg[$gpuCallable].bind(neg),
   void: () => snip(undefined, wgsl.Void, 'constant', false),
   '!': (ctx: ResolutionCtx, [argExpr]: Snippet[]) => {
     if (argExpr === undefined) {
@@ -198,11 +203,11 @@ const unaryOpCodeToCodegen = {
 } satisfies Partial<Record<tinyest.UnaryOperator, (...args: never[]) => unknown>>;
 
 const binaryOpCodeToCodegen = {
-  '+': add[$gpuCallable].call.bind(add),
-  '-': sub[$gpuCallable].call.bind(sub),
-  '*': mul[$gpuCallable].call.bind(mul),
-  '/': div[$gpuCallable].call.bind(div),
-  '**': pow[$gpuCallable].call.bind(pow),
+  '+': add[$gpuCallable].bind(add),
+  '-': sub[$gpuCallable].bind(sub),
+  '*': mul[$gpuCallable].bind(mul),
+  '/': div[$gpuCallable].bind(div),
+  '**': pow[$gpuCallable].bind(pow),
 } satisfies Partial<Record<tinyest.BinaryOperator, (...args: never[]) => unknown>>;
 
 const usageToVarTemplateMap: Record<VariableScope | BindableBufferUsage, string> = {
@@ -404,7 +409,7 @@ export class WgslGenerator implements ShaderGenerator {
    * A wrapper for `generateExpression` that updates `ctx.expectedType`
    * and tries to convert the result when it does not match the expected type.
    */
-  protected _typedExpression(
+  protected _expressionWithTypeSuggestion(
     expression: tinyest.Expression,
     expectedType: wgsl.BaseData | wgsl.BaseData[],
   ) {
@@ -412,17 +417,110 @@ export class WgslGenerator implements ShaderGenerator {
     this.ctx.expectedType = expectedType;
 
     try {
-      const result = this._expression(expression);
-      if (expectedType instanceof AutoStruct) {
-        // We provide a certain AutoStruct object to later
-        // investigate what props were accessed. No need to
-        // convert the result.
-        return result;
-      }
-      return tryConvertSnippet(this.ctx, result, expectedType);
+      return this._expression(expression);
     } finally {
       this.ctx.expectedType = prevExpectedType;
     }
+  }
+
+  protected _expressionWithTypeConversion(
+    expression: tinyest.Expression,
+    expectedType: wgsl.BaseData | wgsl.BaseData[],
+  ) {
+    const result = this._expressionWithTypeSuggestion(expression, expectedType);
+    if (expectedType instanceof AutoStruct) {
+      // We provide a certain AutoStruct object to later
+      // investigate what props were accessed. No need to
+      // convert the result.
+      return result;
+    }
+    return tryConvertSnippet(this.ctx, result, expectedType);
+  }
+
+  public call(_callee: AnyFn, args: readonly Snippet[]): Snippet {
+    const callee = mathToStd.get(_callee) ?? _callee;
+
+    if (supportedLogOps().includes(callee)) {
+      return this.ctx.generateLog(callee, args);
+    }
+
+    if (callee === constant) {
+      throw new Error(
+        'Constants cannot be defined within TypeGPU function scope. To address this, move the constant definition outside the function scope.',
+      );
+    }
+
+    if (isInfixDispatch(callee)) {
+      if (!args[0]) {
+        throw new WgslTypeError(
+          `An infix operator '${getName(callee.operator)}' was called without any arguments`,
+        );
+      }
+      const lhs = coerceToSnippet(callee.lhs);
+      const rhs = args[0];
+      return callee.operator[$gpuCallable](this.ctx, [lhs, rhs]);
+    }
+
+    if (isGPUCallable(callee)) {
+      const strictSignature = callee[$gpuCallableStrictSignature];
+
+      let convertedArguments: readonly Snippet[];
+      if (strictSignature) {
+        // The function's signature does not depend on the context, so it can be used to
+        // give a hint to the argument expressions that a specific type is expected.
+        convertedArguments = args.map((arg, i) => {
+          const argType = strictSignature.argTypes[i];
+          return argType ? tryConvertSnippet(this.ctx, arg, argType) : arg;
+        });
+      } else {
+        convertedArguments = args;
+      }
+
+      try {
+        return callee[$gpuCallable](this.ctx, convertedArguments);
+      } catch (err) {
+        if (err instanceof ResolutionError) {
+          throw err;
+        }
+
+        throw new ResolutionError(err, [
+          {
+            toString: () => `fn:${getName(callee)}`,
+          },
+        ]);
+      }
+    }
+
+    if (!isMarkedInternal(callee) || isGenericFn(callee)) {
+      const result = this._callShellless(callee, args);
+
+      if (result) {
+        return result;
+      }
+    }
+
+    // try to throw a descriptive error
+    const maybeMathMethod = Object.getOwnPropertyNames(Math).find(
+      (prop) => Math[prop as keyof typeof Math] === callee,
+    );
+    if (maybeMathMethod) {
+      throw new Error(
+        `Unsupported Math functionality 'Math.${maybeMathMethod}()'. Use an std alternative, or implement the function manually.`,
+      );
+    }
+
+    const maybeConsoleMethod = Object.getOwnPropertyNames(console).find(
+      (prop) => console[prop as keyof typeof console] === callee,
+    );
+    if (maybeConsoleMethod) {
+      throw new Error(`Unsupported console functionality 'console.${maybeConsoleMethod}()'.`);
+    }
+
+    throw new Error(
+      `Function '${
+        getName(callee) ?? String(callee)
+      }' is not marked with the 'use gpu' directive and cannot be used in a shader`,
+    );
   }
 
   protected _expression(expression: tinyest.Expression): Snippet {
@@ -717,174 +815,35 @@ export class WgslGenerator implements ShaderGenerator {
       // Function Call
       const [_, calleeNode, argNodes] = expression;
       const _callee = this._expression(calleeNode);
-      const callee = mathToStd.has(_callee.value as AnyFn)
-        ? snip(
-            mathToStd.get(_callee.value as AnyFn) as DualFn<AnyFn>,
-            UnknownData,
-            'runtime',
-            _callee.possibleSideEffects,
-          )
-        : _callee;
+      const callee = mathToStd.get(_callee.value as AnyFn) ?? (_callee.value as AnyFn);
 
-      if (supportedLogOps().includes(callee.value as AnyFn)) {
-        return this.ctx.generateLog(
-          callee.value as AnyFn,
-          argNodes.map((arg) => this._expression(arg)),
-        );
-      }
-
-      if (wgsl.isWgslStruct(callee.value)) {
-        // Struct schema call.
-        if (argNodes.length > 1) {
-          throw new WgslTypeError('Struct schemas should always be called with at most 1 argument');
-        }
-
-        // No arguments `Struct()`, resolve struct name and return.
-        if (!argNodes[0]) {
-          // The schema becomes the data type.
-          return snip(
-            `${this.ctx.resolve(callee.value).value}()`,
-            callee.value,
-            // A new struct, so not a reference.
-            /* origin */ 'runtime',
-            false,
-          );
-        }
-
-        const arg = this._typedExpression(argNodes[0], callee.value);
-
-        // Either `Struct({ x: 1, y: 2 })`, or `Struct(otherStruct)`.
-        // In both cases, we just let the argument resolve everything.
-        return snip(
-          this.ctx.resolveSnippet(arg).value,
-          callee.value,
-          // A new struct, so not a reference.
-          /* origin */ 'runtime',
-          arg.possibleSideEffects,
-        );
-      }
-
-      if (wgsl.isWgslArray(callee.value)) {
-        // Array schema call.
-        if (argNodes.length > 1) {
-          throw new WgslTypeError('Array schemas should always be called with at most 1 argument');
-        }
-
-        // No arguments `array<...>()`, resolve array type and return.
-        if (!argNodes[0]) {
-          // The schema becomes the data type.
-          return this.typeInstantiation(callee.value, []);
-        }
-
-        const arg = this._typedExpression(argNodes[0], callee.value);
-
-        // `d.arrayOf(...)([...])`.
-        // We don't resolve the ArrayExpression object itself to
-        // avoid reference checks (we're copying so it's fine)
-        if (arg.value instanceof ArrayExpression) {
-          return this.typeInstantiation(callee.value, arg.value.elements);
-        }
-
-        // `d.arrayOf(...)(otherArr)`.
-        // We just let the argument resolve everything.
-        return snip(
-          this.ctx.resolveSnippet(arg).value,
-          callee.value,
-          // A new array, so not a reference.
-          /* origin */ 'runtime',
-          arg.possibleSideEffects,
-        );
-      }
-
-      if (callee.value === constant) {
-        throw new Error(
-          'Constants cannot be defined within TypeGPU function scope. To address this, move the constant definition outside the function scope.',
-        );
-      }
-
-      if (isInfixDispatch(callee.value)) {
-        if (!argNodes[0]) {
-          throw new WgslTypeError(
-            `An infix operator '${getName(callee.value.operator)}' was called without any arguments`,
-          );
-        }
-        const lhs = coerceToSnippet(callee.value.lhs);
-        const rhs = this._expression(argNodes[0]);
-        const callable = callee.value.operator[$gpuCallable];
-        return callable.call(this.ctx, [lhs, rhs]);
-      }
-
-      if ((callee.value === _ref || callee.value === unroll) && argNodes[0]) {
+      if ((callee === _ref || callee === unroll) && argNodes[0]) {
         this.tryMarkModified(argNodes[0]);
       }
 
-      if (isGPUCallable(callee.value)) {
-        const callable = callee.value[$gpuCallable];
-        const strictSignature = callable.strictSignature;
+      let args: readonly Snippet[];
 
-        let convertedArguments: Snippet[];
-        if (strictSignature) {
-          // The function's signature does not depend on the context, so it can be used to
-          // give a hint to the argument expressions that a specific type is expected.
-          convertedArguments = argNodes.map((arg, i) => {
-            const argType = strictSignature.argTypes[i];
-            if (!argType) {
-              throw new WgslTypeError(
-                `Call '${stringifyNode(expression)}' is invalid since the function expected fewer arguments`,
-              );
-            }
-            return this._typedExpression(arg, argType);
-          });
-        } else {
-          convertedArguments = argNodes.map((arg) => this._expression(arg));
-        }
+      if (isGPUCallable(callee) && callee[$gpuCallableStrictSignature]) {
+        const strictSignature = callee[$gpuCallableStrictSignature];
 
-        try {
-          return callable.call(this.ctx, convertedArguments);
-        } catch (err) {
-          if (err instanceof ResolutionError) {
-            throw err;
+        // The function's signature does not depend on the context, so it can be used to
+        // give a hint to the argument expressions that a specific type is expected.
+        args = argNodes.map((arg, i) => {
+          const argType = strictSignature.argTypes[i];
+          if (!argType) {
+            const length = strictSignature.argTypes.length;
+            throw new WgslTypeError(
+              `Call '${stringifyNode(expression)}' is invalid, the function expected at most ${length} argument${length === 1 ? '' : 's'}`,
+            );
           }
-
-          throw new ResolutionError(err, [
-            {
-              toString: () => `fn:${getName(callee.value)}`,
-            },
-          ]);
-        }
+          // It's only a suggestion, the conversion happens later on
+          return this._expressionWithTypeSuggestion(arg, argType);
+        });
+      } else {
+        args = argNodes.map((arg) => this._expression(arg));
       }
 
-      if (!isMarkedInternal(callee.value) || isGenericFn(callee.value)) {
-        const args = argNodes.map((arg) => this._expression(arg));
-        const result = this._callShellless(callee.value as AnyFn, args);
-
-        if (result) {
-          return result;
-        }
-      }
-
-      // try to throw a descriptive error
-      const maybeMathMethod = Object.getOwnPropertyNames(Math).find(
-        (prop) => Math[prop as keyof typeof Math] === callee.value,
-      );
-      if (maybeMathMethod) {
-        throw new Error(
-          `Unsupported Math functionality 'Math.${maybeMathMethod}()'. Use an std alternative, or implement the function manually.`,
-        );
-      }
-
-      const maybeConsoleMethod = Object.getOwnPropertyNames(console).find(
-        (prop) => console[prop as keyof typeof console] === callee.value,
-      );
-      if (maybeConsoleMethod) {
-        throw new Error(`Unsupported console functionality 'console.${maybeConsoleMethod}()'.`);
-      }
-
-      throw new Error(
-        `Function '${
-          getName(callee.value) ?? String(callee.value)
-        }' is not marked with the 'use gpu' directive and cannot be used in a shader`,
-      );
+      return this.call(callee, args);
     }
 
     if (expression[0] === NODE.objectExpr) {
@@ -899,7 +858,7 @@ export class WgslGenerator implements ShaderGenerator {
             let expr: Snippet;
             if (accessed) {
               // Generating the expression expecting a specific type
-              expr = this._typedExpression(value, accessed.type);
+              expr = this._expressionWithTypeConversion(value, accessed.type);
             } else {
               // Generating the expression and inferring the type instead
               expr = this._expression(value);
@@ -935,7 +894,7 @@ export class WgslGenerator implements ShaderGenerator {
                 `Missing property ${key} in object literal for struct ${structType}`,
               );
             }
-            const result = this._typedExpression(val, value);
+            const result = this._expressionWithTypeConversion(val, value);
             return [key, result];
           }),
         );
@@ -965,7 +924,7 @@ export class WgslGenerator implements ShaderGenerator {
       if (wgsl.isWgslArray(arrType)) {
         elemType = arrType.elementType;
         // The array is typed, so its elements should be as well.
-        values = valueNodes.map((value) => this._typedExpression(value, elemType));
+        values = valueNodes.map((value) => this._expressionWithTypeConversion(value, elemType));
         // Since it's an expected type, we enforce the length
         if (values.length !== arrType.elementCount) {
           throw new WgslTypeError(
@@ -1235,7 +1194,7 @@ export class WgslGenerator implements ShaderGenerator {
     if (returnNode !== undefined) {
       const expectedReturnType = this.ctx.topFunctionReturnType;
       let returnSnippet = expectedReturnType
-        ? this._typedExpression(returnNode, expectedReturnType)
+        ? this._expressionWithTypeConversion(returnNode, expectedReturnType)
         : this._expression(returnNode);
 
       if (returnSnippet.value === undefined && wgsl.isVoid(returnSnippet.dataType)) {
@@ -1560,7 +1519,7 @@ Try 'return ${typeStr}(${str});' instead.
 
     if (statement[0] === NODE.if) {
       const [_, condNode, consNode, altNode] = statement;
-      const condition = this._typedExpression(condNode, bool);
+      const condition = this._expressionWithTypeConversion(condNode, bool);
 
       if (typeof condition.value === 'boolean') {
         // the condition is known at comptime
@@ -1625,7 +1584,7 @@ ${this.ctx.pre}else ${alternate}`,
         const [initStatement, conditionExpr, updateStatement] = this.ctx.withResetIndentLevel(
           () => [
             init ? this._statement(init).code : undefined,
-            condition ? this._typedExpression(condition, bool) : undefined,
+            condition ? this._expressionWithTypeConversion(condition, bool) : undefined,
             update ? this._statement(update).code : undefined,
           ],
         );
@@ -1649,7 +1608,7 @@ ${this.ctx.pre}else ${alternate}`,
       this.#unrollingChain = [];
       try {
         const [_, condition, body] = statement;
-        const condSnippet = this._typedExpression(condition, bool);
+        const condSnippet = this._expressionWithTypeConversion(condition, bool);
         const conditionStr = this.ctx.resolveSnippet(condSnippet).value;
 
         const bodyStr = this._block(blockifySingleStatement(body), /* allowInlining */ false).code;

--- a/packages/typegpu/src/types.ts
+++ b/packages/typegpu/src/types.ts
@@ -34,6 +34,7 @@ import {
 import {
   $cast,
   $gpuCallable,
+  $gpuCallableStrictSignature,
   $gpuValueOf,
   $internal,
   $ownSnippet,
@@ -402,7 +403,7 @@ export interface ResolutionCtx {
 
   pushBlockScope(): void;
   popBlockScope(): void;
-  generateLog(op: SupportedLogOp, args: Snippet[]): Snippet;
+  generateLog(op: SupportedLogOp, args: readonly Snippet[]): Snippet;
   getById(id: string): Snippet | null;
   defineVariable(id: string, snippet: Snippet): void;
   setBlockExternals(externals: Record<string, Snippet>): void;
@@ -443,11 +444,14 @@ export function getOwnSnippet(value: unknown): Snippet | undefined {
   return (value as WithOwnSnippet)?.[$ownSnippet];
 }
 
+export type GPUCallableStrictSignature = {
+  argTypes: (BaseData | BaseData[])[];
+  returnType: BaseData;
+};
+
 export interface GPUCallable<TArgs extends unknown[] = unknown[]> {
-  [$gpuCallable]: {
-    strictSignature?: { argTypes: (BaseData | BaseData[])[]; returnType: BaseData } | undefined;
-    call(ctx: ResolutionCtx, args: MapValueToSnippet<TArgs>): Snippet;
-  };
+  [$gpuCallable](ctx: ResolutionCtx, args: MapValueToSnippet<TArgs>): Snippet;
+  [$gpuCallableStrictSignature]?: GPUCallableStrictSignature | undefined;
 }
 
 export function isGPUCallable(value: unknown): value is GPUCallable {

--- a/packages/typegpu/tests/array.test.ts
+++ b/packages/typegpu/tests/array.test.ts
@@ -138,7 +138,7 @@ describe('array', () => {
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:f
-      - fn*:f(): Array schemas should always be called with at most 1 argument]
+      - fn*:f(): Call 'ArraySchema([1, 1], [6, 7])' is invalid, the function expected at most 1 argument]
     `);
   });
 

--- a/packages/typegpu/tests/bindGroupLayout.test.ts
+++ b/packages/typegpu/tests/bindGroupLayout.test.ts
@@ -186,7 +186,7 @@ describe('TgpuBindGroupLayout', () => {
     const getFirst = () => {
       'use gpu';
       const boids = layout.$.boids;
-      return Boid(boids[0]!);
+      return Boid(boids[0]);
     };
 
     expect(tgpu.resolve([getFirst])).toMatchInlineSnapshot(`

--- a/packages/typegpu/tests/struct.test.ts
+++ b/packages/typegpu/tests/struct.test.ts
@@ -397,7 +397,7 @@ describe('struct', () => {
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:f
-      - fn*:f(): Struct schemas should always be called with at most 1 argument]
+      - fn*:f(): Call 'Boid(b1, b1)' is invalid, the function expected at most 1 argument]
     `);
   });
 
@@ -594,7 +594,7 @@ describe('struct', () => {
       const boids = d.arrayOf(Boid, 2)();
       // Should fail, because even though `boids[getNextCounter()]` is an alias for an existing
       // value, the expression has side-effects (increments counter).
-      const bird = Bird(boids[getNextCounter()]!);
+      const bird = Bird(boids[getNextCounter()]);
     }
 
     expect(() => tgpu.resolve([main2])).toThrowErrorMatchingInlineSnapshot(`

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -1304,7 +1304,7 @@ describe('WgslGenerator', () => {
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:main
-      - fn*:main(): Call 'testFn(1, 2)' is invalid since the function expected fewer arguments]
+      - fn*:main(): Call 'testFn(1, 2)' is invalid, the function expected at most 0 arguments]
     `);
   });
 

--- a/packages/typegpu/tests/utils/parseResolved.ts
+++ b/packages/typegpu/tests/utils/parseResolved.ts
@@ -39,7 +39,7 @@ class ExtractingGenerator extends WgslGenerator {
       }
       const expectedReturnType = this.ctx.topFunctionReturnType;
       this.returnedSnippet = expectedReturnType
-        ? this._typedExpression(statement[1], expectedReturnType)
+        ? this._expressionWithTypeConversion(statement[1], expectedReturnType)
         : this._expression(statement[1]);
       return super._return([NODE.return]);
     }


### PR DESCRIPTION
Changes:
- Struct and array schemas now take care of what happens when somebody calls them.
- Generating argument snippets out of `tinyest` nodes is now a seperate step from actually calling a function. This allows other parts of the generator to call helper functions without needing to reach into the deep internals via symbols (helpful in GLSL generation as well as the future matrix std function rewrites)