### PR TITLE
docs: Small example page fixes

### DIFF
--- a/apps/typegpu-docs/src/components/ExampleLayout.tsx
+++ b/apps/typegpu-docs/src/components/ExampleLayout.tsx
@@ -49,7 +49,7 @@ export function ExampleLayout({ children }: ExampleLayoutProps) {
       </div>
 
       {!fullscreen && (
-        <footer className="text-tameplum-600 dark:text-gray-300 box-border flex w-full items-center justify-center px-6 pb-6 text-xs md:px-8">
+        <footer className="text-tameplum-600 dark:text-gray-300 box-border flex w-full items-center justify-center px-6 pb-6 text-center text-xs md:px-8">
           &copy; Software Mansion {new Date().getFullYear()}. All trademarks and copyrights belong
           to their respective owners.
         </footer>

--- a/apps/typegpu-docs/src/components/design/Select.tsx
+++ b/apps/typegpu-docs/src/components/design/Select.tsx
@@ -17,7 +17,7 @@ export function Select({
       </RadixSelect.Trigger>
 
       <RadixSelect.Portal>
-        <RadixSelect.Content position="popper" className="-top-4 relative min-w-30">
+        <RadixSelect.Content position="popper" className="-top-4 relative z-50 min-w-30">
           <RadixSelect.Viewport className="bg-tameplum-50 dark:bg-[#272b3c] max-h-[50vh] rounded-lg shadow-xl">
             {options.map((option) => (
               <RadixSelect.Item


### PR DESCRIPTION
Changes:
- In fullscreen mode, a select's list is now on top of the control panel, instead of behind it
- The copyright in the footer is now aligned to the center properly