### PR TITLE
fix: evaluate matrix constructor inputs once

### DIFF
--- a/apps/typegpu-docs/tests/individual-example-tests/3d-fish.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/3d-fish.test.ts
@@ -306,6 +306,37 @@ describe('3d fish example', () => {
 
       @group(0) @binding(4) var<uniform> currentTime: f32;
 
+      fn scaling4(vector: vec3f) -> mat4x4f {
+        return mat4x4f(
+          vector.x, 0, 0, 0,
+          0, vector.y, 0, 0,
+          0, 0, vector.z, 0,
+          0, 0, 0, 1
+        );
+      }
+
+      fn rotationZ4(angle: f32) -> mat4x4f {
+        let c = cos(angle);
+        let s = sin(angle);
+        return mat4x4f(
+          c, s, 0, 0,
+          -s, c, 0, 0,
+          0, 0, 1, 0,
+          0, 0, 0, 1
+        );
+      }
+
+      fn rotationY4(angle: f32) -> mat4x4f {
+        let c = cos(angle);
+        let s = sin(angle);
+        return mat4x4f(
+          c, 0, -s, 0,
+          0, 1, 0, 0,
+          s, 0, c, 0,
+          0, 0, 0, 1
+        );
+      }
+
       struct Camera {
         position: vec4f,
         targetPos: vec4f,
@@ -334,10 +365,10 @@ describe('3d fish example', () => {
         let direction = normalize((*currentModelData).direction);
         let yaw = (-(atan2(direction.z, direction.x)) + 3.141592653589793f);
         let pitch = asin(-(direction.y));
-        let scaleMatrix = mat4x4f(vec3f((*currentModelData).scale).x, 0, 0, 0, 0, vec3f((*currentModelData).scale).y, 0, 0, 0, 0, vec3f((*currentModelData).scale).z, 0, 0, 0, 0, 1);
-        let pitchMatrix = mat4x4f(cos(pitch), sin(pitch), 0, 0, -sin(pitch), cos(pitch), 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
-        let yawMatrix = mat4x4f(cos(yaw), 0, -sin(yaw), 0, 0, 1, 0, 0, sin(yaw), 0, cos(yaw), 0, 0, 0, 0, 1);
-        let translationMatrix = mat4x4f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, (*currentModelData).position.x, (*currentModelData).position.y, (*currentModelData).position.z, 1);
+        let scaleMatrix = scaling4(vec3f((*currentModelData).scale));
+        let pitchMatrix = rotationZ4(pitch);
+        let yawMatrix = rotationY4(yaw);
+        let translationMatrix = mat4x4f(vec4f(1, 0, 0, 0), vec4f(0, 1, 0, 0), vec4f(0, 0, 1, 0), vec4f((*currentModelData).position, 1));
         var worldPosition = ((((translationMatrix * yawMatrix) * pitchMatrix) * scaleMatrix) * vec4f(wavedVertex.position, 1f));
         let worldNormal = normalize(((yawMatrix * pitchMatrix) * vec4f(wavedVertex.normal, 1f)).xyz);
         let worldPositionUniform = (&worldPosition);

--- a/apps/typegpu-docs/tests/individual-example-tests/ray-marching.test.ts
+++ b/apps/typegpu-docs/tests/individual-example-tests/ray-marching.test.ts
@@ -38,6 +38,28 @@ describe('ray-marching example', () => {
         dist: f32,
       }
 
+      fn rotationZ4(angle: f32) -> mat4x4f {
+        let c = cos(angle);
+        let s = sin(angle);
+        return mat4x4f(
+          c, s, 0, 0,
+          -s, c, 0, 0,
+          0, 0, 1, 0,
+          0, 0, 0, 1
+        );
+      }
+
+      fn rotationX4(angle: f32) -> mat4x4f {
+        let c = cos(angle);
+        let s = sin(angle);
+        return mat4x4f(
+          1, 0, 0, 0,
+          0, c, s, 0,
+          0, -s, c, 0,
+          0, 0, 0, 1
+        );
+      }
+
       fn sdSphere(point: vec3f, radius: f32) -> f32 {
         return (length(point) - radius);
       }
@@ -63,8 +85,8 @@ describe('ray-marching example', () => {
       fn getMorphingShape(p: vec3f, t: f32) -> Shape {
         let center = vec3f(0, 2, 6);
         let localP = (p - center);
-        let rotMatZ = mat4x4f(cos(-(t)), sin(-(t)), 0, 0, -sin(-(t)), cos(-(t)), 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
-        let rotMatX = mat4x4f(1, 0, 0, 0, 0, cos((-(t) * 0.6f)), sin((-(t) * 0.6f)), 0, 0, -sin((-(t) * 0.6f)), cos((-(t) * 0.6f)), 0, 0, 0, 0, 1);
+        let rotMatZ = rotationZ4(-(t));
+        let rotMatX = rotationX4((-(t) * 0.6f));
         let rotatedP = (rotMatZ * (rotMatX * vec4f(localP, 1f))).xyz;
         let boxSize = vec3f(0.699999988079071);
         let sphere1Offset = vec3f((cos((t * 2f)) * 0.8f), (sin((t * 3f)) * 0.3f), (sin((t * 2f)) * 0.8f));

--- a/packages/typegpu/src/data/matrix.ts
+++ b/packages/typegpu/src/data/matrix.ts
@@ -587,7 +587,7 @@ export const translation4 = dualImpl({
     return { argTypes: [vec3f], returnType: mat4x4f };
   },
   codegenImpl: (_ctx, [v]) =>
-    stitch`mat4x4f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, ${v}.x, ${v}.y, ${v}.z, 1)`,
+    stitch`mat4x4f(vec4f(1, 0, 0, 0), vec4f(0, 1, 0, 0), vec4f(0, 0, 1, 0), vec4f(${v}, 1))`,
   sideEffects: false,
 });
 

--- a/packages/typegpu/src/data/matrix.ts
+++ b/packages/typegpu/src/data/matrix.ts
@@ -1,9 +1,10 @@
 import { comptime } from '../core/function/comptime.ts';
 import { callableSchema } from '../core/function/createCallableSchema.ts';
 import { dualImpl } from '../core/function/dualImpl.ts';
+import { fn } from '../core/function/tgpuFn.ts';
 import { stitch } from '../core/resolve/stitch.ts';
 import { $repr } from '../shared/symbols.ts';
-import { $internal, $resolve } from '../shared/symbols.ts';
+import { $gpuCallable, $internal, $resolve } from '../shared/symbols.ts';
 import { numericLiteralToSnippet } from '../tgsl/generationHelpers.ts';
 import type { ResolutionCtx, SelfResolvable } from '../types.ts';
 import { f32 } from './numeric.ts';
@@ -609,8 +610,7 @@ export const scaling4 = dualImpl({
   get signature() {
     return { argTypes: [vec3f], returnType: mat4x4f };
   },
-  codegenImpl: (_ctx, [v]) =>
-    stitch`mat4x4f(${v}.x, 0, 0, 0, 0, ${v}.y, 0, 0, 0, 0, ${v}.z, 0, 0, 0, 0, 1)`,
+  codegenImpl: (ctx, [v]) => stitch`${scaling4Gpu[$gpuCallable].call(ctx, [v])}`,
   sideEffects: false,
 });
 
@@ -632,8 +632,7 @@ export const rotationX4 = dualImpl({
   get signature() {
     return { argTypes: [f32], returnType: mat4x4f };
   },
-  codegenImpl: (_ctx, [a]) =>
-    stitch`mat4x4f(1, 0, 0, 0, 0, cos(${a}), sin(${a}), 0, 0, -sin(${a}), cos(${a}), 0, 0, 0, 0, 1)`,
+  codegenImpl: (ctx, [a]) => stitch`${rotationX4Gpu[$gpuCallable].call(ctx, [a])}`,
   sideEffects: false,
 });
 
@@ -655,8 +654,7 @@ export const rotationY4 = dualImpl({
   get signature() {
     return { argTypes: [f32], returnType: mat4x4f };
   },
-  codegenImpl: (_ctx, [a]) =>
-    stitch`mat4x4f(cos(${a}), 0, -sin(${a}), 0, 0, 1, 0, 0, sin(${a}), 0, cos(${a}), 0, 0, 0, 0, 1)`,
+  codegenImpl: (ctx, [a]) => stitch`${rotationY4Gpu[$gpuCallable].call(ctx, [a])}`,
   sideEffects: false,
 });
 
@@ -678,8 +676,7 @@ export const rotationZ4 = dualImpl({
   get signature() {
     return { argTypes: [f32], returnType: mat4x4f };
   },
-  codegenImpl: (_ctx, [a]) =>
-    stitch`mat4x4f(cos(${a}), sin(${a}), 0, 0, -sin(${a}), cos(${a}), 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)`,
+  codegenImpl: (ctx, [a]) => stitch`${rotationZ4Gpu[$gpuCallable].call(ctx, [a])}`,
   sideEffects: false,
 });
 
@@ -776,6 +773,48 @@ export const mat4x4f = createMatSchema<'mat4x4f', m4x4f, v4f>({
   columns: 4,
   MatImpl: mat4x4fImpl,
 }) as Mat4x4f;
+
+const scaling4Gpu = fn([vec3f], mat4x4f)`(vector) {
+  return mat4x4f(
+    vector.x, 0, 0, 0,
+    0, vector.y, 0, 0,
+    0, 0, vector.z, 0,
+    0, 0, 0, 1
+  );
+}`.$name('scaling4');
+
+const rotationX4Gpu = fn([f32], mat4x4f)`(angle) {
+  let c = cos(angle);
+  let s = sin(angle);
+  return mat4x4f(
+    1, 0, 0, 0,
+    0, c, s, 0,
+    0, -s, c, 0,
+    0, 0, 0, 1
+  );
+}`.$name('rotationX4');
+
+const rotationY4Gpu = fn([f32], mat4x4f)`(angle) {
+  let c = cos(angle);
+  let s = sin(angle);
+  return mat4x4f(
+    c, 0, -s, 0,
+    0, 1, 0, 0,
+    s, 0, c, 0,
+    0, 0, 0, 1
+  );
+}`.$name('rotationY4');
+
+const rotationZ4Gpu = fn([f32], mat4x4f)`(angle) {
+  let c = cos(angle);
+  let s = sin(angle);
+  return mat4x4f(
+    c, s, 0, 0,
+    -s, c, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1
+  );
+}`.$name('rotationZ4');
 
 export function matToArray(mat: m2x2f | m3x3f | m4x4f): number[] {
   if (mat.kind === 'mat3x3f') {

--- a/packages/typegpu/tests/matrix.test.ts
+++ b/packages/typegpu/tests/matrix.test.ts
@@ -404,21 +404,98 @@ describe('different matrix constructors', () => {
       const translation = d.mat4x4f.translation(d.vec3f(nextValue()));
     };
 
-    const wgsl = tgpu.resolve([main]);
-    const mainStart = wgsl.indexOf('fn main');
-    expect(mainStart).toBeGreaterThanOrEqual(0);
-    const mainSource = wgsl.slice(mainStart);
+    expect(tgpu.resolve([main])).toMatchInlineSnapshot(`
+      "var<private> value: u32;
 
-    expect(mainSource.match(/nextValue\(\)/g) ?? []).toHaveLength(1);
-    expect(mainSource).toMatch(
-      /vec4f\s*\(\s*vec3f\s*\(\s*f32\s*\(\s*nextValue\(\)\s*\)\s*\)\s*,\s*1\s*\)/,
-    );
+      fn nextValue() -> u32 {
+        value++;
+        return value;
+      }
+
+      fn main() {
+        let translation = mat4x4f(vec4f(1, 0, 0, 0), vec4f(0, 1, 0, 0), vec4f(0, 0, 1, 0), vec4f(vec3f(f32(nextValue())), 1));
+      }"
+    `);
   });
 
   it('returns scaling matrix', () => {
     expect(d.mat4x4f.scaling(d.vec3f(3, 4, 5))).toStrictEqual(
       d.mat4x4f(d.vec4f(3, 0, 0, 0), d.vec4f(0, 4, 0, 0), d.vec4f(0, 0, 5, 0), d.vec4f(0, 0, 0, 1)),
     );
+  });
+
+  it('evaluates remaining matrix constructor inputs once during WGSL generation', () => {
+    const value = tgpu.privateVar(d.u32);
+    const nextValue = () => {
+      'use gpu';
+      value.$++;
+      return value.$;
+    };
+    const main = () => {
+      'use gpu';
+      const scaling = d.mat4x4f.scaling(d.vec3f(nextValue()));
+      const rotationX = d.mat4x4f.rotationX(nextValue());
+      const rotationY = d.mat4x4f.rotationY(nextValue());
+      const rotationZ = d.mat4x4f.rotationZ(nextValue());
+    };
+
+    expect(tgpu.resolve([main])).toMatchInlineSnapshot(`
+      "var<private> value: u32;
+
+      fn nextValue() -> u32 {
+        value++;
+        return value;
+      }
+
+      fn scaling4(vector: vec3f) -> mat4x4f {
+        return mat4x4f(
+          vector.x, 0, 0, 0,
+          0, vector.y, 0, 0,
+          0, 0, vector.z, 0,
+          0, 0, 0, 1
+        );
+      }
+
+      fn rotationX4(angle: f32) -> mat4x4f {
+        let c = cos(angle);
+        let s = sin(angle);
+        return mat4x4f(
+          1, 0, 0, 0,
+          0, c, s, 0,
+          0, -s, c, 0,
+          0, 0, 0, 1
+        );
+      }
+
+      fn rotationY4(angle: f32) -> mat4x4f {
+        let c = cos(angle);
+        let s = sin(angle);
+        return mat4x4f(
+          c, 0, -s, 0,
+          0, 1, 0, 0,
+          s, 0, c, 0,
+          0, 0, 0, 1
+        );
+      }
+
+      fn rotationZ4(angle: f32) -> mat4x4f {
+        let c = cos(angle);
+        let s = sin(angle);
+        return mat4x4f(
+          c, s, 0, 0,
+          -s, c, 0, 0,
+          0, 0, 1, 0,
+          0, 0, 0, 1
+        );
+      }
+
+      fn main() {
+        let scaling = scaling4(vec3f(f32(nextValue())));
+        let rotationX = rotationX4(f32(nextValue()));
+        let rotationY = rotationY4(f32(nextValue()));
+        let rotationZ = rotationZ4(f32(nextValue()));
+      }"
+    `);
   });
 
   it('returns rotationX matrix', () => {

--- a/packages/typegpu/tests/matrix.test.ts
+++ b/packages/typegpu/tests/matrix.test.ts
@@ -405,10 +405,14 @@ describe('different matrix constructors', () => {
     };
 
     const wgsl = tgpu.resolve([main]);
-    const mainSource = wgsl.slice(wgsl.indexOf('fn main'));
+    const mainStart = wgsl.indexOf('fn main');
+    expect(mainStart).toBeGreaterThanOrEqual(0);
+    const mainSource = wgsl.slice(mainStart);
 
-    expect(mainSource.match(/nextValue\(\)/g)).toHaveLength(1);
-    expect(mainSource).toContain('vec4f(vec3f(f32(nextValue())), 1)');
+    expect(mainSource.match(/nextValue\(\)/g) ?? []).toHaveLength(1);
+    expect(mainSource).toMatch(
+      /vec4f\s*\(\s*vec3f\s*\(\s*f32\s*\(\s*nextValue\(\)\s*\)\s*\)\s*,\s*1\s*\)/,
+    );
   });
 
   it('returns scaling matrix', () => {

--- a/packages/typegpu/tests/matrix.test.ts
+++ b/packages/typegpu/tests/matrix.test.ts
@@ -392,6 +392,25 @@ describe('different matrix constructors', () => {
     );
   });
 
+  it('evaluates the translation vector once during WGSL generation', () => {
+    const value = tgpu.privateVar(d.u32);
+    const nextValue = () => {
+      'use gpu';
+      value.$++;
+      return value.$;
+    };
+    const main = () => {
+      'use gpu';
+      const translation = d.mat4x4f.translation(d.vec3f(nextValue()));
+    };
+
+    const wgsl = tgpu.resolve([main]);
+    const mainSource = wgsl.slice(wgsl.indexOf('fn main'));
+
+    expect(mainSource.match(/nextValue\(\)/g)).toHaveLength(1);
+    expect(mainSource).toContain('vec4f(vec3f(f32(nextValue())), 1)');
+  });
+
   it('returns scaling matrix', () => {
     expect(d.mat4x4f.scaling(d.vec3f(3, 4, 5))).toStrictEqual(
       d.mat4x4f(d.vec4f(3, 0, 0, 0), d.vec4f(0, 4, 0, 0), d.vec4f(0, 0, 5, 0), d.vec4f(0, 0, 0, 1)),

--- a/packages/typegpu/tests/std/matrix/rotate.test.ts
+++ b/packages/typegpu/tests/std/matrix/rotate.test.ts
@@ -13,9 +13,20 @@ describe('rotate', () => {
     });
 
     expect(tgpu.resolve([rotateFn])).toMatchInlineSnapshot(`
-      "fn rotateFn() {
+      "fn rotationX4(angle: f32) -> mat4x4f {
+        let c = cos(angle);
+        let s = sin(angle);
+        return mat4x4f(
+          1, 0, 0, 0,
+          0, c, s, 0,
+          0, -s, c, 0,
+          0, 0, 0, 1
+        );
+      }
+
+      fn rotateFn() {
         const angle = 4;
-        let resultExpression = (mat4x4f(1, 0, 0, 0, 0, cos(f32(angle)), sin(f32(angle)), 0, 0, -sin(f32(angle)), cos(f32(angle)), 0, 0, 0, 0, 1) * mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1));
+        let resultExpression = (rotationX4(f32(angle)) * mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1));
       }"
     `);
   });
@@ -29,9 +40,20 @@ describe('rotate', () => {
     });
 
     expect(tgpu.resolve([rotateFn])).toMatchInlineSnapshot(`
-      "fn rotateFn() {
+      "fn rotationY4(angle: f32) -> mat4x4f {
+        let c = cos(angle);
+        let s = sin(angle);
+        return mat4x4f(
+          c, 0, -s, 0,
+          0, 1, 0, 0,
+          s, 0, c, 0,
+          0, 0, 0, 1
+        );
+      }
+
+      fn rotateFn() {
         const angle = 4;
-        let resultExpression = (mat4x4f(cos(f32(angle)), 0, -sin(f32(angle)), 0, 0, 1, 0, 0, sin(f32(angle)), 0, cos(f32(angle)), 0, 0, 0, 0, 1) * mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1));
+        let resultExpression = (rotationY4(f32(angle)) * mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1));
       }"
     `);
   });
@@ -45,9 +67,20 @@ describe('rotate', () => {
     });
 
     expect(tgpu.resolve([rotateFn])).toMatchInlineSnapshot(`
-      "fn rotateFn() {
+      "fn rotationZ4(angle: f32) -> mat4x4f {
+        let c = cos(angle);
+        let s = sin(angle);
+        return mat4x4f(
+          c, s, 0, 0,
+          -s, c, 0, 0,
+          0, 0, 1, 0,
+          0, 0, 0, 1
+        );
+      }
+
+      fn rotateFn() {
         const angle = 4;
-        let resultExpression = (mat4x4f(cos(f32(angle)), sin(f32(angle)), 0, 0, -sin(f32(angle)), cos(f32(angle)), 0, 0, 0, 0, 1, 0, 0, 0, 0, 1) * mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1));
+        let resultExpression = (rotationZ4(f32(angle)) * mat4x4f(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1));
       }"
     `);
   });


### PR DESCRIPTION
## Summary

- construct translation matrices from four `vec4f` columns so the translation vector is consumed once
- delegate scaling and X/Y/Z rotation constructors to typed WGSL helpers, so vector/angle expressions are evaluated once at the call boundary
- compute each rotation sine/cosine pair once inside its helper
- use readable inline WGSL snapshots for translation and the four remaining constructors, plus update affected example/rotation snapshots

The CPU matrix layouts and public APIs are unchanged. Generated WGSL now calls a helper only where a constructor must reuse components; the translation constructor retains its compact four-column form.

## TDD evidence

RED: scaling expanded a vector expression three times and each rotation expanded its angle four times.

GREEN: the inline snapshot shows one `nextValue()` argument at each translation/scaling/rotation call, with helper parameters reused inside the generated WGSL.

## Verification

- focused matrix suite: 38/38 passed
- full source unit suite: 275 files; 2,854 passed, 2 skipped
- full monorepo typecheck: 0 errors
- full Oxlint/Prettier/Oxfmt style gate passed
- `git diff --check` passed

Fixes #2859