### PR TITLE
feat(unplugin-typegpu): Support Node & Deno via synchronous hooks

### DIFF
--- a/apps/typegpu-docs/src/content/docs/tooling/unplugin-typegpu.mdx
+++ b/apps/typegpu-docs/src/content/docs/tooling/unplugin-typegpu.mdx
@@ -51,7 +51,8 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   </TabItem>
 </Tabs>
 
-After installing the package, the exported plugin needs to be included in the list of plugins in the bundler config.
+After installing the package, add the plugin to your bundler config or register it
+with your runtime using one of the setups below.
 
 ## Supported bundlers
 
@@ -86,6 +87,84 @@ module.exports = (api) => {
   };
 };
 ```
+
+## Node.js and Deno
+
+Node.js 22.15+ and Deno 2.8+ support synchronous module hooks, so TypeScript shaders
+can be transformed without a bundler. `unplugin-typegpu/node` exports the installer;
+`unplugin-typegpu/deno` is an alias for the same function.
+
+```js title="preload.mjs"
+import install from 'unplugin-typegpu/node';
+
+const hooks = install(); // Accepts the plugin options below.
+```
+
+```sh
+# Node.js
+node --import ./preload.mjs main.ts
+
+# Deno
+deno run --import ./preload.mjs main.ts
+```
+
+The hooks transform subsequently loaded `.ts`, `.js`, `.mts`, `.mjs`, `.cts`, and
+`.cjs` modules, including CommonJS modules loaded with `require()`.
+Deno also handles `.jsx` and `.tsx` files. Node.js needs an additional JSX loader
+for these files: the TypeGPU plugin transforms shaders but does not compile JSX.
+Node.js's [native TypeScript support](https://nodejs.org/api/typescript.html)
+handles erasable syntax by default and does not use `tsconfig.json`.
+Call `hooks.deregister()` to remove the hooks.
+
+You can also call `install()` directly in your entry module, followed by
+`await import('./main.ts')`. Use a dynamic import in that case: static imports in
+the module calling `install()` are loaded before the hooks are installed.
+Already loaded modules are not transformed retroactively.
+
+See the [Node.js module hooks documentation](https://nodejs.org/api/module.html#moduleregisterhooksoptions)
+and [Deno loader hooks documentation](https://docs.deno.com/runtime/reference/loader_hooks/)
+for more about runtime hooks.
+
+## Bun
+
+Register the Bun plugin in a preload module so it runs before your application is loaded:
+
+```ts title="preload.ts"
+import { plugin } from 'bun';
+import typegpu from 'unplugin-typegpu/bun';
+
+await plugin(typegpu());
+```
+
+```sh
+bun --preload ./preload.ts main.ts
+```
+
+Alternatively, configure the preload in `bunfig.toml` and run `bun main.ts`:
+
+```toml title="bunfig.toml"
+preload = ["./preload.ts"]
+
+# Also register the plugin when running `bun test`.
+[test]
+preload = ["./preload.ts"]
+```
+
+For bundling, pass the plugin directly to `Bun.build`:
+
+```ts title="build.ts"
+import typegpu from 'unplugin-typegpu/bun';
+
+await Bun.build({
+  entrypoints: ['./main.ts'],
+  outdir: './dist',
+  plugins: [typegpu()],
+});
+```
+
+The Bun plugin accepts a single regular expression for `include`; arrays, glob
+patterns, and `exclude` are unsupported. By default, it skips files without `typegpu`,
+`tgpu`, or a `'use gpu'` directive. Set `earlyPruning: false` to disable this optimization.
 
 ## Plugin options
 

--- a/packages/unplugin-typegpu/README.md
+++ b/packages/unplugin-typegpu/README.md
@@ -9,7 +9,7 @@ Read more about the plugin in the
 
 </div>
 
-A set of bundler plugins that enhance [TypeGPU](https://typegpu.com) with:
+A set of bundler plugins and runtime hooks that enhance [TypeGPU](https://typegpu.com) with:
 
 - JavaScript/TypeScript shader support ('use gpu' directive)
 - Improved debugging with automatic naming of resources
@@ -55,8 +55,38 @@ export default defineConfig({
 import { plugin } from 'bun';
 import typegpu from 'unplugin-typegpu/bun';
 
-void plugin(typegpu());
+await plugin(typegpu());
 ```
+
+Run with `bun --preload ./preload.ts main.ts`, or add
+`preload = ["./preload.ts"]` to `bunfig.toml`.
+For `Bun.build`, pass `typegpu()` in the `plugins` array instead.
+The Bun plugin accepts a single regular expression for `include` and does not
+support `exclude`.
+
+- Node.js (22.15+) and Deno (2.8+)
+
+```js
+// preload.mjs
+import install from 'unplugin-typegpu/node';
+
+const hooks = install(); // Accepts the usual plugin options.
+// Call hooks.deregister() to stop transforming future imports.
+```
+
+Run with `node --import ./preload.mjs main.ts` or
+`deno run --import ./preload.mjs main.ts`. `unplugin-typegpu/deno` is an alias
+for the same installer.
+
+The hooks transform `.js`, `.ts`, `.mjs`, `.mts`, `.cjs`, and `.cts` modules.
+Deno also handles `.jsx` and `.tsx`; Node.js needs an additional JSX loader.
+Node.js's native TypeScript support is limited to erasable syntax by default
+and does not use `tsconfig.json`.
+
+Alternatively, call `install()`
+in your entry module and then load your application with `await import('./main.ts')`.
+Static imports in the module calling `install()` are loaded before the hooks are
+installed. Already loaded modules are not transformed retroactively.
 
 ## TypeGPU is created by Software Mansion
 

--- a/packages/unplugin-typegpu/package.json
+++ b/packages/unplugin-typegpu/package.json
@@ -159,6 +159,30 @@
         "default": "./dist/webpack.cjs"
       },
       "default": "./dist/webpack.js"
+    },
+    "./deno": "./src/deno.ts",
+    "./deno/$built$": {
+      "import": {
+        "types": "./dist/deno.d.ts",
+        "default": "./dist/deno.js"
+      },
+      "require": {
+        "types": "./dist/deno.d.cts",
+        "default": "./dist/deno.cjs"
+      },
+      "default": "./dist/deno.js"
+    },
+    "./node": "./src/node.ts",
+    "./node/$built$": {
+      "import": {
+        "types": "./dist/node.d.ts",
+        "default": "./dist/node.js"
+      },
+      "require": {
+        "types": "./dist/node.d.cts",
+        "default": "./dist/node.cjs"
+      },
+      "default": "./dist/node.js"
     }
   },
   "publishConfig": {
@@ -274,6 +298,26 @@
         "require": {
           "types": "./dist/webpack.d.cts",
           "default": "./dist/webpack.cjs"
+        }
+      },
+      "./deno": {
+        "import": {
+          "types": "./dist/deno.d.ts",
+          "default": "./dist/deno.js"
+        },
+        "require": {
+          "types": "./dist/deno.d.cts",
+          "default": "./dist/deno.cjs"
+        }
+      },
+      "./node": {
+        "import": {
+          "types": "./dist/node.d.ts",
+          "default": "./dist/node.js"
+        },
+        "require": {
+          "types": "./dist/node.d.cts",
+          "default": "./dist/node.cjs"
         }
       }
     },

--- a/packages/unplugin-typegpu/src/core/filter.ts
+++ b/packages/unplugin-typegpu/src/core/filter.ts
@@ -1,5 +1,5 @@
 // Copied from https://github.com/unjs/unplugin/blob/f514bf8e2d751b48b3a5acb1077eb1292d9711b3/src/utils/filter.ts#L2
-// Used only in the babel version of the plugin, since others can rely on native unplugin functionality.
+// Used by the Babel and Deno integrations, which cannot rely on native unplugin filtering.
 
 import { resolve } from 'pathe';
 import picomatch from 'picomatch';

--- a/packages/unplugin-typegpu/src/deno.ts
+++ b/packages/unplugin-typegpu/src/deno.ts
@@ -1,0 +1,2 @@
+export { default } from './node.ts';
+export type { Options } from './node.ts';

--- a/packages/unplugin-typegpu/src/node.ts
+++ b/packages/unplugin-typegpu/src/node.ts
@@ -1,0 +1,49 @@
+import { registerHooks, type ModuleHooks } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import type { UnpluginBuildContext, UnpluginContext } from 'unplugin';
+import { earlyPruneRegex, type Options } from './core/common.ts';
+import { unpluginFactory } from './core/factory.ts';
+import { createFilterForId } from './core/filter.ts';
+
+export type { Options } from './core/common.ts';
+
+/**
+ * Installs TypeGPU's synchronous module hooks in Node.js 22.15+ and Deno 2.8+.
+ * Use a dynamic import after calling this function, or call it from a preloaded
+ * module (`node --import ./preload.mjs main.ts` or
+ * `deno run --import ./preload.mjs main.ts`).
+ */
+export default function install(rawOptions?: Options): ModuleHooks {
+  const plugin = unpluginFactory(
+    { include: /\.[cm]?[jt]sx?$/, ...rawOptions },
+    { framework: 'unloader' },
+  );
+  const filter = createFilterForId(plugin.transform.filter.id);
+  const transformContext = {
+    warn: (message: string) => console.warn(`[unplugin-typegpu] ${message}`),
+  } as UnpluginBuildContext & UnpluginContext;
+
+  return registerHooks({
+    load(url, context, nextLoad) {
+      const result = nextLoad(url, context);
+      if (result.source == null || result.format === 'json' || result.format === 'wasm') {
+        return result;
+      }
+
+      const moduleURL = new URL(url);
+      const id = moduleURL.protocol === 'file:' ? fileURLToPath(moduleURL) : moduleURL.pathname;
+      if (filter && !filter(id)) {
+        return result;
+      }
+
+      const code =
+        typeof result.source === 'string' ? result.source : new TextDecoder().decode(result.source);
+      if (rawOptions?.earlyPruning !== false && earlyPruneRegex.every((p) => !p.test(code))) {
+        return result;
+      }
+
+      const transformed = plugin.transform.handler.call(transformContext, code, id);
+      return transformed ? { ...result, source: transformed.code } : result;
+    },
+  });
+}

--- a/packages/unplugin-typegpu/test/node-integration.test.ts
+++ b/packages/unplugin-typegpu/test/node-integration.test.ts
@@ -1,0 +1,104 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const version = spawnSync('deno', ['--version'], { encoding: 'utf8' }).stdout;
+const match = version?.match(/deno (\d+)\.(\d+)/);
+const supportsHooks =
+  match && (Number(match[1]) > 2 || (Number(match[1]) === 2 && Number(match[2]) >= 8));
+
+describe.each(['node', 'deno'])('%s loader integration', (runtime) => {
+  it.skipIf(runtime === 'deno' && !supportsHooks).each(['dynamic import', 'preload'])(
+    'transforms modules using %s',
+    (mode) => {
+      const directory = mkdtempSync(join(tmpdir(), 'typegpu-deno-'));
+      try {
+        const entrypoint = fileURLToPath(new URL(`../src/${runtime}.ts`, import.meta.url));
+        writeFileSync(
+          join(directory, 'deno.json'),
+          JSON.stringify({
+            nodeModulesDir: 'manual',
+            lock: false,
+            compilerOptions: { jsx: 'react', jsxFactory: 'h' },
+          }),
+        );
+        writeFileSync(
+          join(directory, 'preload.ts'),
+          `
+        import install from ${JSON.stringify(entrypoint)};
+        export const hooks = install();
+      `,
+        );
+        let main = `import assert from 'node:assert/strict';\nimport { hooks } from './preload.ts';\n`;
+        for (const extension of [
+          'ts',
+          'js',
+          'mts',
+          'mjs',
+          'cts',
+          'cjs',
+          ...(runtime === 'deno' ? ['tsx', 'jsx'] : []),
+        ]) {
+          const typed = ['ts', 'tsx', 'mts', 'cts'].includes(extension);
+          const jsx = ['tsx', 'jsx'].includes(extension);
+          const commonjs = ['cts', 'cjs'].includes(extension);
+          writeFileSync(
+            join(directory, `shader.${extension}`),
+            `
+          const shader = (x${typed ? ': number' : ''}) => { 'use gpu'; return x; };
+          ${jsx ? 'const h = (tag, props) => tag; const element = <div />;' : ''}
+          ${commonjs ? 'module.exports = { shader };' : 'export { shader };'}
+        `,
+          );
+          main += `
+          import { shader as shader_${extension} } from './shader.${extension}';
+          assert.equal(shader_${extension}(42), 42);
+          assert.ok(globalThis.__TYPEGPU_META__?.has(shader_${extension}), '${extension}');
+        `;
+        }
+        writeFileSync(
+          join(directory, 'after.ts'),
+          `export const shader = () => { 'use gpu'; return 1; };`,
+        );
+        main += `
+        hooks.deregister();
+        const after = await import('./after.ts');
+        assert.equal(globalThis.__TYPEGPU_META__.has(after.shader), false);
+        console.log('All shaders transformed; deregistration passed');
+      `;
+        writeFileSync(join(directory, 'main.ts'), main);
+        writeFileSync(
+          join(directory, 'bootstrap.ts'),
+          `
+        import './preload.ts';
+        await import('./main.ts');
+      `,
+        );
+        const result = spawnSync(
+          runtime === 'node' ? process.execPath : 'deno',
+          [
+            ...(runtime === 'deno'
+              ? ['run', '--allow-read', '--allow-env', '--config', join(directory, 'deno.json')]
+              : []),
+            ...(mode === 'preload'
+              ? ['--import', join(directory, 'preload.ts'), join(directory, 'main.ts')]
+              : [join(directory, 'bootstrap.ts')]),
+          ],
+          {
+            encoding: 'utf8',
+            timeout: 20_000,
+            env: { ...process.env, DENO_DIR: join(directory, 'cache') },
+          },
+        );
+        expect(result.error).toBeUndefined();
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain('All shaders transformed; deregistration passed');
+      } finally {
+        rmSync(directory, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/packages/unplugin-typegpu/test/node.test.ts
+++ b/packages/unplugin-typegpu/test/node.test.ts
@@ -1,0 +1,94 @@
+import type { LoadHookSync } from 'node:module';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import install from '../src/node.ts';
+import denoInstall from '../src/deno.ts';
+
+const { registerHooks } = vi.hoisted(() => ({ registerHooks: vi.fn() }));
+vi.mock('node:module', () => ({ registerHooks }));
+
+const shader = `export const shader = () => { 'use gpu'; return 42; };`;
+const context = { format: 'module', conditions: [], importAttributes: {} };
+
+function loadHook(options?: Parameters<typeof install>[0]): LoadHookSync {
+  install(options);
+  return registerHooks.mock.lastCall?.[0].load;
+}
+
+beforeEach(() => registerHooks.mockReset());
+
+describe('Node.js and Deno loader hooks', () => {
+  it('exposes the same installer through the Deno alias', () => {
+    expect(denoInstall).toBe(install);
+  });
+  it('returns the registration handle for deregistration', () => {
+    const handle = { deregister: vi.fn() };
+    registerHooks.mockReturnValue(handle);
+    expect(install()).toBe(handle);
+  });
+
+  it.each(['ts', 'js', 'jsx', 'tsx', 'mts', 'mjs', 'cts', 'cjs'])(
+    'transforms .%s modules and preserves the loader result',
+    (extension) => {
+      const load = loadHook();
+      const result = { source: shader, format: 'module', shortCircuit: true };
+      const nextLoad = vi.fn(() => result);
+      const url = `file:///shaders/my%20shader.${extension}?version=1#shader`;
+      const transformed = load(url, context, nextLoad);
+      expect(nextLoad).toHaveBeenCalledWith(url, context);
+      expect(transformed).toEqual({
+        ...result,
+        source: expect.stringContaining('__TYPEGPU_META__'),
+      });
+    },
+  );
+
+  it.each([new TextEncoder().encode(shader), new TextEncoder().encode(shader).buffer])(
+    'decodes binary source',
+    (source) => {
+      const transformed = loadHook()('file:///shader.ts', context, () => ({
+        source,
+        format: 'module',
+      }));
+      expect(transformed.source).toContain('__TYPEGPU_META__');
+    },
+  );
+
+  it('supports remote URLs and include/exclude globs with decoded file paths', () => {
+    const load = loadHook({ include: '**/my shaders/*.ts', exclude: '**/skip.ts' });
+    const result = { source: shader, format: 'module' };
+    expect(load('file:///my%20shaders/test.ts', context, () => result).source).toContain(
+      '__TYPEGPU_META__',
+    );
+    expect(load('file:///my%20shaders/skip.ts', context, () => result)).toBe(result);
+    expect(load('file:///other/test.ts', context, () => result)).toBe(result);
+    expect(loadHook()('https://example.com/shader.ts?v=1', context, () => result).source).toContain(
+      '__TYPEGPU_META__',
+    );
+  });
+
+  it.each([
+    ['node:fs', { format: 'builtin', source: undefined }],
+    ['file:///data.json', { format: 'json', source: shader }],
+    ['file:///shader.wgsl', { format: 'module', source: shader }],
+    ['file:///plain.ts', { format: 'module', source: 'export const value = 42;' }],
+  ] as const)('passes through %s unchanged', (url, result) => {
+    expect(loadHook()(url, context, () => result)).toBe(result);
+  });
+
+  it('honors earlyPruning and autoNamingEnabled options', () => {
+    const result = { source: 'const value = custom.fn([])(() => 1);', format: 'module' };
+    const options = { forceTgpuAlias: 'custom' };
+    expect(loadHook(options)('file:///shader.ts', context, () => result)).toBe(result);
+    expect(
+      loadHook({ ...options, earlyPruning: false })('file:///shader.ts', context, () => result)
+        .source,
+    ).toContain('__TYPEGPU_AUTONAME__');
+    expect(
+      loadHook({ ...options, earlyPruning: false, autoNamingEnabled: false })(
+        'file:///shader.ts',
+        context,
+        () => result,
+      ).source,
+    ).not.toContain('__TYPEGPU_AUTONAME__');
+  });
+});

--- a/packages/unplugin-typegpu/tsdown.config.ts
+++ b/packages/unplugin-typegpu/tsdown.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
     'src/rollup.ts',
     'src/babel.ts',
     'src/bun.ts',
+    'src/deno.ts',
+    'src/node.ts',
     'src/esbuild.ts',
     'src/farm.ts',
     'src/rolldown.ts',


### PR DESCRIPTION
This PR adds the `unplugin-typegpu/node` and `unplugin-typegpu/deno` entrypoints that expose a hook config that can be used by the [`registerHooks` Node API](https://nodejs.org/api/module.html#customization-hooks).