### PR TITLE
fix: `tgpu` default export tree shakeability

### DIFF
--- a/packages/typegpu/src/index.d.ts
+++ b/packages/typegpu/src/index.d.ts
@@ -4,7 +4,7 @@
 
 // NOTE: This is a barrel file, internal files should not import things from this file
 
-export declare const tgpu: {
+declare const tgpu_default: {
   const: typeof import('./core/constant/tgpuConstant.ts').constant;
   fn: typeof import('./core/function/tgpuFn.ts').fn;
   comptime: typeof import('./core/function/comptime.ts').comptime;
@@ -28,6 +28,7 @@ export declare const tgpu: {
   '~unstable': typeof import('./tgpuUnstable.ts');
 };
 
-export default tgpu;
+export { tgpu_default as tgpu };
+export default tgpu_default;
 
 export * from './indexNamedExports.ts';

--- a/packages/typegpu/src/index.js
+++ b/packages/typegpu/src/index.js
@@ -4,8 +4,7 @@
 
 // NOTE: This is a barrel file, internal files should not import things from this file
 
-import * as tgpu from './tgpu.ts';
 export * as tgpu from './tgpu.ts';
-export default tgpu;
+export * as default from './tgpu.ts';
 
 export * from './indexNamedExports.ts';


### PR DESCRIPTION
Changes:
- The default tgpu import is now as treeshakeable as `{ tgpu }`
- The default is no longer preferred over `{ tgpu }` when auto-importing with an IDE