### PR TITLE
fix(gl): translate vector equality to GLSL equal

### DIFF
--- a/packages/typegpu-gl/src/glslGenerator.ts
+++ b/packages/typegpu-gl/src/glslGenerator.ts
@@ -823,6 +823,10 @@ export class GlslGenerator extends WgslGenerator {
   }
 
   override emitBinaryOp(lhs: Snippet, op: BinaryOperator, rhs: Snippet): string {
+    if (op === '==' && lhs.dataType !== UnknownData && lhs.dataType.type.startsWith('vec')) {
+      return super.emitCall('equal', [], [lhs, rhs]);
+    }
+
     if (op === '%' && (isF32VecfSchema(lhs.dataType) || isF32VecfSchema(rhs.dataType))) {
       const result = this._callShellless(HELPERS.remainder, [lhs, rhs]);
       if (!result) {

--- a/packages/typegpu-gl/src/glslGenerator.ts
+++ b/packages/typegpu-gl/src/glslGenerator.ts
@@ -823,10 +823,15 @@ export class GlslGenerator extends WgslGenerator {
   }
 
   override emitBinaryOp(lhs: Snippet, op: BinaryOperator, rhs: Snippet): string {
-    if (op === '==' && lhs.dataType !== UnknownData && lhs.dataType.type.startsWith('vec')) {
-      return super.emitCall('equal', [], [lhs, rhs]);
+    if (
+      (op === '==' || op === '!=') &&
+      lhs.dataType !== UnknownData &&
+      rhs.dataType !== UnknownData &&
+      lhs.dataType.type.startsWith('vec') &&
+      rhs.dataType.type.startsWith('vec')
+    ) {
+      return super.emitCall(op === '==' ? 'equal' : 'notEqual', [], [lhs, rhs]);
     }
-
     if (op === '%' && (isF32VecfSchema(lhs.dataType) || isF32VecfSchema(rhs.dataType))) {
       const result = this._callShellless(HELPERS.remainder, [lhs, rhs]);
       if (!result) {

--- a/packages/typegpu-gl/tests/glslGenerator.test.ts
+++ b/packages/typegpu-gl/tests/glslGenerator.test.ts
@@ -363,6 +363,16 @@ describe('GlslGenerator - operator', () => {
       }"
     `);
   });
+
+  it('translates component-wise vector inequality to notEqual', () => {
+    const compare = tgpu.fn([d.vec3f, d.vec3f], d.vec3b)((lhs, rhs) => std.ne(lhs, rhs));
+
+    expect(tgpu.resolve([compare], glOptions())).toMatchInlineSnapshot(`
+      "bvec3 compare(vec3 lhs, vec3 rhs) {
+        return notEqual(lhs, rhs);
+      }"
+    `);
+  });
 });
 
 describe('GlslGenerator - function definitions', () => {

--- a/packages/typegpu-gl/tests/glslGenerator.test.ts
+++ b/packages/typegpu-gl/tests/glslGenerator.test.ts
@@ -353,6 +353,16 @@ describe('GlslGenerator - operator', () => {
       }"
     `);
   });
+
+  it('translates component-wise vector equality to equal', () => {
+    const compare = tgpu.fn([d.vec3f, d.vec3f], d.vec3b)((lhs, rhs) => std.eq(lhs, rhs));
+
+    expect(tgpu.resolve([compare], glOptions())).toMatchInlineSnapshot(`
+      "bvec3 compare(vec3 lhs, vec3 rhs) {
+        return equal(lhs, rhs);
+      }"
+    `);
+  });
 });
 
 describe('GlslGenerator - function definitions', () => {

--- a/packages/typegpu/src/std/boolean.ts
+++ b/packages/typegpu/src/std/boolean.ts
@@ -106,7 +106,7 @@ export const ne = dualImpl({
     returnType: correspondingBooleanVectorSchema(argTypes[0]),
   }),
   normalImpl: <T extends AnyVecInstance>(lhs: T, rhs: T) => cpuNot(cpuEq(lhs, rhs)),
-  codegenImpl: (_ctx, [lhs, rhs]) => stitch`(${lhs} != ${rhs})`,
+  codegenImpl: (ctx, [lhs, rhs]) => ctx.gen.emitBinaryOp(lhs, '!=', rhs),
   sideEffects: false,
 });
 

--- a/packages/typegpu/src/std/boolean.ts
+++ b/packages/typegpu/src/std/boolean.ts
@@ -87,7 +87,7 @@ export const eq = dualImpl({
     returnType: correspondingBooleanVectorSchema(argTypes[0]),
   }),
   normalImpl: cpuEq,
-  codegenImpl: (_ctx, [lhs, rhs]) => stitch`(${lhs} == ${rhs})`,
+  codegenImpl: (ctx, [lhs, rhs]) => ctx.gen.emitBinaryOp(lhs, '==', rhs),
   sideEffects: false,
 });
 


### PR DESCRIPTION
WGSL vector equality is component-wise and returns a boolean vector. GLSL’s `==` operator instead returns a scalar boolean for vector operands, so the fallback currently emits an expression whose type does not match `std.eq`.

`std.eq` now delegates binary emission to the active generator. The GLSL generator recognizes vector equality and emits GLSL’s `equal(lhs, rhs)` builtin; WGSL output remains unchanged through the base generator. A GLSL regression test covers the generated `bvec3` function.

Verification:
- focused GLSL generator suite: 32 passed
- WGSL equality suites: 6 passed
- TypeGPU and `@typegpu/gl` type tests
- changed-file Oxlint and Oxfmt checks
- fast unit suite on Node 24: 2,809 passed, 2 skipped
- TypeGPU and `@typegpu/gl` package builds

Closes #2832.