### PR TITLE
fix: Validate derivative builtin signatures in codegen mode

### DIFF
--- a/packages/typegpu/src/std/derivative.ts
+++ b/packages/typegpu/src/std/derivative.ts
@@ -1,16 +1,21 @@
 import { dualImpl } from '../core/function/dualImpl.ts';
 import { stitch } from '../core/resolve/stitch.ts';
+import { f32 } from '../data/numeric.ts';
+import { vec2f, vec3f, vec4f } from '../data/vector.ts';
 import type { AnyFloat32VecInstance } from '../data/wgslTypes.ts';
+import { unifyRestrictedSignature } from './numeric.ts';
 
 type DerivativeSignature = ((value: number) => number) &
   (<T extends AnyFloat32VecInstance>(value: T) => T);
 
 const derivativeNormalError = 'Derivative builtins are not allowed on the CPU';
+// WGSL derivative builtins only accept f32 and vecN<f32>
+const derivativeSignature = unifyRestrictedSignature([f32, vec2f, vec3f, vec4f]);
 
 export const dpdx = dualImpl<DerivativeSignature>({
   name: 'dpdx',
   normalImpl: derivativeNormalError,
-  signature: (value) => ({ argTypes: [value], returnType: value }),
+  signature: derivativeSignature,
   codegenImpl: (ctx, [value]) => ctx.gen.emitCall('dpdx', [], [value]),
   sideEffects: false,
 });
@@ -18,7 +23,7 @@ export const dpdx = dualImpl<DerivativeSignature>({
 export const dpdxCoarse = dualImpl<DerivativeSignature>({
   name: 'dpdxCoarse',
   normalImpl: derivativeNormalError,
-  signature: (value) => ({ argTypes: [value], returnType: value }),
+  signature: derivativeSignature,
   codegenImpl: (_ctx, [value]) => stitch`dpdxCoarse(${value})`,
   sideEffects: false,
 });
@@ -26,7 +31,7 @@ export const dpdxCoarse = dualImpl<DerivativeSignature>({
 export const dpdxFine = dualImpl<DerivativeSignature>({
   name: 'dpdxFine',
   normalImpl: derivativeNormalError,
-  signature: (value) => ({ argTypes: [value], returnType: value }),
+  signature: derivativeSignature,
   codegenImpl: (_ctx, [value]) => stitch`dpdxFine(${value})`,
   sideEffects: false,
 });
@@ -34,7 +39,7 @@ export const dpdxFine = dualImpl<DerivativeSignature>({
 export const dpdy = dualImpl<DerivativeSignature>({
   name: 'dpdy',
   normalImpl: derivativeNormalError,
-  signature: (value) => ({ argTypes: [value], returnType: value }),
+  signature: derivativeSignature,
   codegenImpl: (ctx, [value]) => ctx.gen.emitCall('dpdy', [], [value]),
   sideEffects: false,
 });
@@ -42,7 +47,7 @@ export const dpdy = dualImpl<DerivativeSignature>({
 export const dpdyCoarse = dualImpl<DerivativeSignature>({
   name: 'dpdyCoarse',
   normalImpl: derivativeNormalError,
-  signature: (value) => ({ argTypes: [value], returnType: value }),
+  signature: derivativeSignature,
   codegenImpl: (_ctx, [value]) => stitch`dpdyCoarse(${value})`,
   sideEffects: false,
 });
@@ -50,7 +55,7 @@ export const dpdyCoarse = dualImpl<DerivativeSignature>({
 export const dpdyFine = dualImpl<DerivativeSignature>({
   name: 'dpdyFine',
   normalImpl: derivativeNormalError,
-  signature: (value) => ({ argTypes: [value], returnType: value }),
+  signature: derivativeSignature,
   codegenImpl: (_ctx, [value]) => stitch`dpdyFine(${value})`,
   sideEffects: false,
 });
@@ -58,7 +63,7 @@ export const dpdyFine = dualImpl<DerivativeSignature>({
 export const fwidth = dualImpl<DerivativeSignature>({
   name: 'fwidth',
   normalImpl: derivativeNormalError,
-  signature: (value) => ({ argTypes: [value], returnType: value }),
+  signature: derivativeSignature,
   codegenImpl: (ctx, [value]) => ctx.gen.emitCall('fwidth', [], [value]),
   sideEffects: false,
 });
@@ -66,7 +71,7 @@ export const fwidth = dualImpl<DerivativeSignature>({
 export const fwidthCoarse = dualImpl<DerivativeSignature>({
   name: 'fwidthCoarse',
   normalImpl: derivativeNormalError,
-  signature: (value) => ({ argTypes: [value], returnType: value }),
+  signature: derivativeSignature,
   codegenImpl: (_ctx, [value]) => stitch`fwidthCoarse(${value})`,
   sideEffects: false,
 });
@@ -74,7 +79,7 @@ export const fwidthCoarse = dualImpl<DerivativeSignature>({
 export const fwidthFine = dualImpl<DerivativeSignature>({
   name: 'fwidthFine',
   normalImpl: derivativeNormalError,
-  signature: (value) => ({ argTypes: [value], returnType: value }),
+  signature: derivativeSignature,
   codegenImpl: (_ctx, [value]) => stitch`fwidthFine(${value})`,
   sideEffects: false,
 });

--- a/packages/typegpu/src/std/numeric.ts
+++ b/packages/typegpu/src/std/numeric.ts
@@ -79,7 +79,7 @@ const variadicUnifySignature = (...args: BaseData[]) => {
   };
 };
 
-const unifyRestrictedSignature =
+export const unifyRestrictedSignature =
   (restrict: BaseData[]) =>
   (...args: BaseData[]) => {
     const uargs = unify(args, restrict);

--- a/packages/typegpu/tests/std/derivative.test.ts
+++ b/packages/typegpu/tests/std/derivative.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { tgpu, d, std } from 'typegpu';
+
+const derivatives = [
+  std.dpdx,
+  std.dpdxCoarse,
+  std.dpdxFine,
+  std.dpdy,
+  std.dpdyCoarse,
+  std.dpdyFine,
+  std.fwidth,
+  std.fwidthCoarse,
+  std.fwidthFine,
+];
+
+describe('derivative builtins', () => {
+  it('accept f32 and f32 vector arguments', () => {
+    const foo = tgpu.fn(
+      [d.f32, d.vec3f],
+      d.vec3f,
+    )((a, b) => {
+      'use gpu';
+      const x = std.dpdx(a);
+      return std.dpdy(b) + std.fwidth(b) * x;
+    });
+
+    expect(tgpu.resolve([foo])).toMatchInlineSnapshot(`
+      "fn foo(a: f32, b: vec3f) -> vec3f {
+        let x = dpdx(a);
+        return (dpdy(b) + (fwidth(b) * x));
+      }"
+    `);
+  });
+
+  it('cast integer scalar arguments to f32', () => {
+    using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const foo = tgpu.fn(
+      [d.u32, d.i32],
+      d.f32,
+    )((a, b) => {
+      'use gpu';
+      return std.dpdx(a) + std.dpdy(b);
+    });
+
+    expect(tgpu.resolve([foo])).toMatchInlineSnapshot(`
+      "fn foo(a: u32, b: i32) -> f32 {
+        return (dpdx(f32(a)) + dpdy(f32(b)));
+      }"
+    `);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(derivatives)('%s throws on integer vector arguments', (derivative) => {
+    const foo = tgpu.fn([d.vec2u])((a) => {
+      'use gpu';
+      // @ts-expect-error
+      derivative(a);
+    });
+
+    expect(() => tgpu.resolve([foo])).toThrow(
+      'Unsupported data types: vec2u. Supported types are: f32, vec2f, vec3f, vec4f.',
+    );
+  });
+});

--- a/packages/typegpu/tests/std/numeric/inverseSqrt.test.ts
+++ b/packages/typegpu/tests/std/numeric/inverseSqrt.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { tgpu, d, std } from 'typegpu';
+
+describe('inverseSqrt', () => {
+  it('computes inverse square root of a number', () => {
+    expect(std.inverseSqrt(4)).toBe(0.5);
+  });
+
+  it('casts integer scalar arguments to f32', () => {
+    using warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const foo = tgpu.fn(
+      [d.u32, d.i32],
+      d.f32,
+    )((a, b) => {
+      'use gpu';
+      return std.inverseSqrt(a) + std.inverseSqrt(b);
+    });
+
+    expect(tgpu.resolve([foo])).toMatchInlineSnapshot(`
+      "fn foo(a: u32, b: i32) -> f32 {
+        return (inverseSqrt(f32(a)) + inverseSqrt(f32(b)));
+      }"
+    `);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws on integer vector arguments', () => {
+    const foo = tgpu.fn([d.vec2u])((a) => {
+      'use gpu';
+      // @ts-expect-error
+      std.inverseSqrt(a);
+    });
+
+    expect(() => tgpu.resolve([foo])).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Resolution of the following tree failed:
+      - <root>
+      - fn:foo
+      - fn:inverseSqrt: Unsupported data types: vec2u. Supported types are: f32, f16, abstractFloat, vec2f, vec3f, vec4f, vec2h, vec3h, vec4h.]
+    `);
+  });
+});


### PR DESCRIPTION
Fixes #2990

`dpdx`/`dpdy`/`fwidth` (and their `Coarse`/`Fine` variants) used an unrestricted `signature: (value) => ({ argTypes: [value], returnType: value })`, so any argument type went straight to codegen. With an integer argument this produced invalid WGSL, e.g.

```ts
const foo = tgpu.fn([d.u32], d.f32)((a) => {
  'use gpu';
  return std.dpdx(a);
});
tgpu.resolve([foo]);
// fn foo(a: u32) -> f32 {
//   return f32(dpdx(a));   // dpdx on a u32
// }
```

This PR gives all nine derivative builtins the same treatment the rest of `std` already uses: `unifyRestrictedSignature([f32, vec2f, vec3f, vec4f])` (WGSL derivative builtins only accept `f32`/`vecN<f32>`, matching the existing `DerivativeSignature` TS type). Integer scalars are now cast to `f32` with the usual implicit-conversion warning (`dpdx(f32(a))`), and integer vectors throw `SignatureNotSupportedError` instead of slipping through. `unifyRestrictedSignature` is exported from `numeric.ts` so `derivative.ts` can reuse it rather than duplicating it.

`inverseSqrt` already had `unifyRestrictedSignature(anyFloat)` and behaves the same way (`inverseSqrt(f32(a))` for scalars, throws for integer vectors); I only added a test locking that in since it had none.

Tests: `packages/typegpu/tests/std/derivative.test.ts` and `packages/typegpu/tests/std/numeric/inverseSqrt.test.ts`. Ran `test:types`, `oxlint`/`oxfmt`, the circular-deps check, and the `typegpu` + `@typegpu/gl` unit suites locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
