### PR TITLE
fix(@typegpu/gl): support array texture loads

### DIFF
--- a/packages/typegpu-gl/src/glslGenerator.ts
+++ b/packages/typegpu-gl/src/glslGenerator.ts
@@ -647,7 +647,9 @@ export class GlslGenerator extends WgslGenerator {
         throw new Error(`Invalid number of arguments for '${name}'`);
       }
 
-      const isTextureArray = (texture.dataType as d.WgslTexture).dimension === '2d-array';
+      const textureType = (texture.dataType as d.WgslTexture).type;
+      const isTextureArray =
+        textureType === 'texture_2d_array' || textureType === 'texture_depth_2d_array';
       const level = isTextureArray ? arrayLevel : arrayIndexOrLevel;
       if (!level) {
         throw new Error(`Invalid number of arguments for '${name}'`);
@@ -658,7 +660,9 @@ export class GlslGenerator extends WgslGenerator {
       const signedCoordsValue =
         coords.dataType !== UnknownData && coords.dataType.type === 'vec2u'
           ? `ivec2(${coordsValue})`
-          : coordsValue;
+          : coords.dataType !== UnknownData && coords.dataType.type === 'vec3u'
+            ? `ivec3(${coordsValue})`
+            : coordsValue;
       const levelValue = this.ctx.resolveSnippet(level).value;
       const flipId = this.#crossShaderStageState.textureFlipIdentifiers.get(textureName);
       const orientedCoords = flipId

--- a/packages/typegpu-gl/src/glslGenerator.ts
+++ b/packages/typegpu-gl/src/glslGenerator.ts
@@ -647,9 +647,7 @@ export class GlslGenerator extends WgslGenerator {
         throw new Error(`Invalid number of arguments for '${name}'`);
       }
 
-      const textureType = (texture.dataType as d.WgslTexture).type;
-      const isTextureArray =
-        textureType === 'texture_2d_array' || textureType === 'texture_depth_2d_array';
+      const isTextureArray = (texture.dataType as d.WgslTexture).type === 'texture_2d_array';
       const level = isTextureArray ? arrayLevel : arrayIndexOrLevel;
       if (!level) {
         throw new Error(`Invalid number of arguments for '${name}'`);

--- a/packages/typegpu-gl/src/glslGenerator.ts
+++ b/packages/typegpu-gl/src/glslGenerator.ts
@@ -642,17 +642,38 @@ export class GlslGenerator extends WgslGenerator {
     }
 
     if (name === 'textureLoad') {
-      const [texture, coords, level] = args;
-      if (!texture || !coords || !level) {
+      const [texture, coords, arrayIndexOrLevel, arrayLevel] = args;
+      if (!texture || !coords || !arrayIndexOrLevel) {
         throw new Error(`Invalid number of arguments for '${name}'`);
       }
+
+      const isTextureArray = (texture.dataType as d.WgslTexture).dimension === '2d-array';
+      const level = isTextureArray ? arrayLevel : arrayIndexOrLevel;
+      if (!level) {
+        throw new Error(`Invalid number of arguments for '${name}'`);
+      }
+
       const textureName = this.ctx.resolveSnippet(texture).value;
       const coordsValue = this.ctx.resolveSnippet(coords).value;
+      const signedCoordsValue =
+        coords.dataType !== UnknownData && coords.dataType.type === 'vec2u'
+          ? `ivec2(${coordsValue})`
+          : coordsValue;
       const levelValue = this.ctx.resolveSnippet(level).value;
       const flipId = this.#crossShaderStageState.textureFlipIdentifiers.get(textureName);
       const orientedCoords = flipId
-        ? `ivec2(${coordsValue}.x, ${flipId} ? textureSize(${textureName}, ${levelValue}).y - 1 - int(${coordsValue}.y) : int(${coordsValue}.y))`
-        : coordsValue;
+        ? `ivec2(${signedCoordsValue}.x, ${flipId} ? textureSize(${textureName}, ${levelValue}).y - 1 - int(${signedCoordsValue}.y) : int(${signedCoordsValue}.y))`
+        : signedCoordsValue;
+
+      if (isTextureArray) {
+        const arrayIndexValue = this.ctx.resolveSnippet(arrayIndexOrLevel).value;
+        const signedArrayIndex =
+          arrayIndexOrLevel.dataType !== UnknownData && arrayIndexOrLevel.dataType.type === 'u32'
+            ? `int(${arrayIndexValue})`
+            : arrayIndexValue;
+        return `texelFetch(${textureName}, ivec3(${orientedCoords}, ${signedArrayIndex}), ${levelValue})`;
+      }
+
       return `texelFetch(${textureName}, ${orientedCoords}, ${levelValue})`;
     }
 

--- a/packages/typegpu-gl/tests/glslGenerator.test.ts
+++ b/packages/typegpu-gl/tests/glslGenerator.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect } from 'vitest';
 import { tgpu, d, std } from 'typegpu';
 import { dualGlOptions, glOptions } from '@typegpu/gl';
-import { translateWgslTypeToGlsl } from '../src/glslGenerator.ts';
+import {
+  CrossShaderStageState,
+  GlslGenerator,
+  translateWgslTypeToGlsl,
+} from '../src/glslGenerator.ts';
 import { it } from './utils/extendedTest.ts';
 
 describe('translateWgslTypeToGlsl', () => {
@@ -137,14 +141,84 @@ describe('GlslGenerator - standard function calls', () => {
 
     function loadArrayTexel() {
       'use gpu';
-      return std.textureLoad(texture.$, d.vec2i(2, 3), 4, 1);
+      return std.textureLoad(texture.$, d.vec2u(2, 3), d.u32(4), 1);
     }
 
     expect(tgpu.resolve([loadArrayTexel], glOptions())).toMatchInlineSnapshot(`
       "vec4 loadArrayTexel() {
-        return texelFetch(palette, ivec3(ivec2(2, 3), 4), 1);
+        return texelFetch(palette, ivec3(ivec2(uvec2(2, 3)), int(4u)), 1);
       }"
     `);
+  });
+
+  it('preserves the flip adaptation when loading a 2d-array texture', () => {
+    const texture = tgpu['~unstable'].rawCodeSnippet('palette', d.texture2dArray(), 'handle');
+    const state = new CrossShaderStageState();
+    state.textureFlipIdentifiers.set('palette', 'palette_flipY');
+
+    function loadArrayTexel() {
+      'use gpu';
+      return std.textureLoad(texture.$, d.vec2i(2, 3), 4, 1);
+    }
+
+    expect(
+      tgpu.resolve([loadArrayTexel], {
+        unstable_shaderGenerator: new GlslGenerator('neutral', state),
+      }),
+    ).toMatchInlineSnapshot(`
+      "vec4 loadArrayTexel() {
+        return texelFetch(palette, ivec3(ivec2(ivec2(2, 3).x, palette_flipY ? textureSize(palette, 1).y - 1 - int(ivec2(2, 3).y) : int(ivec2(2, 3).y)), 4), 1);
+      }"
+    `);
+  });
+
+  it('loads depth 2d-array textures with combined coordinates and array index', () => {
+    const texture = tgpu['~unstable'].rawCodeSnippet(
+      'depthPalette',
+      d.textureDepth2dArray(),
+      'handle',
+    );
+
+    function loadArrayTexel() {
+      'use gpu';
+      return std.textureLoad(texture.$, d.vec2i(2, 3), 4, 1);
+    }
+
+    expect(tgpu.resolve([loadArrayTexel], glOptions())).toMatchInlineSnapshot(`
+      "float loadArrayTexel() {
+        return texelFetch(depthPalette, ivec3(ivec2(2, 3), 4), 1);
+      }"
+    `);
+  });
+
+  it('converts unsigned 3d load coordinates to signed coordinates', () => {
+    const texture = tgpu['~unstable'].rawCodeSnippet('volume', d.texture3d(), 'handle');
+
+    function loadTexel() {
+      'use gpu';
+      return std.textureLoad(texture.$, d.vec3u(2, 3, 4), 1);
+    }
+
+    expect(tgpu.resolve([loadTexel], glOptions())).toMatchInlineSnapshot(`
+      "vec4 loadTexel() {
+        return texelFetch(volume, ivec3(uvec3(2, 3, 4)), 1);
+      }"
+    `);
+  });
+
+  it('does not treat storage 2d-array loads as sampled array loads', () => {
+    const texture = tgpu['~unstable'].rawCodeSnippet(
+      'storagePalette',
+      d.textureStorage2dArray('rgba8unorm', 'read-only'),
+      'handle',
+    );
+
+    function loadTexel() {
+      'use gpu';
+      return std.textureLoad(texture.$, d.vec2i(2, 3), 4);
+    }
+
+    expect(() => tgpu.resolve([loadTexel], glOptions())).not.toThrow();
   });
 
   it('translates textureSample() to texture() with the combined sampler', () => {

--- a/packages/typegpu-gl/tests/glslGenerator.test.ts
+++ b/packages/typegpu-gl/tests/glslGenerator.test.ts
@@ -172,25 +172,6 @@ describe('GlslGenerator - standard function calls', () => {
     `);
   });
 
-  it('loads depth 2d-array textures with combined coordinates and array index', () => {
-    const texture = tgpu['~unstable'].rawCodeSnippet(
-      'depthPalette',
-      d.textureDepth2dArray(),
-      'handle',
-    );
-
-    function loadArrayTexel() {
-      'use gpu';
-      return std.textureLoad(texture.$, d.vec2i(2, 3), 4, 1);
-    }
-
-    expect(tgpu.resolve([loadArrayTexel], glOptions())).toMatchInlineSnapshot(`
-      "float loadArrayTexel() {
-        return texelFetch(depthPalette, ivec3(ivec2(2, 3), 4), 1);
-      }"
-    `);
-  });
-
   it('converts unsigned 3d load coordinates to signed coordinates', () => {
     const texture = tgpu['~unstable'].rawCodeSnippet('volume', d.texture3d(), 'handle');
 

--- a/packages/typegpu-gl/tests/glslGenerator.test.ts
+++ b/packages/typegpu-gl/tests/glslGenerator.test.ts
@@ -132,6 +132,21 @@ describe('GlslGenerator - standard function calls', () => {
     `);
   });
 
+  it('combines coordinates and array index when loading a 2d-array texture', () => {
+    const texture = tgpu['~unstable'].rawCodeSnippet('palette', d.texture2dArray(), 'handle');
+
+    function loadArrayTexel() {
+      'use gpu';
+      return std.textureLoad(texture.$, d.vec2i(2, 3), 4, 1);
+    }
+
+    expect(tgpu.resolve([loadArrayTexel], glOptions())).toMatchInlineSnapshot(`
+      "vec4 loadArrayTexel() {
+        return texelFetch(palette, ivec3(ivec2(2, 3), 4), 1);
+      }"
+    `);
+  });
+
   it('translates textureSample() to texture() with the combined sampler', () => {
     const texture = tgpu['~unstable'].rawCodeSnippet('palette', d.texture2d(), 'handle');
     const sampler = tgpu['~unstable'].rawCodeSnippet('paletteSampler', d.sampler(), 'handle');


### PR DESCRIPTION
`textureLoad` receives `(texture, coords, arrayIndex, level)` for 2D-array textures, but the GLSL fallback was destructuring every call as `(texture, coords, level)`. That dropped the real mip level and emitted 2D coordinates for a `sampler2DArray`.

The generator now detects 2D-array textures, keeps the array index and mip level separate, and emits `texelFetch` with an `ivec3(coords, layer)`. It also normalizes unsigned coordinate/index inputs to the signed integer types GLSL requires. Non-array and multisampled loads keep their existing path.

Verification:
- focused GLSL generator suite: 32 passed
- `@typegpu/gl` type tests and build
- changed-file Oxlint and Oxfmt checks
- fast unit suite on Node 24: 2,809 passed, 2 skipped

Closes #2943.