### PR TITLE
fix: Validate unresolved declaration initializers

### DIFF
--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -1345,7 +1345,7 @@ Try 'return ${typeStr}(${str});' instead.
 
     const definitionDataType = eq.dataType;
 
-    if (definitionDataType === UnknownData) {
+    if (definitionDataType === UnknownData || wgsl.isVoid(definitionDataType)) {
       const rhsStr = stringifyNode(eqNode);
       const declaration = `let ${rawId}`;
       throw new WgslTypeError(
@@ -1432,7 +1432,7 @@ Try 'return ${typeStr}(${str});' instead.
     let varType: 'var' | 'let' | 'const' | '<deferred>' = '<deferred>';
     let definitionDataType = eq.dataType;
 
-    if (definitionDataType === UnknownData) {
+    if (definitionDataType === UnknownData || wgsl.isVoid(definitionDataType)) {
       const rhsStr = stringifyNode(eqNode);
       const declaration = `const ${rawId}`;
       throw new WgslTypeError(

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -1334,7 +1334,10 @@ Try 'return ${typeStr}(${str});' instead.
 
     const definitionDataType = eq.dataType;
 
-    if (definitionDataType === UnknownData) {
+    if (
+      definitionDataType === UnknownData ||
+      (eq.value === undefined && wgsl.isVoid(definitionDataType))
+    ) {
       const rhsStr = stringifyNode(eqNode);
       throw new WgslTypeError(
         `'let ${rawId} = ${rhsStr}' is invalid, cannot determine WGSL type of '${rhsStr}'
@@ -1423,7 +1426,10 @@ Try 'return ${typeStr}(${str});' instead.
     let varType: 'var' | 'let' | 'const' | '<deferred>' = '<deferred>';
     let definitionDataType = eq.dataType;
 
-    if (definitionDataType === UnknownData) {
+    if (
+      definitionDataType === UnknownData ||
+      (eq.value === undefined && wgsl.isVoid(definitionDataType))
+    ) {
       const rhsStr = stringifyNode(eqNode);
       throw new WgslTypeError(
         `'const ${rawId} = ${rhsStr}' is invalid, cannot determine WGSL type of '${rhsStr}'

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -218,6 +218,17 @@ const usageToVarTemplateMap: Record<VariableScope | BindableBufferUsage, string>
  */
 const functionInitialBlockDepth = 2;
 
+function schemaWrappingSuggestion(declaration: string, rhs: string, value: unknown): string {
+  if (value === null || value === undefined || typeof value === 'string') {
+    return '';
+  }
+
+  return `
+-----
+- Try using or defining a schema that matches your desired value the most, and wrap the value with it: '${declaration} = Schema(${rhs})'
+-----`;
+}
+
 export class WgslGenerator implements ShaderGenerator {
   #ctx: ResolutionCtx | undefined = undefined;
   // used to detect `continue` and `break` nodes in loop body, as well as label
@@ -1339,11 +1350,9 @@ Try 'return ${typeStr}(${str});' instead.
       (eq.value === undefined && wgsl.isVoid(definitionDataType))
     ) {
       const rhsStr = stringifyNode(eqNode);
+      const declaration = `let ${rawId}`;
       throw new WgslTypeError(
-        `'let ${rawId} = ${rhsStr}' is invalid, cannot determine WGSL type of '${rhsStr}'
------
-- Try using or defining a schema that matches your desired value the most, and wrap the value with it: 'let ${rawId} = Schema(${rhsStr})'
------`,
+        `'${declaration} = ${rhsStr}' is invalid, cannot determine WGSL type of '${rhsStr}'${schemaWrappingSuggestion(declaration, rhsStr, eq.value)}`,
       );
     }
 
@@ -1431,11 +1440,9 @@ Try 'return ${typeStr}(${str});' instead.
       (eq.value === undefined && wgsl.isVoid(definitionDataType))
     ) {
       const rhsStr = stringifyNode(eqNode);
+      const declaration = `const ${rawId}`;
       throw new WgslTypeError(
-        `'const ${rawId} = ${rhsStr}' is invalid, cannot determine WGSL type of '${rhsStr}'
------
-- Try using or defining a schema that matches your desired value the most, and wrap the value with it: 'const ${rawId} = Schema(${rhsStr})'
------`,
+        `'${declaration} = ${rhsStr}' is invalid, cannot determine WGSL type of '${rhsStr}'${schemaWrappingSuggestion(declaration, rhsStr, eq.value)}`,
       );
     }
 

--- a/packages/typegpu/src/tgsl/wgslGenerator.ts
+++ b/packages/typegpu/src/tgsl/wgslGenerator.ts
@@ -1345,10 +1345,7 @@ Try 'return ${typeStr}(${str});' instead.
 
     const definitionDataType = eq.dataType;
 
-    if (
-      definitionDataType === UnknownData ||
-      (eq.value === undefined && wgsl.isVoid(definitionDataType))
-    ) {
+    if (definitionDataType === UnknownData) {
       const rhsStr = stringifyNode(eqNode);
       const declaration = `let ${rawId}`;
       throw new WgslTypeError(
@@ -1435,10 +1432,7 @@ Try 'return ${typeStr}(${str});' instead.
     let varType: 'var' | 'let' | 'const' | '<deferred>' = '<deferred>';
     let definitionDataType = eq.dataType;
 
-    if (
-      definitionDataType === UnknownData ||
-      (eq.value === undefined && wgsl.isVoid(definitionDataType))
-    ) {
+    if (definitionDataType === UnknownData) {
       const rhsStr = stringifyNode(eqNode);
       const declaration = `const ${rawId}`;
       throw new WgslTypeError(

--- a/packages/typegpu/tests/tgsl/letDeclaration.test.ts
+++ b/packages/typegpu/tests/tgsl/letDeclaration.test.ts
@@ -55,4 +55,22 @@ describe('let declarations', () => {
       -----]
     `);
   });
+
+  it('suggests wrapping an untyped undefined value with a schema', () => {
+    function foo() {
+      'use gpu';
+      let a = undefined;
+      return a;
+    }
+
+    expect(() => tgpu.resolve([foo])).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn*:foo
+      - fn*:foo(): 'let a = undefined' is invalid, cannot determine WGSL type of 'undefined'
+      -----
+      - Try using or defining a schema that matches your desired value the most, and wrap the value with it: 'let a = Schema(undefined)'
+      -----]
+    `);
+  });
 });

--- a/packages/typegpu/tests/tgsl/letDeclaration.test.ts
+++ b/packages/typegpu/tests/tgsl/letDeclaration.test.ts
@@ -4,6 +4,22 @@ import { tgpu, d } from 'typegpu';
 import { expectSnippetOf } from '../utils/parseResolved.ts';
 
 describe('let declarations', () => {
+  it('supports assigning the result of a void function', () => {
+    const noop = tgpu.fn([])(() => {});
+
+    const f = tgpu.fn([])(() => {
+      const a = noop();
+    });
+
+    expect(tgpu.resolve([f])).toMatchInlineSnapshot(`
+      "fn noop() {}
+
+      fn f() {
+        let a = noop();
+      }"
+    `);
+  });
+
   it('initializes a local definition with a scalar value', () => {
     function foo() {
       'use gpu';
@@ -53,7 +69,22 @@ describe('let declarations', () => {
     `);
   });
 
-  it('does not suggest wrapping undefined with a schema', () => {
+  it('throws when initializing with null without a schema hint', () => {
+    function foo() {
+      'use gpu';
+      let a = null;
+      return a;
+    }
+
+    expect(() => tgpu.resolve([foo])).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn*:foo
+      - fn*:foo(): 'let a = null' is invalid, cannot determine WGSL type of 'null']
+    `);
+  });
+
+  it('reports that bare undefined cannot resolve to void', () => {
     function foo() {
       'use gpu';
       let a = undefined;
@@ -64,7 +95,7 @@ describe('let declarations', () => {
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:foo
-      - fn*:foo(): 'let a = undefined' is invalid, cannot determine WGSL type of 'undefined']
+      - fn*:foo(): Value undefined is not resolvable to type void]
     `);
   });
 });

--- a/packages/typegpu/tests/tgsl/letDeclaration.test.ts
+++ b/packages/typegpu/tests/tgsl/letDeclaration.test.ts
@@ -4,20 +4,6 @@ import { tgpu, d } from 'typegpu';
 import { expectSnippetOf } from '../utils/parseResolved.ts';
 
 describe('let declarations', () => {
-  it('rejects assigning the result of a void function', () => {
-    const noop = tgpu.fn([])(() => {});
-
-    const f = tgpu.fn([])(() => {
-      const a = noop();
-    });
-
-    expect(() => tgpu.resolve([f])).toThrowErrorMatchingInlineSnapshot(`
-      [Error: Resolution of the following tree failed:
-      - <root>
-      - fn:f: 'const a = noop()' is invalid, cannot determine WGSL type of 'noop()']
-    `);
-  });
-
   it('rejects let assigning the result of a void function', () => {
     const noop = tgpu.fn([])(() => {});
 

--- a/packages/typegpu/tests/tgsl/letDeclaration.test.ts
+++ b/packages/typegpu/tests/tgsl/letDeclaration.test.ts
@@ -4,19 +4,31 @@ import { tgpu, d } from 'typegpu';
 import { expectSnippetOf } from '../utils/parseResolved.ts';
 
 describe('let declarations', () => {
-  it('supports assigning the result of a void function', () => {
+  it('rejects assigning the result of a void function', () => {
     const noop = tgpu.fn([])(() => {});
 
     const f = tgpu.fn([])(() => {
       const a = noop();
     });
 
-    expect(tgpu.resolve([f])).toMatchInlineSnapshot(`
-      "fn noop() {}
+    expect(() => tgpu.resolve([f])).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn:f: 'const a = noop()' is invalid, cannot determine WGSL type of 'noop()']
+    `);
+  });
 
-      fn f() {
-        let a = noop();
-      }"
+  it('rejects let assigning the result of a void function', () => {
+    const noop = tgpu.fn([])(() => {});
+
+    const f = tgpu.fn([])(() => {
+      let a = noop();
+    });
+
+    expect(() => tgpu.resolve([f])).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn:f: 'let a = noop()' is invalid, cannot determine WGSL type of 'noop()']
     `);
   });
 
@@ -84,7 +96,7 @@ describe('let declarations', () => {
     `);
   });
 
-  it('reports that bare undefined cannot resolve to void', () => {
+  it('rejects bare undefined because it has no WGSL type', () => {
     function foo() {
       'use gpu';
       let a = undefined;
@@ -95,7 +107,7 @@ describe('let declarations', () => {
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:foo
-      - fn*:foo(): Value undefined is not resolvable to type void]
+      - fn*:foo(): 'let a = undefined' is invalid, cannot determine WGSL type of 'undefined']
     `);
   });
 });

--- a/packages/typegpu/tests/tgsl/letDeclaration.test.ts
+++ b/packages/typegpu/tests/tgsl/letDeclaration.test.ts
@@ -49,14 +49,11 @@ describe('let declarations', () => {
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:foo
-      - fn*:foo(): 'let a = "12"' is invalid, cannot determine WGSL type of '"12"'
-      -----
-      - Try using or defining a schema that matches your desired value the most, and wrap the value with it: 'let a = Schema("12")'
-      -----]
+      - fn*:foo(): 'let a = "12"' is invalid, cannot determine WGSL type of '"12"']
     `);
   });
 
-  it('suggests wrapping an untyped undefined value with a schema', () => {
+  it('does not suggest wrapping undefined with a schema', () => {
     function foo() {
       'use gpu';
       let a = undefined;
@@ -67,10 +64,7 @@ describe('let declarations', () => {
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:foo
-      - fn*:foo(): 'let a = undefined' is invalid, cannot determine WGSL type of 'undefined'
-      -----
-      - Try using or defining a schema that matches your desired value the most, and wrap the value with it: 'let a = Schema(undefined)'
-      -----]
+      - fn*:foo(): 'let a = undefined' is invalid, cannot determine WGSL type of 'undefined']
     `);
   });
 });

--- a/packages/typegpu/tests/tgsl/typeInference.test.ts
+++ b/packages/typegpu/tests/tgsl/typeInference.test.ts
@@ -317,7 +317,7 @@ describe('wgsl generator type inference', () => {
     `);
   });
 
-  it('suggests wrapping an untyped null variable with a schema', () => {
+  it('does not suggest wrapping null with a schema', () => {
     const myFn = () => {
       'use gpu';
       const a = null;
@@ -327,14 +327,11 @@ describe('wgsl generator type inference', () => {
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:myFn
-      - fn*:myFn(): 'const a = null' is invalid, cannot determine WGSL type of 'null'
-      -----
-      - Try using or defining a schema that matches your desired value the most, and wrap the value with it: 'const a = Schema(null)'
-      -----]
+      - fn*:myFn(): 'const a = null' is invalid, cannot determine WGSL type of 'null']
     `);
   });
 
-  it('suggests wrapping an untyped undefined variable with a schema', () => {
+  it('does not suggest wrapping undefined with a schema', () => {
     const myFn = () => {
       'use gpu';
       const a = undefined;
@@ -344,10 +341,21 @@ describe('wgsl generator type inference', () => {
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:myFn
-      - fn*:myFn(): 'const a = undefined' is invalid, cannot determine WGSL type of 'undefined'
-      -----
-      - Try using or defining a schema that matches your desired value the most, and wrap the value with it: 'const a = Schema(undefined)'
-      -----]
+      - fn*:myFn(): 'const a = undefined' is invalid, cannot determine WGSL type of 'undefined']
+    `);
+  });
+
+  it('does not suggest wrapping a string with a schema', () => {
+    const myFn = () => {
+      'use gpu';
+      const a = 'hello';
+    };
+
+    expect(() => tgpu.resolve([myFn])).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn*:myFn
+      - fn*:myFn(): 'const a = "hello"' is invalid, cannot determine WGSL type of '"hello"']
     `);
   });
 

--- a/packages/typegpu/tests/tgsl/typeInference.test.ts
+++ b/packages/typegpu/tests/tgsl/typeInference.test.ts
@@ -331,7 +331,7 @@ describe('wgsl generator type inference', () => {
     `);
   });
 
-  it('does not suggest wrapping undefined with a schema', () => {
+  it('reports that bare undefined cannot resolve to void', () => {
     const myFn = () => {
       'use gpu';
       const a = undefined;
@@ -341,7 +341,7 @@ describe('wgsl generator type inference', () => {
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:myFn
-      - fn*:myFn(): 'const a = undefined' is invalid, cannot determine WGSL type of 'undefined']
+      - fn*:myFn(): Value undefined is not resolvable to type void]
     `);
   });
 

--- a/packages/typegpu/tests/tgsl/typeInference.test.ts
+++ b/packages/typegpu/tests/tgsl/typeInference.test.ts
@@ -331,7 +331,7 @@ describe('wgsl generator type inference', () => {
     `);
   });
 
-  it('reports that bare undefined cannot resolve to void', () => {
+  it('rejects bare undefined because it has no WGSL type', () => {
     const myFn = () => {
       'use gpu';
       const a = undefined;
@@ -341,7 +341,7 @@ describe('wgsl generator type inference', () => {
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:myFn
-      - fn*:myFn(): Value undefined is not resolvable to type void]
+      - fn*:myFn(): 'const a = undefined' is invalid, cannot determine WGSL type of 'undefined']
     `);
   });
 

--- a/packages/typegpu/tests/tgsl/typeInference.test.ts
+++ b/packages/typegpu/tests/tgsl/typeInference.test.ts
@@ -317,6 +317,40 @@ describe('wgsl generator type inference', () => {
     `);
   });
 
+  it('suggests wrapping an untyped null variable with a schema', () => {
+    const myFn = () => {
+      'use gpu';
+      const a = null;
+    };
+
+    expect(() => tgpu.resolve([myFn])).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn*:myFn
+      - fn*:myFn(): 'const a = null' is invalid, cannot determine WGSL type of 'null'
+      -----
+      - Try using or defining a schema that matches your desired value the most, and wrap the value with it: 'const a = Schema(null)'
+      -----]
+    `);
+  });
+
+  it('suggests wrapping an untyped undefined variable with a schema', () => {
+    const myFn = () => {
+      'use gpu';
+      const a = undefined;
+    };
+
+    expect(() => tgpu.resolve([myFn])).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn*:myFn
+      - fn*:myFn(): 'const a = undefined' is invalid, cannot determine WGSL type of 'undefined'
+      -----
+      - Try using or defining a schema that matches your desired value the most, and wrap the value with it: 'const a = Schema(undefined)'
+      -----]
+    `);
+  });
+
   it('throws when creating an empty untyped array', () => {
     const myFn = tgpu.fn([])(() => {
       const myArr = [];

--- a/packages/typegpu/tests/tgsl/typeInference.test.ts
+++ b/packages/typegpu/tests/tgsl/typeInference.test.ts
@@ -359,6 +359,20 @@ describe('wgsl generator type inference', () => {
     `);
   });
 
+  it('rejects assigning the result of a void function', () => {
+    const noop = tgpu.fn([])(() => {});
+
+    const f = tgpu.fn([])(() => {
+      const a = noop();
+    });
+
+    expect(() => tgpu.resolve([f])).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn:f: 'const a = noop()' is invalid, cannot determine WGSL type of 'noop()']
+    `);
+  });
+
   it('throws when creating an empty untyped array', () => {
     const myFn = tgpu.fn([])(() => {
       const myArr = [];

--- a/packages/typegpu/tests/tgslFn.test.ts
+++ b/packages/typegpu/tests/tgslFn.test.ts
@@ -1312,20 +1312,6 @@ describe('string injection', () => {
 });
 
 describe('nulls in TGSL', () => {
-  it('throws when assigning to a variable', () => {
-    const myFn = () => {
-      'use gpu';
-      const a = null;
-    };
-
-    expect(() => tgpu.resolve([myFn])).toThrowErrorMatchingInlineSnapshot(`
-      [Error: Resolution of the following tree failed:
-      - <root>
-      - fn*:myFn
-      - fn*:myFn(): 'const a = null' is invalid, cannot determine WGSL type of 'null']
-    `);
-  });
-
   it('allows comptime usage', () => {
     let externalNum: number | null;
     const myFn = () => {

--- a/packages/typegpu/tests/tgslFn.test.ts
+++ b/packages/typegpu/tests/tgslFn.test.ts
@@ -1322,10 +1322,7 @@ describe('nulls in TGSL', () => {
       [Error: Resolution of the following tree failed:
       - <root>
       - fn*:myFn
-      - fn*:myFn(): 'const a = null' is invalid, cannot determine WGSL type of 'null'
-      -----
-      - Try using or defining a schema that matches your desired value the most, and wrap the value with it: 'const a = Schema(null)'
-      -----]
+      - fn*:myFn(): 'const a = null' is invalid, cannot determine WGSL type of 'null']
     `);
   });
 


### PR DESCRIPTION
## Summary

- reject `let` and `const` declarations whose initializer resolves to `void`, including void-returning function calls and bare `undefined`
- route those declarations through the existing cannot-determine-WGSL-type diagnostic
- show schema-wrapping guidance only when the unresolved runtime value can actually be wrapped by a schema
- retain valid object/array guidance while suppressing invalid `Schema(null)`, `Schema(undefined)`, and string suggestions
- cover `let`/`const`, null/string diagnostics, bare `undefined`, and void-call results

Closes #2934

## Verification

- focused declaration/type-inference tests: 39 passed
- `pnpm --filter typegpu test:types`: passed
- `pnpm test:style`: passed
- `pnpm test:fast-unit`: 216 files passed, 2,815 tests passed, 2 skipped