### PR TITLE
fix: accept scalar-vector unions in floor and sign

### DIFF
--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -515,6 +515,8 @@ export const firstTrailingBit = dualImpl<typeof cpuFirstTrailingBit>({
   sideEffects: false,
 });
 
+function cpuFloor(value: number): number;
+function cpuFloor<T extends AnyFloatVecInstance | number>(value: T): T;
 function cpuFloor<T extends AnyFloatVecInstance | number>(value: T): T {
   return generalizeFn(Math.floor, [value]);
 }
@@ -1000,6 +1002,8 @@ export const saturate = dualImpl({
   sideEffects: false,
 });
 
+function cpuSign(e: number): number;
+function cpuSign<T extends AnySignedVecInstance | number>(e: T): T;
 function cpuSign<T extends AnySignedVecInstance | number>(e: T): T {
   return generalizeFn(Math.sign, [e]);
 }

--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -515,8 +515,6 @@ export const firstTrailingBit = dualImpl<typeof cpuFirstTrailingBit>({
   sideEffects: false,
 });
 
-function cpuFloor(value: number): number;
-function cpuFloor<T extends AnyFloatVecInstance>(value: T): T;
 function cpuFloor<T extends AnyFloatVecInstance | number>(value: T): T {
   return generalizeFn(Math.floor, [value]);
 }
@@ -1002,8 +1000,6 @@ export const saturate = dualImpl({
   sideEffects: false,
 });
 
-function cpuSign(e: number): number;
-function cpuSign<T extends AnySignedVecInstance>(e: T): T;
 function cpuSign<T extends AnySignedVecInstance | number>(e: T): T {
   return generalizeFn(Math.sign, [e]);
 }

--- a/packages/typegpu/tests/std/numeric/sign.test.ts
+++ b/packages/typegpu/tests/std/numeric/sign.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { vec2f, vec3f, type v2f } from 'typegpu/data';
 import { floor, isCloseTo, sign } from 'typegpu/std';
 
@@ -13,10 +13,13 @@ describe('sign', () => {
     expect(isCloseTo(sign(vec3f(-1000, 0, 2000)), vec3f(-1, 0, 1))).toBe(true);
   });
 
-  it('accepts scalar-vector unions', () => {
-    const value = vec2f(-1.5, 2.5) as number | v2f;
+  it('accepts scalar-vector unions without preserving scalar literal types', () => {
+    const apply = (value: number | v2f) => [sign(value), floor(value)];
+    const [signed, floored] = apply(vec2f(-1.5, 2.5));
 
-    expect(sign(value)).toEqual(vec2f(-1, 1));
-    expect(floor(value)).toEqual(vec2f(-2, 2));
+    expect(signed).toEqual(vec2f(-1, 1));
+    expect(floored).toEqual(vec2f(-2, 2));
+    expectTypeOf(sign(2.5 as const)).toEqualTypeOf<number>();
+    expectTypeOf(floor(1.5 as const)).toEqualTypeOf<number>();
   });
 });

--- a/packages/typegpu/tests/std/numeric/sign.test.ts
+++ b/packages/typegpu/tests/std/numeric/sign.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { vec3f } from 'typegpu/data';
-import { isCloseTo, sign } from 'typegpu/std';
+import { vec2f, vec3f, type v2f } from 'typegpu/data';
+import { floor, isCloseTo, sign } from 'typegpu/std';
 
 describe('sign', () => {
   it('computes sign of numeric value', () => {
@@ -11,5 +11,12 @@ describe('sign', () => {
 
   it('computes sign of a numeric vector', () => {
     expect(isCloseTo(sign(vec3f(-1000, 0, 2000)), vec3f(-1, 0, 1))).toBe(true);
+  });
+
+  it('accepts scalar-vector unions', () => {
+    const value = vec2f(-1.5, 2.5) as number | v2f;
+
+    expect(sign(value)).toEqual(vec2f(-1, 1));
+    expect(floor(value)).toEqual(vec2f(-2, 2));
   });
 });


### PR DESCRIPTION
The CPU-facing overloads for `std.floor` and `std.sign` split scalars and vectors into separate signatures. TypeScript therefore rejected a value typed as `number | d.v2f`, even though both sides of that union are valid inputs and the implementation already handles both.

This replaces the split overloads with one identity-preserving generic over the existing scalar/vector domain. Narrow scalar and vector calls keep their precise return types, while unions now pass through as the same union. The regression exercises both functions with a `number | v2f` input.

Verification:
- TypeGPU type tests
- focused numeric runtime suite: 3 passed
- changed-file Oxlint and Oxfmt checks
- fast unit suite on Node 24: 2,809 passed, 2 skipped
- `typegpu` package build

Closes #2821.