### PR TITLE
test: cover raw snippets in unrolled blocks

### DIFF
--- a/packages/typegpu/tests/unroll.test.ts
+++ b/packages/typegpu/tests/unroll.test.ts
@@ -63,6 +63,29 @@ describe('tgpu.unroll', () => {
     `);
   });
 
+  it('does not break with raw code snippets', () => {
+    const snip = tgpu['~unstable'].rawCodeSnippet('const a = 1', d.Void);
+
+    const fn = () => {
+      'use gpu';
+      for (const a of tgpu.unroll([1, 2, 3])) {
+        snip.$;
+      }
+    };
+
+    expect(tgpu.resolve([fn])).toMatchInlineSnapshot(`
+      "fn fn_1() {
+        // unrolled iteration #0
+        const a = 1;
+        // unrolled iteration #1
+        const a = 1;
+        // unrolled iteration #2
+        const a = 1;
+        // ---
+      }"
+    `);
+  });
+
   it('unrolls correctly when loop variable is overriding', () => {
     const f = () => {
       'use gpu';


### PR DESCRIPTION
## Summary

- add the regression from #2897 to the existing `tgpu.unroll` suite
- verify a side-effectful raw `d.Void` snippet is retained once per unrolled iteration
- pin the exact generated WGSL, including iteration markers and block terminator

Current `main` already preserves this behavior, so this PR intentionally adds the missing regression guard without changing resolver code.

## Verification

- focused `unroll.test.ts`: 29/29 pass
- source attest suite: 275 files, 2,853 pass, 2 skip
- built-package attest suite: 243 files, 2,430 pass, 2 skip
- workspace type checks and style checks pass
- circular dependency check passes

The first root run hit the existing 5-second timeout in the unrelated docs probability example. It passed alone in 648 ms, and the complete source attest suite passed on the clean rerun.

Closes #2897