### PR TITLE
fix: Avoid CLI misleading error for error codes outside missing version

### DIFF
--- a/packages/typegpu/bin.mjs
+++ b/packages/typegpu/bin.mjs
@@ -1,79 +1,51 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
 import pkg from './package.json' with { type: 'json' };
 
-/**
- * Used to extract the version of `typegpu` that was used to
- * trigger the CLI, which then allows us to download the latest
- * version matching the major and minor of the `typegpu` package.
- */
-const versionPattern = /^(\d+)\.(\d+)\.(\d+)/;
-
-const result = versionPattern.exec(pkg.version);
-const [_, major, minor] = result;
-
-if (major === undefined || minor === undefined) {
-  throw new Error(`TypeGPU version doesn't match the expected major.minor.patch format`);
-}
-
-/**
- * Targeting the latest version with the same major and minor as `typegpu`
- */
+const [major, minor] = pkg.version.split('.');
 const semver = `^${major}.${minor}.0`;
 
-/**
- * @returns {Promise<number | undefined>}
- */
-function asyncSpawn(...args) {
+const windows = process.platform === 'win32';
+const npm = windows ? 'npm.cmd' : 'npm';
+const npx = windows ? 'npx.cmd' : 'npx';
+const execFileAsync = promisify(execFile);
+
+/** True only when the registry confirms no `@typegpu/cli` satisfies `semver` */
+async function noMatchingCli() {
+  const args = ['view', `@typegpu/cli@${semver}`, 'version', '--json'];
+  try {
+    const { stdout } = await execFileAsync(npm, args, { shell: windows });
+    return ['', '[]'].includes(stdout.trim());
+  } catch (err) {
+    return /E404|ETARGET/.test(err.stderr ?? '');
+  }
+}
+
+/** Resolves with the child's exit code, re-raising a fatal signal on this process */
+function run(command, args) {
   return new Promise((resolve, reject) => {
-    const child = spawn(...args);
-
-    child.on('exit', (code, signal) => {
-      if (signal) {
-        process.kill(process.pid, signal);
-        process.exit(0);
-        return;
-      }
-
-      resolve(code);
-    });
-
-    child.on('error', (err) => {
-      reject(err);
-    });
+    spawn(command, args, { stdio: 'inherit', shell: windows })
+      .on('error', reject)
+      .on('exit', (code, signal) => {
+        if (signal) {
+          process.kill(process.pid, signal);
+        } else {
+          resolve(code ?? 1);
+        }
+      });
   });
 }
 
-/**
- * @param {string} label
- */
-function failedToRunErrHandler(label) {
-  return (err) => {
-    console.error(`Failed to run '${label}':`, err);
-    process.exit(1);
-  };
+const fallback = await noMatchingCli();
+if (fallback) {
+  console.warn(`Couldn't find @typegpu/cli version matching ${semver}, falling back to latest...`);
 }
+const spec = fallback ? '@typegpu/cli@latest' : `@typegpu/cli@${semver}`;
 
-(async () => {
-  const windows = process.platform === 'win32';
-  const npxCommand = windows ? 'npx.cmd' : 'npx';
-
-  const code = await asyncSpawn(npxCommand, [`@typegpu/cli@${semver}`, ...process.argv.slice(2)], {
-    stdio: 'inherit',
-    shell: windows, // needs to be ran through the shell on Windows
-  }).catch(failedToRunErrHandler(`npx @typegpu/cli@${semver}`));
-
-  if (code !== 0) {
-    console.warn(
-      `Couldn't find @typegpu/cli version matching ${semver}, falling back to latest...`,
-    );
-    // Fallback to latest
-    const code = await asyncSpawn(npxCommand, [`@typegpu/cli@latest`, ...process.argv.slice(2)], {
-      stdio: 'inherit',
-      shell: windows, // needs to be ran through the shell on Windows
-    }).catch(failedToRunErrHandler('npx @typegpu/cli@latest'));
-    process.exit(code ?? 0);
-  }
-
-  process.exit(code ?? 0);
-})();
+try {
+  process.exit(await run(npx, [spec, ...process.argv.slice(2)]));
+} catch (err) {
+  console.error(`Failed to run 'npx ${spec}':`, err);
+  process.exit(2);
+}

--- a/packages/typegpu/bin.mjs
+++ b/packages/typegpu/bin.mjs
@@ -15,7 +15,7 @@ const execFileAsync = promisify(execFile);
 async function noMatchingCli() {
   const args = ['view', `@typegpu/cli@${semver}`, 'version', '--json'];
   try {
-    const { stdout } = await execFileAsync(npm, args, { shell: windows });
+    const { stdout } = await execFileAsync(npm, args, { shell: windows, timeout: 3_000 });
     return ['', '[]'].includes(stdout.trim());
   } catch (err) {
     return /E404|ETARGET/.test(err.stderr ?? '');


### PR DESCRIPTION
The `typegpu` bin treated any non-zero exit from `@typegpu/cli` as "no matching version" and reran the command with `@latest`. Breaks `inspect check`, which exits 1 on findings (as is standard for linter like clis)

- asks the registry first, falls back only on E404
- probe returns one boolean ("no match confirmed") instead of `true | false | undefined`, an unreachable registry just lands in the `catch` and keeps the range
- swapped the version regex for a `split('.')` since we only ever use the first two numbers, which are safe for any valid semver