### PR TITLE
fix: Emit empty fragment targets instead of [null]

### DIFF
--- a/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/point-light-shadow/index.ts
@@ -393,6 +393,7 @@ function render(timestamp: number) {
     .withColorAttachment({
       resolveTarget: context,
       view: msaaTexture,
+      clearValue: [0, 0, 0, 1],
     })
     .with(mainBindGroup)
     .withIndexBuffer(BoxGeometry.indexBuffer)

--- a/packages/typegpu/src/core/pipeline/connectTargetsToShader.ts
+++ b/packages/typegpu/src/core/pipeline/connectTargetsToShader.ts
@@ -9,7 +9,7 @@ export function connectTargetsToShader(
   let presentationFormat: GPUTextureFormat | undefined;
 
   if (isVoid(fragmentOut) || isBuiltin(fragmentOut)) {
-    return [null];
+    return [];
   }
 
   if (isWgslStruct(fragmentOut)) {

--- a/packages/typegpu/src/core/pipeline/renderPipeline.ts
+++ b/packages/typegpu/src/core/pipeline/renderPipeline.ts
@@ -960,7 +960,7 @@ class RenderPipelineCore implements SelfResolvable {
     // then this.#latestAutoFragmentOut will be undefined.
     const fragmentOut =
       (fragment as TgpuFragmentFn)?.shell?.returnType ?? this.#latestAutoFragmentOut;
-    const connectedTargets = fragmentOut ? connectTargetsToShader(fragmentOut, targets) : [null];
+    const connectedTargets = fragmentOut ? connectTargetsToShader(fragmentOut, targets) : [];
 
     const descriptor: GPURenderPipelineDescriptor = {
       layout: device.createPipelineLayout({


### PR DESCRIPTION
- Fragment shaders that return only a builtin e.g (`out: d.builtin.fragDepth`) now create pipelines with `fragment.targets: []` instead of `[null]`. 
Both ways are spec-legal, but Firefox rejects `[null]` with `Missing required 'format' member of GPUColorTargetState`, so the pipeline never ran. 

- Due to this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1968315) `Point Light Shadow` example now clears the color attachment to `[0, 0, 0, 1]`. 