### PR TITLE
fix: validate comparison operand schemas

### DIFF
--- a/packages/typegpu/src/std/boolean.ts
+++ b/packages/typegpu/src/std/boolean.ts
@@ -51,6 +51,26 @@ function correspondingBooleanVectorSchema(dataType: BaseData) {
   return vec4b;
 }
 
+function assertMatchingKinds(lhs: string, rhs: string): void {
+  if (lhs !== rhs) {
+    throw new Error(
+      `Unsupported signature. Expected the following kinds to be equal: '${lhs}, ${rhs}'.`,
+    );
+  }
+}
+
+function matchingArgTypes(lhs: BaseData, rhs: BaseData): [BaseData, BaseData] {
+  assertMatchingKinds(lhs.type, rhs.type);
+  return [lhs, rhs];
+}
+
+function comparisonSignature(lhs: BaseData, rhs: BaseData) {
+  return {
+    argTypes: matchingArgTypes(lhs, rhs),
+    returnType: correspondingBooleanVectorSchema(lhs),
+  };
+}
+
 // comparison
 
 /**
@@ -62,14 +82,16 @@ function correspondingBooleanVectorSchema(dataType: BaseData) {
  */
 export const allEq = dualImpl({
   name: 'allEq',
-  signature: (...argTypes) => ({ argTypes, returnType: bool }),
+  signature: (lhs, rhs) => ({ argTypes: matchingArgTypes(lhs, rhs), returnType: bool }),
   normalImpl: <T extends AnyVecInstance>(lhs: T, rhs: T) => cpuAll(cpuEq(lhs, rhs)),
   codegenImpl: (_ctx, [lhs, rhs]) => stitch`all(${lhs} == ${rhs})`,
   sideEffects: false,
 });
 
-const cpuEq = <T extends AnyVecInstance>(lhs: T, rhs: T) =>
-  generalizeBoolFn((a, b) => a === b, [lhs, rhs]);
+const cpuEq = <T extends AnyVecInstance>(lhs: T, rhs: T) => {
+  assertMatchingKinds(lhs.kind, rhs.kind);
+  return generalizeBoolFn((a, b) => a === b, [lhs, rhs]);
+};
 
 /**
  * Checks **component-wise** whether `lhs == rhs`.
@@ -82,10 +104,7 @@ const cpuEq = <T extends AnyVecInstance>(lhs: T, rhs: T) =>
  */
 export const eq = dualImpl({
   name: 'eq',
-  signature: (...argTypes) => ({
-    argTypes,
-    returnType: correspondingBooleanVectorSchema(argTypes[0]),
-  }),
+  signature: comparisonSignature,
   normalImpl: cpuEq,
   codegenImpl: (_ctx, [lhs, rhs]) => stitch`(${lhs} == ${rhs})`,
   sideEffects: false,
@@ -101,17 +120,16 @@ export const eq = dualImpl({
  */
 export const ne = dualImpl({
   name: 'ne',
-  signature: (...argTypes) => ({
-    argTypes,
-    returnType: correspondingBooleanVectorSchema(argTypes[0]),
-  }),
+  signature: comparisonSignature,
   normalImpl: <T extends AnyVecInstance>(lhs: T, rhs: T) => cpuNot(cpuEq(lhs, rhs)),
   codegenImpl: (_ctx, [lhs, rhs]) => stitch`(${lhs} != ${rhs})`,
   sideEffects: false,
 });
 
-const cpuLt = <T extends AnyNumericVecInstance>(lhs: T, rhs: T) =>
-  generalizeBoolFn((a, b) => a < b, [lhs, rhs]);
+const cpuLt = <T extends AnyNumericVecInstance>(lhs: T, rhs: T) => {
+  assertMatchingKinds(lhs.kind, rhs.kind);
+  return generalizeBoolFn((a, b) => a < b, [lhs, rhs]);
+};
 
 /**
  * Checks **component-wise** whether `lhs < rhs`.
@@ -123,10 +141,7 @@ const cpuLt = <T extends AnyNumericVecInstance>(lhs: T, rhs: T) =>
  */
 export const lt = dualImpl({
   name: 'lt',
-  signature: (...argTypes) => ({
-    argTypes,
-    returnType: correspondingBooleanVectorSchema(argTypes[0]),
-  }),
+  signature: comparisonSignature,
   normalImpl: cpuLt,
   codegenImpl: (_ctx, [lhs, rhs]) => stitch`(${lhs} < ${rhs})`,
   sideEffects: false,
@@ -142,10 +157,7 @@ export const lt = dualImpl({
  */
 export const le = dualImpl({
   name: 'le',
-  signature: (...argTypes) => ({
-    argTypes,
-    returnType: correspondingBooleanVectorSchema(argTypes[0]),
-  }),
+  signature: comparisonSignature,
   normalImpl: <T extends AnyNumericVecInstance>(lhs: T, rhs: T) =>
     cpuOr(cpuLt(lhs, rhs), cpuEq(lhs, rhs)),
   codegenImpl: (_ctx, [lhs, rhs]) => stitch`(${lhs} <= ${rhs})`,
@@ -162,10 +174,7 @@ export const le = dualImpl({
  */
 export const gt = dualImpl({
   name: 'gt',
-  signature: (...argTypes) => ({
-    argTypes,
-    returnType: correspondingBooleanVectorSchema(argTypes[0]),
-  }),
+  signature: comparisonSignature,
   normalImpl: <T extends AnyNumericVecInstance>(lhs: T, rhs: T) =>
     cpuAnd(cpuNot(cpuLt(lhs, rhs)), cpuNot(cpuEq(lhs, rhs))),
   codegenImpl: (_ctx, [lhs, rhs]) => stitch`(${lhs} > ${rhs})`,
@@ -182,10 +191,7 @@ export const gt = dualImpl({
  */
 export const ge = dualImpl({
   name: 'ge',
-  signature: (...argTypes) => ({
-    argTypes: argTypes,
-    returnType: correspondingBooleanVectorSchema(argTypes[0]),
-  }),
+  signature: comparisonSignature,
   normalImpl: <T extends AnyNumericVecInstance>(lhs: T, rhs: T) => cpuNot(cpuLt(lhs, rhs)),
   codegenImpl: (_ctx, [lhs, rhs]) => stitch`(${lhs} >= ${rhs})`,
   sideEffects: false,

--- a/packages/typegpu/tests/std/boolean/lt.test.ts
+++ b/packages/typegpu/tests/std/boolean/lt.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { d, tgpu } from 'typegpu';
 import { vec2b, vec2f, vec2i, vec3b, vec3f, vec3i, vec4b, vec4f, vec4i } from 'typegpu/data';
 import { lt } from 'typegpu/std';
 
@@ -16,6 +17,24 @@ describe('lt', () => {
     expect(lt(vec3f(1.2, 2.3, 3.4), vec3f(2.3, 3.2, 3.4))).toStrictEqual(vec3b(true, true, false));
     expect(lt(vec4f(0.1, -0.2, -0.3, 0.4), vec4f(0.1, 0.2, 0.3, 0.4))).toStrictEqual(
       vec4b(false, true, true, false),
+    );
+  });
+
+  it('rejects mismatched vector schemas on CPU and GPU paths', () => {
+    // @ts-expect-error mismatched vector schemas are intentionally tested
+    expect(() => lt(d.vec3u(), d.vec3f())).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Unsupported signature. Expected the following kinds to be equal: 'vec3u, vec3f'.]`,
+    );
+
+    const f = () => {
+      'use gpu';
+      const x = d.vec3u();
+      // @ts-expect-error mismatched vector schemas are intentionally tested
+      return lt(x, d.vec3f());
+    };
+
+    expect(() => tgpu.resolve([f])).toThrowError(
+      /Unsupported signature\. Expected the following kinds to be equal: 'vec3u, vec3f'\./,
     );
   });
 });


### PR DESCRIPTION
## Summary

- reject mismatched vector kinds before CPU comparison execution
- apply the same invariant to WGSL signature resolution for allEq, eq, ne, lt, le, gt, and ge
- add a regression covering both CPU and generated-code paths

The TypeScript overloads already require matching vector schemas, but the runtime and generator paths accepted mixed kinds and could emit invalid WGSL such as vec3u < vec3f.

## TDD evidence

RED: the focused test failed because neither the direct lt call nor tgpu.resolve threw for vec3u versus vec3f.

GREEN: the focused test passes and both paths now return the same descriptive unsupported-signature error.

## Verification

- focused lt regression: 3/3 passed
- boolean std suite: 14 files, 49 tests passed
- source suite with attest: 216 files, 2,794 passed, 2 skipped
- built-artifact suite with attest: 184 files, 2,371 passed, 2 skipped
- all checked-out workspace package typechecks passed
- Oxlint and Oxfmt passed
- all packages built successfully
- circular dependency scan passed
- git diff --check passed

Fixes #2924