### PR TITLE
fix: reject unsigned unary negation

### DIFF
--- a/packages/typegpu/src/std/operators.ts
+++ b/packages/typegpu/src/std/operators.ts
@@ -20,7 +20,7 @@ import {
   isVecInstance,
   type vecIToVecU,
 } from '../data/wgslTypes.ts';
-import { SignatureNotSupportedError } from '../errors.ts';
+import { SignatureNotSupportedError, WgslTypeError } from '../errors.ts';
 import { unify } from '../tgsl/conversion.ts';
 
 type NumVec = AnyNumericVecInstance;
@@ -247,10 +247,17 @@ function cpuNeg(value: NumVec | number): NumVec | number {
 
 export const neg = dualImpl({
   name: 'neg',
-  signature: (arg) => ({
-    argTypes: [arg],
-    returnType: arg,
-  }),
+  signature: (arg) => {
+    if (getPrimitive(arg) === u32) {
+      throw new WgslTypeError(
+        `Unary operator - requires a signed integer or floating-point operand. Got ${String(arg)}.`,
+      );
+    }
+    return {
+      argTypes: [arg],
+      returnType: arg,
+    };
+  },
   normalImpl: cpuNeg,
   codegenImpl: (_ctx, [arg]) => stitch`-(${arg})`,
   sideEffects: false,

--- a/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
+++ b/packages/typegpu/tests/tgsl/wgslGenerator.test.ts
@@ -1707,6 +1707,39 @@ describe('WgslGenerator', () => {
     `);
   });
 
+  describe('handles unary operator -', () => {
+    it('throws on unsigned integer operands', () => {
+      const testFn = tgpu.fn(
+        [],
+        d.u32,
+      )(() => {
+        return -d.u32(7.5);
+      });
+
+      expect(() => tgpu.resolve([testFn])).toThrowErrorMatchingInlineSnapshot(`
+        [Error: Resolution of the following tree failed:
+        - <root>
+        - fn:testFn: Unary operator - requires a signed integer or floating-point operand. Got u32.]
+      `);
+    });
+
+    it('throws on unsigned integer vector operands passed to std.neg', () => {
+      const testFn = tgpu.fn(
+        [d.vec2u],
+        d.vec2u,
+      )((value) => {
+        return std.neg(value);
+      });
+
+      expect(() => tgpu.resolve([testFn])).toThrowErrorMatchingInlineSnapshot(`
+        [Error: Resolution of the following tree failed:
+        - <root>
+        - fn:testFn
+        - fn:neg: Unary operator - requires a signed integer or floating-point operand. Got vec2u.]
+      `);
+    });
+  });
+
   describe('handles unary operator !', () => {
     it('works with boolean runtime-known operand', () => {
       const testFn = tgpu.fn(


### PR DESCRIPTION
## Summary

- reject unary negation when the operand primitive is `u32`
- validate in `neg.signature` so the error is raised before both comptime folding and WGSL emission
- cover scalar unary `-` and unsigned-vector `std.neg` paths with exact resolution errors

WGSL does not define unary negation for unsigned integer scalars or vectors. This follows the maintainer direction in #2846 and avoids an implicit signed cast.

## TDD evidence

**RED:** the scalar regression failed because `tgpu.resolve()` emitted code instead of throwing.

**GREEN:** the focused WgslGenerator suite passes 90/90 and both `u32` and `vec2u` now fail at resolution with a descriptive `WgslTypeError`.

## Verification

- package typecheck passes
- changed files pass oxlint and oxfmt
- source TypeGPU suite: 176 files, 2,364 tests pass
- built TypeGPU suite: 144 files, 1,941 tests pass
- circular dependency check passes
- `git diff --check`

Fixes #2846