### PR TITLE
fix: preserve signed float intdiv operands

### DIFF
--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -1229,7 +1229,7 @@ export const intdiv = dualImpl({
   signature: (lhs, rhs) => {
     const unified = unify([lhs, rhs], [i32, u32]);
     if (!unified) {
-      throw new SignatureNotSupportedError([lhs, rhs], [u32, i32, abstractInt]);
+      throw new SignatureNotSupportedError([lhs, rhs], [i32, u32, abstractInt]);
     }
     return { argTypes: unified, returnType: unified[0] };
   },

--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -1227,7 +1227,7 @@ function cpuIntdiv(lhs: number, rhs: number): number {
 export const intdiv = dualImpl({
   name: 'intdiv',
   signature: (lhs, rhs) => {
-    const unified = unify([lhs, rhs], [u32, i32]);
+    const unified = unify([lhs, rhs], [i32, u32]);
     if (!unified) {
       throw new SignatureNotSupportedError([lhs, rhs], [u32, i32, abstractInt]);
     }

--- a/packages/typegpu/tests/std/numeric/intdiv.test.ts
+++ b/packages/typegpu/tests/std/numeric/intdiv.test.ts
@@ -150,7 +150,7 @@ test('intdiv throws with vector arguments', () => {
     - <root>
     - fn*:undefined
     - fn*:<unnamed>()
-    - fn:intdiv: Unsupported data types: vec3u, abstractInt. Supported types are: u32, i32, abstractInt.]
+    - fn:intdiv: Unsupported data types: vec3u, abstractInt. Supported types are: i32, u32, abstractInt.]
   `);
 
   expect(() =>
@@ -166,6 +166,6 @@ test('intdiv throws with vector arguments', () => {
     - <root>
     - fn*:undefined
     - fn*:<unnamed>()
-    - fn:intdiv: Unsupported data types: abstractInt, vec3i. Supported types are: u32, i32, abstractInt.]
+    - fn:intdiv: Unsupported data types: abstractInt, vec3i. Supported types are: i32, u32, abstractInt.]
   `);
 });

--- a/packages/typegpu/tests/std/numeric/intdiv.test.ts
+++ b/packages/typegpu/tests/std/numeric/intdiv.test.ts
@@ -95,6 +95,20 @@ test('intdiv with u32 mixed with i32', () => {
   `);
 });
 
+test('intdiv preserves signed runtime float operands', () => {
+  using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  const foo = tgpu.fn([d.f32, d.f32], d.i32)((lhs, rhs) => std.intdiv(lhs, rhs));
+
+  expect(foo(-5.9, 2.1)).toBe(-2);
+  expect(tgpu.resolve([foo])).toMatchInlineSnapshot(`
+    "fn foo(lhs: f32, rhs: f32) -> i32 {
+      return (i32(lhs) / i32(rhs));
+    }"
+  `);
+  expect(warnSpy.mock.calls).toHaveLength(2);
+});
+
 test('intdiv coerces float arguments to integers', () => {
   using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 


### PR DESCRIPTION
## Summary

- prefer `i32` when `std.intdiv` must choose between equally ranked signed and unsigned targets
- keep explicitly unsigned operands on the existing `u32` path
- cover negative runtime `f32` operands across the CPU implementation and generated WGSL

Closes #2892

## Verification

- `vitest run --config vitest.config.mts` from `packages/typegpu` — 2,370 tests passed
- `pnpm --filter typegpu test:types`
- `oxlint` on the changed source and test files
- `oxfmt --check` on the changed source and test files