### PR TITLE
feat: Add triangular patches to `@typegpu/geometry`

### DIFF
--- a/apps/typegpu-docs/src/examples/rendering/mesh-patches/index.html
+++ b/apps/typegpu-docs/src/examples/rendering/mesh-patches/index.html
@@ -1,0 +1,1 @@
+<canvas data-fit-to-container></canvas>

--- a/apps/typegpu-docs/src/examples/rendering/mesh-patches/index.ts
+++ b/apps/typegpu-docs/src/examples/rendering/mesh-patches/index.ts
@@ -1,0 +1,140 @@
+import { meshes } from '@typegpu/geometry';
+import { d, std, tgpu } from 'typegpu';
+import { Camera, setupOrbitCamera } from '../../common/setup-orbit-camera.ts';
+import { defineControls } from '../../common/defineControls.ts';
+
+const root = await tgpu.init();
+const canvas = document.querySelector('canvas') as HTMLCanvasElement;
+const context = root.configureContext({ canvas, alphaMode: 'premultiplied' });
+
+const maxSegments = 32;
+let segments = 4;
+const Scene = d.struct({ camera: Camera, segments: d.u32, wireframe: d.u32 });
+const scene = root.createUniform(Scene, { camera: Camera(), segments, wireframe: 1 });
+const indices = root
+  .createBuffer(
+    d.arrayOf(d.u32, meshes.triangleIndexCount(maxSegments)),
+    meshes.triangleIndices(maxSegments),
+  )
+  .$usage('index');
+
+const shapes = [
+  meshes.patches.icosphere(),
+  meshes.patches.capsule({ radius: 0.35, height: 0.6 }),
+  meshes.patches.roundedBox({ radius: 0.2 }),
+];
+const colors = [d.vec3f(0.2, 0.65, 0.8), d.vec3f(0.9, 0.55, 0.2), d.vec3f(0.6, 0.4, 0.8)];
+
+const fragment = tgpu.fragmentFn({
+  in: { normal: d.vec3f, color: d.vec3f, grid: d.vec3f },
+  out: d.vec4f,
+})(({ normal, color, grid }) => {
+  'use gpu';
+  const light = std.normalize(d.vec3f(-0.4, 0.8, 1));
+  let shaded = color * (0.25 + 0.75 * std.saturate(std.dot(std.normalize(normal), light)));
+  if (scene.$.wireframe !== 0) {
+    const f = std.fract(grid);
+    const distance = std.min(f, 1 - f) / std.max(std.fwidth(grid), d.vec3f(1e-4));
+    const edge = std.min(distance.x, std.min(distance.y, distance.z));
+    shaded = std.mix(shaded * 0.2, shaded, std.smoothstep(0, 1, edge));
+  }
+  return d.vec4f(shaded, 1);
+});
+
+const pipelines = shapes.map((shape, i) => {
+  const offset = d.vec3f((i - 1) * 1.5, 0, 0);
+  const color = colors[i];
+  return root
+    .createRenderPipeline({
+      vertex: ({ $vertexIndex, $instanceIndex }) => {
+        'use gpu';
+        const weights = meshes.triangleBarycentrics($vertexIndex, scene.$.segments);
+        const vertex = shape.at($instanceIndex, weights);
+        const camera = scene.$.camera;
+        return {
+          $position: camera.projection * camera.view * d.vec4f(vertex.position + offset, 1),
+          normal: vertex.normal,
+          color,
+          grid: weights * d.f32(scene.$.segments),
+        };
+      },
+      fragment,
+      primitive: { cullMode: 'back' },
+      depthStencil: { format: 'depth24plus', depthWriteEnabled: true, depthCompare: 'less' },
+    })
+    .withIndexBuffer(indices);
+});
+
+await Promise.all(pipelines.map((pipeline) => pipeline.initAsync()));
+
+function createDepth() {
+  return root
+    .createTexture({ size: [canvas.width, canvas.height], format: 'depth24plus' })
+    .$usage('transient');
+}
+let depth = createDepth();
+let frame: number | undefined;
+
+function render() {
+  frame = undefined;
+  const encoder = root['~unstable'].createCommandEncoder();
+  const pass = encoder.beginRenderPass({
+    colorAttachments: [{ view: context, clearValue: [0.04, 0.05, 0.07, 1] }],
+    depthStencilAttachment: { view: depth, depthStoreOp: 'discard' },
+  });
+  pipelines.forEach((pipeline, i) => {
+    pipeline.with(pass).drawIndexed(meshes.triangleIndexCount(segments), shapes[i].patchCount);
+  });
+  pass.end();
+  encoder.submit();
+}
+
+function requestRender() {
+  frame ??= requestAnimationFrame(render);
+}
+
+const { cleanupCamera } = setupOrbitCamera(
+  canvas,
+  { initPos: d.vec4f(2.5, 1.8, 5, 1), target: d.vec4f(0, 0, 0, 1), minZoom: 2, maxZoom: 10 },
+  (camera) => {
+    scene.patch({ camera });
+    requestRender();
+  },
+);
+
+requestRender();
+
+const resizeObserver = new ResizeObserver(() => {
+  depth.destroy();
+  depth = createDepth();
+  requestRender();
+});
+resizeObserver.observe(canvas);
+
+export const controls = defineControls({
+  Detail: {
+    initial: segments,
+    min: 1,
+    max: maxSegments,
+    step: 1,
+    onSliderChange: (value) => {
+      segments = value;
+      scene.patch({ segments });
+      requestRender();
+    },
+  },
+  Wireframe: {
+    initial: true,
+    onToggleChange: (value) => {
+      scene.patch({ wireframe: value ? 1 : 0 });
+      requestRender();
+    },
+  },
+});
+
+export function onCleanup() {
+  if (frame !== undefined) cancelAnimationFrame(frame);
+  resizeObserver.disconnect();
+  cleanupCamera();
+  root.destroy();
+}

--- a/apps/typegpu-docs/src/examples/rendering/mesh-patches/meta.json
+++ b/apps/typegpu-docs/src/examples/rendering/mesh-patches/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Mesh Patches",
+  "category": "rendering",
+  "tags": ["3d", "geometry", "rasterization"],
+  "coolFactor": 5
+}

--- a/packages/typegpu-geometry/src/mesh/index.ts
+++ b/packages/typegpu-geometry/src/mesh/index.ts
@@ -6,3 +6,6 @@ export type { Geometry, IndexedGeometry, Topology } from './geometry.ts';
 export { parametric } from './parametric.ts';
 export type { Parametric, ParametricOptions } from './parametric.ts';
 export * from './primitives.ts';
+export * from './patchPrimitives.ts';
+export * from './triangles.ts';
+export * as patches from './patches/index.ts';

--- a/packages/typegpu-geometry/src/mesh/patchPrimitives.ts
+++ b/packages/typegpu-geometry/src/mesh/patchPrimitives.ts
@@ -1,0 +1,23 @@
+import * as patches from './patches/index.ts';
+import { tessellate } from './triangles.ts';
+
+export function icosphere({
+  segments = 4,
+  ...options
+}: patches.IcosphereOptions & { segments?: number } = {}) {
+  return tessellate(patches.icosphere(options), segments);
+}
+
+export function capsule({
+  segments = 4,
+  ...options
+}: patches.CapsuleOptions & { segments?: number } = {}) {
+  return tessellate(patches.capsule(options), segments);
+}
+
+export function roundedBox({
+  segments = 4,
+  ...options
+}: patches.RoundedBoxOptions & { segments?: number } = {}) {
+  return tessellate(patches.roundedBox(options), segments);
+}

--- a/packages/typegpu-geometry/src/mesh/patches/icosphere.ts
+++ b/packages/typegpu-geometry/src/mesh/patches/icosphere.ts
@@ -1,0 +1,58 @@
+import { d, std, tgpu } from 'typegpu';
+import { Surface } from '../geometry.ts';
+import { type PatchSurface } from '../triangles.ts';
+import { uniformArea } from './spherical.ts';
+
+const phi = (1 + Math.sqrt(5)) / 2;
+const corners = (
+  [
+    [-1, phi, 0],
+    [1, phi, 0],
+    [-1, -phi, 0],
+    [1, -phi, 0],
+    [0, -1, phi],
+    [0, 1, phi],
+    [0, -1, -phi],
+    [0, 1, -phi],
+    [phi, 0, -1],
+    [phi, 0, 1],
+    [-phi, 0, -1],
+    [-phi, 0, 1],
+  ] as const
+).map(([x, y, z]) => std.normalize(d.vec3f(x, y, z)));
+const faces = [
+  0, 11, 5, 0, 5, 1, 0, 1, 7, 0, 7, 10, 0, 10, 11, 1, 5, 9, 5, 11, 4, 11, 10, 2, 10, 7, 6, 7, 1, 8,
+  3, 9, 4, 3, 4, 2, 3, 2, 6, 3, 6, 8, 3, 8, 9, 4, 9, 5, 2, 4, 11, 6, 2, 10, 8, 6, 7, 9, 8, 1,
+];
+const vertices = tgpu.const(
+  d.arrayOf(d.vec3f, faces.length),
+  faces.map((i) => corners[i] as d.v3f),
+);
+
+export interface IcosphereOptions {
+  radius?: number;
+  interpolate?: typeof uniformArea;
+}
+
+/** UVs are local barycentric coordinates within each patch */
+export function icosphere({
+  radius = 0.5,
+  interpolate = uniformArea,
+}: IcosphereOptions = {}): PatchSurface {
+  if (!Number.isFinite(radius) || radius <= 0) {
+    throw new Error('icosphere needs a positive finite radius');
+  }
+  return {
+    schema: Surface,
+    patchCount: 20,
+    at: (patch: number, w: d.v3f) => {
+      'use gpu';
+      const offset = patch * 3;
+      const a = vertices.$[offset] as d.v3f;
+      const b = vertices.$[offset + 1] as d.v3f;
+      const c = vertices.$[offset + 2] as d.v3f;
+      const normal = interpolate(a, b, c, w);
+      return Surface({ position: normal * radius, normal, uv: w.yz });
+    },
+  };
+}

--- a/packages/typegpu-geometry/src/mesh/patches/index.ts
+++ b/packages/typegpu-geometry/src/mesh/patches/index.ts
@@ -1,0 +1,3 @@
+export * from './icosphere.ts';
+export * from './rounded.ts';
+export { linear, uniformArea } from './spherical.ts';

--- a/packages/typegpu-geometry/src/mesh/patches/rounded.ts
+++ b/packages/typegpu-geometry/src/mesh/patches/rounded.ts
@@ -1,0 +1,140 @@
+import { d, std, tgpu } from 'typegpu';
+import { Surface } from '../geometry.ts';
+import { X, Y, Z } from '../math.ts';
+import { type PatchSurface } from '../triangles.ts';
+import { arc, uniformArea } from './spherical.ts';
+
+const axes = tgpu.const(d.arrayOf(d.vec3f, 3), [X, Y, Z]);
+
+function octantSigns(octant: number) {
+  'use gpu';
+  return d.vec3f(
+    std.select(1, -1, (octant & 1) !== 0),
+    std.select(1, -1, (octant & 2) !== 0),
+    std.select(1, -1, (octant & 4) !== 0),
+  );
+}
+
+function cornerNormal(octant: number, weights: d.v3f) {
+  'use gpu';
+  const signs = octantSigns(octant);
+  const w = std.select(weights.xzy, weights, signs.x * signs.y * signs.z > 0);
+  return uniformArea(d.vec3f(signs.x, 0, 0), d.vec3f(0, signs.y, 0), d.vec3f(0, 0, signs.z), w);
+}
+
+function quadCoordinates(triangle: number, weights: d.v3f) {
+  'use gpu';
+  return std.select(
+    d.vec2f(weights.y, weights.y + weights.z),
+    d.vec2f(weights.y + weights.z, weights.z),
+    triangle === 0,
+  );
+}
+
+function edgeSurface(
+  triangle: number,
+  weights: d.v3f,
+  center: d.v3f,
+  axis: d.v3f,
+  u: d.v3f,
+  v: d.v3f,
+  halfHeight: number,
+  radius: number,
+) {
+  'use gpu';
+  const w = std.select(weights.xzy, weights, std.dot(std.cross(v, axis), u) > 0);
+  const uv = quadCoordinates(triangle, w);
+  const normal = arc(u, v, uv.x);
+  return Surface({
+    position: center + axis * ((2 * uv.y - 1) * halfHeight) + normal * radius,
+    normal,
+    uv,
+  });
+}
+
+export interface CapsuleOptions {
+  radius?: number;
+  /** Length of the cylindrical section */
+  height?: number;
+}
+
+/** Cap UVs are patch-local, side UVs span each quarter cylinder */
+export function capsule({ radius = 0.25, height = 0.5 }: CapsuleOptions = {}): PatchSurface {
+  if (!Number.isFinite(radius) || radius <= 0 || !Number.isFinite(height) || height < 0) {
+    throw new Error('capsule needs a positive finite radius and a nonnegative finite height');
+  }
+  const halfHeight = height / 2;
+  return {
+    schema: Surface,
+    patchCount: height === 0 ? 8 : 16,
+    at: (patch: number, w: d.v3f) => {
+      'use gpu';
+      if (patch < 8) {
+        const normal = cornerNormal(patch, w);
+        const center = d.vec3f(0, octantSigns(patch).y * halfHeight, 0);
+        return Surface({ position: center + normal * radius, normal, uv: w.yz });
+      }
+      const edge = std.intdiv(patch - 8, 2);
+      const u = X * std.select(1, -1, (edge & 1) !== 0);
+      const v = Z * std.select(1, -1, (edge & 2) !== 0);
+      return edgeSurface(patch % 2, w, d.vec3f(), Y, u, v, halfHeight, radius);
+    },
+  };
+}
+
+export interface RoundedBoxOptions {
+  width?: number;
+  height?: number;
+  depth?: number;
+  radius?: number;
+}
+
+/** Corner UVs are patch-local, face and edge UVs span their respective quads */
+export function roundedBox({
+  width = 1,
+  height = 1,
+  depth = 1,
+  radius = 0.1,
+}: RoundedBoxOptions = {}): PatchSurface {
+  if (![width, height, depth].every((size) => Number.isFinite(size) && size > 0)) {
+    throw new Error('roundedBox needs positive finite dimensions');
+  }
+  if (!Number.isFinite(radius) || radius < 0 || radius > Math.min(width, height, depth) / 2) {
+    throw new Error('roundedBox radius must fit within half its smallest dimension');
+  }
+  const halfSize = d.vec3f(width / 2, height / 2, depth / 2);
+  const inset = halfSize.sub(radius);
+  return {
+    schema: Surface,
+    patchCount: radius === 0 ? 12 : 44,
+    at: (index: number, w: d.v3f) => {
+      'use gpu';
+      const patch = index + (radius === 0 ? 8 : 0);
+      if (patch < 8) {
+        const normal = cornerNormal(patch, w);
+        return Surface({
+          position: octantSigns(patch) * inset + normal * radius,
+          normal,
+          uv: w.yz,
+        });
+      }
+      if (patch < 20) {
+        const face = std.intdiv(patch - 8, 2);
+        const axisIndex = std.intdiv(face, 2);
+        const sign = std.select(1, -1, face % 2 !== 0);
+        const normal = (axes.$[axisIndex] as d.v3f) * sign;
+        const u = axes.$[(axisIndex + 1) % 3] as d.v3f;
+        const v = (axes.$[(axisIndex + 2) % 3] as d.v3f) * sign;
+        const uv = quadCoordinates(patch % 2, w);
+        const position = normal * halfSize + (u * (2 * uv.x - 1) + v * (2 * uv.y - 1)) * inset;
+        return Surface({ position, normal, uv });
+      }
+      const edge = std.intdiv(patch - 20, 2);
+      const axisIndex = std.intdiv(edge, 4);
+      const axis = axes.$[axisIndex] as d.v3f;
+      const u = (axes.$[(axisIndex + 1) % 3] as d.v3f) * std.select(1, -1, (edge & 1) !== 0);
+      const v = (axes.$[(axisIndex + 2) % 3] as d.v3f) * std.select(1, -1, (edge & 2) !== 0);
+      return edgeSurface(patch % 2, w, (u + v) * inset, axis, u, v, std.dot(axis, inset), radius);
+    },
+  };
+}

--- a/packages/typegpu-geometry/src/mesh/patches/spherical.ts
+++ b/packages/typegpu-geometry/src/mesh/patches/spherical.ts
@@ -1,0 +1,29 @@
+import { d, std } from 'typegpu';
+
+export function linear(a: d.v3f, b: d.v3f, c: d.v3f, weights: d.v3f) {
+  'use gpu';
+  return std.normalize(a * weights.x + b * weights.y + c * weights.z);
+}
+
+function warp(cosAngle: number, t: number) {
+  'use gpu';
+  const cosHalf = std.sqrt(0.5 * (1 + cosAngle));
+  const b = (2 - 2 * cosHalf) / (2 + cosHalf);
+  const u = 2 * t - 1;
+  return (u * (1 - b) * 0.5) / (1 - b * u * u) + 0.5;
+}
+
+export function uniformArea(a: d.v3f, b: d.v3f, c: d.v3f, weights: d.v3f) {
+  'use gpu';
+  const w = d.vec3f(
+    warp(std.dot(b, c), weights.x),
+    warp(std.dot(a, c), weights.y),
+    warp(std.dot(a, b), weights.z),
+  );
+  return std.normalize(a * w.x + b * w.y + c * w.z);
+}
+
+export function arc(a: d.v3f, b: d.v3f, t: number) {
+  'use gpu';
+  return std.normalize(std.mix(a, b, warp(std.dot(a, b), t)));
+}

--- a/packages/typegpu-geometry/src/mesh/triangles.ts
+++ b/packages/typegpu-geometry/src/mesh/triangles.ts
@@ -1,0 +1,90 @@
+import { d, std } from 'typegpu';
+import { type IndexedGeometry, type Surface } from './geometry.ts';
+
+export interface PatchSurface<V extends d.AnyWgslData = typeof Surface> {
+  readonly schema: V;
+  readonly patchCount: number;
+  at(this: void, patch: number, weights: d.v3f): d.InferGPU<V>;
+}
+
+function checkSegments(segments: number) {
+  if (!Number.isSafeInteger(segments) || segments < 1 || segments > 32767) {
+    throw new Error('tessellation needs an integer segment count between 1 and 32767');
+  }
+}
+
+export function triangleVertexCount(segments: number) {
+  checkSegments(segments);
+  return ((segments + 1) * (segments + 2)) / 2;
+}
+
+export function triangleIndexCount(segments: number) {
+  checkSegments(segments);
+  return 3 * segments * segments;
+}
+
+export function triangleBarycentrics(vertex: number, segments: number) {
+  'use gpu';
+  let row = d.u32((std.sqrt(8 * d.f32(vertex) + 1) - 1) / 2);
+  if (std.intdiv(row * (row + 1), 2) > vertex) row -= 1;
+  else if (std.intdiv((row + 1) * (row + 2), 2) <= vertex) row += 1;
+  const start = std.intdiv(row * (row + 1), 2);
+  const col = vertex - start;
+  return d.vec3f(1 - row / segments, (row - col) / segments, col / segments);
+}
+
+export function triangleIndexAt(index: number) {
+  'use gpu';
+  const triangle = std.intdiv(index, 3);
+  let row = d.u32(std.sqrt(d.f32(triangle)));
+  if (row * row > triangle) row -= 1;
+  else if ((row + 1) * (row + 1) <= triangle) row += 1;
+  const col = triangle - row * row;
+  const start = std.intdiv(row * (row + 1), 2);
+  const corner = index % 3;
+  if (col <= row) {
+    if (corner === 0) return start + col;
+    return start + col + row + corner;
+  }
+  const vertex = start + col - row - 1;
+  if (corner === 0) return vertex;
+  if (corner === 1) return vertex + row + 2;
+  return vertex + 1;
+}
+
+/** Lower subdivision levels use a prefix of these indices */
+export function triangleIndices(maxSegments: number) {
+  checkSegments(maxSegments);
+  return Array.from({ length: triangleIndexCount(maxSegments) }, (_, i) => triangleIndexAt(i));
+}
+
+export function tessellate<V extends d.AnyWgslData>(
+  patches: PatchSurface<V>,
+  segments: number,
+): IndexedGeometry<V> {
+  checkSegments(segments);
+  const vertices = triangleVertexCount(segments);
+  const indices = triangleIndexCount(segments);
+  if (
+    !Number.isSafeInteger(patches.patchCount) ||
+    patches.patchCount < 1 ||
+    patches.patchCount * vertices > 0xffffffff ||
+    patches.patchCount * indices > 0xffffffff
+  ) {
+    throw new Error('tessellate needs a positive patch count and counts that fit in u32');
+  }
+  return {
+    schema: patches.schema,
+    topology: 'triangle-list',
+    vertexCount: patches.patchCount * vertices,
+    indexCount: patches.patchCount * indices,
+    vertexAt: (i: number) => {
+      'use gpu';
+      return patches.at(std.intdiv(i, vertices), triangleBarycentrics(i % vertices, segments));
+    },
+    indexAt: (i: number) => {
+      'use gpu';
+      return std.intdiv(i, indices) * vertices + triangleIndexAt(i % indices);
+    },
+  };
+}

--- a/packages/typegpu-geometry/tests/mesh.test.ts
+++ b/packages/typegpu-geometry/tests/mesh.test.ts
@@ -45,6 +45,12 @@ describe('meshes on the CPU', () => {
     ['box', meshes.box()],
     ['cylinder', meshes.cylinder({ radialSegments: 6 })],
     ['torus', meshes.torus({ ringSegments: 6, tubeSegments: 4 })],
+    ['icosphere', meshes.icosphere()],
+    ['capsule', meshes.capsule()],
+    ['rounded box', meshes.roundedBox()],
+    ['sharp box', meshes.roundedBox({ radius: 0 })],
+    ['fully rounded box', meshes.roundedBox({ radius: 0.5 })],
+    ['collapsed capsule', meshes.capsule({ radius: 0.5, height: 0 })],
   ])('%s fits a unit cube with outward unit normals', (_, shape) => {
     expect(windingAgreesWithNormals(shape)).toBe(true);
 
@@ -192,8 +198,8 @@ describe('meshes on the CPU', () => {
     );
   });
 
-  it.each([meshes.sphere(), meshes.cylinder()])(
-    'omits collapsed pole and cap triangles',
+  it.each([meshes.sphere(), meshes.cylinder(), meshes.roundedBox({ radius: 0 })])(
+    'omits collapsed pole, cap and zero-radius triangles',
     (shape) => {
       for (let i = 0; i < shape.indexCount; i += 3) {
         const a = shape.vertexAt(shape.indexAt(i)).position;

--- a/packages/typegpu-geometry/tests/patches.test.ts
+++ b/packages/typegpu-geometry/tests/patches.test.ts
@@ -1,0 +1,113 @@
+import { expect } from 'vitest';
+import { d, std, tgpu } from 'typegpu';
+import { it } from 'typegpu-testing-utility';
+import { meshes } from '@typegpu/geometry';
+
+it('covers the whole triangle with each index prefix', () => {
+  const indices = meshes.triangleIndices(16);
+  for (const segments of [1, 2, 3, 7, 16]) {
+    const prefix = indices.slice(0, meshes.triangleIndexCount(segments));
+    expect(prefix).toEqual(meshes.triangleIndices(segments));
+    expect(Math.max(...prefix) + 1).toBe(meshes.triangleVertexCount(segments));
+    let area = 0;
+    for (let i = 0; i < prefix.length; i += 3) {
+      const [a, b, c] = prefix
+        .slice(i, i + 3)
+        .map((v) => meshes.triangleBarycentrics(v, segments).yz) as [d.v2f, d.v2f, d.v2f];
+      const ab = b.sub(a);
+      const ac = c.sub(a);
+      const signedArea = (ab.x * ac.y - ab.y * ac.x) / 2;
+      expect(signedArea).toBeGreaterThan(0);
+      area += signedArea;
+    }
+    expect(area).toBeCloseTo(0.5);
+  }
+});
+
+it.each([
+  ['icosphere', meshes.patches.icosphere()],
+  ['capsule', meshes.patches.capsule()],
+  ['rounded box', meshes.patches.roundedBox({ width: 2, height: 1, depth: 3 })],
+])('%s keeps adjacent patches watertight and supports both evaluation paths', (_, patches) => {
+  const segments = 3;
+  const perPatch = meshes.triangleVertexCount(segments);
+  const mesh = meshes.tessellate(patches, segments);
+  const edges = new Map<string, number>();
+  const positions = Array.from({ length: mesh.vertexCount }, (_, i) => {
+    const vertex = mesh.vertexAt(i);
+    const patchVertex = patches.at(
+      Math.floor(i / perPatch),
+      meshes.triangleBarycentrics(i % perPatch, segments),
+    );
+    expect(vertex).toEqual(patchVertex);
+    return [...vertex.position].map((v) => v.toFixed(5).replace('-0.00000', '0.00000')).join(',');
+  });
+  for (let i = 0; i < mesh.indexCount; i += 3) {
+    const corners = [0, 1, 2].map((c) => positions[mesh.indexAt(i + c)]);
+    for (let c = 0; c < 3; c++) {
+      const key = [corners[c], corners[(c + 1) % 3]].toSorted().join('|');
+      edges.set(key, (edges.get(key) ?? 0) + 1);
+    }
+  }
+  expect(new Set(edges.values())).toEqual(new Set([2]));
+
+  const procedural = tgpu.fn([d.u32, d.vec3f], meshes.Surface)(patches.at);
+  const baked = tgpu.fn([d.u32], meshes.Surface)(mesh.vertexAt);
+  expect(() => tgpu.resolve([procedural, baked])).not.toThrow();
+});
+
+it('keeps the icosphere on the sphere without pole triangles', () => {
+  const mesh = meshes.icosphere({ segments: 7, radius: 2 });
+  const areas = [];
+  for (let i = 0; i < mesh.indexCount; i += 3) {
+    const a = mesh.vertexAt(mesh.indexAt(i));
+    const b = mesh.vertexAt(mesh.indexAt(i + 1));
+    const c = mesh.vertexAt(mesh.indexAt(i + 2));
+    expect(std.length(a.position)).toBeCloseTo(2);
+    expect(std.length(b.position)).toBeCloseTo(2);
+    expect(std.length(c.position)).toBeCloseTo(2);
+    areas.push(std.length(std.cross(b.position.sub(a.position), c.position.sub(a.position))));
+  }
+  expect(Math.min(...areas)).toBeGreaterThan(0);
+  expect(Math.max(...areas) / Math.min(...areas)).toBeLessThan(1.15);
+});
+
+it('specializes spherical interpolation through a slot', () => {
+  const interpolation = tgpu.slot(meshes.patches.uniformArea);
+  const patches = meshes.patches.icosphere({
+    interpolate: (a, b, c, w) => {
+      'use gpu';
+      return interpolation.$(a, b, c, w);
+    },
+  });
+  const vertex = tgpu
+    .fn(
+      [d.u32, d.vec3f],
+      meshes.Surface,
+    )(patches.at)
+    .with(interpolation, meshes.patches.linear);
+  const code = tgpu.resolve([vertex]);
+  expect(code.match(/fn (linear|uniformArea|warp)\(/g)).toMatchInlineSnapshot(`
+    [
+      "fn linear(",
+    ]
+  `);
+});
+
+it('rejects invalid tessellation and shape dimensions', () => {
+  expect(() => meshes.icosphere({ segments: 0 })).toThrowErrorMatchingInlineSnapshot(
+    `[Error: tessellation needs an integer segment count between 1 and 32767]`,
+  );
+  expect(() => meshes.icosphere({ radius: NaN })).toThrowErrorMatchingInlineSnapshot(
+    `[Error: icosphere needs a positive finite radius]`,
+  );
+  expect(() => meshes.capsule({ height: -1 })).toThrowErrorMatchingInlineSnapshot(
+    `[Error: capsule needs a positive finite radius and a nonnegative finite height]`,
+  );
+  expect(() => meshes.roundedBox({ width: 0 })).toThrowErrorMatchingInlineSnapshot(
+    `[Error: roundedBox needs positive finite dimensions]`,
+  );
+  expect(() => meshes.roundedBox({ radius: 0.6 })).toThrowErrorMatchingInlineSnapshot(
+    `[Error: roundedBox radius must fit within half its smallest dimension]`,
+  );
+});


### PR DESCRIPTION
Adds triangular patch surfaces to `meshes`, with subdivision separate from surface sampling

- icosphere, capsule and rounded box primitives
- tessellate into indexed geometry or sample patches directly in vertex shaders
- shared index buffer across subdivision levels, so detail can change without rebuilding buffers
- spherical interpolation helpers + an interactive patch tessellation example

Tessellation and spherical interpolation ideas yoinked from @deluksic’s [de/geometry-spheres branch](https://github.com/deluksic/TypeGPU/tree/de/geometry-spheres), shared in [the original PR comment](https://github.com/software-mansion/TypeGPU/pull/2997#issuecomment-5581661374)

Stacks on #2997
